### PR TITLE
Fix how PhotoCalTask calls Colorterm methods DM-2919

### DIFF
--- a/python/lsst/pipe/tasks/colorterms.py
+++ b/python/lsst/pipe/tasks/colorterms.py
@@ -109,13 +109,13 @@ class ColortermDict(Config):
 
 
 class ColortermLibrary(Config):
-    """!A mapping of catalog name to ColortermDict
+    """!A mapping of photometric reference catalog name or glob to ColortermDict
 
-    This is intended to support a particular camera with a variety of reference catalogs
+    This allows photometric calibration using a variety of reference catalogs.
 
     To construct a ColortermLibrary, use keyword arguments:
     ColortermLibrary(data=dataDict)
-    where dataDict is a Python dict of reference_catalog_name: ColortermDict.
+    where dataDict is a Python dict of catalog_name_or_glob: ColortermDict
 
     For example:
     ColortermLibrary(data = {
@@ -152,10 +152,11 @@ class ColortermLibrary(Config):
         exact match and no unique match to the globs, we raise an exception.
 
         @param filterName  name of filter
-        @param refCatName  reference catalog name or glob expression; if a glob expression then
-            there must be exactly one match in the library
+        @param refCatName  name of photometric reference catalog from which to retrieve the data.
+            This argument is not glob-expanded (but the catalog names in the library are,
+            if no exact match is found).
         @param[in] doRaise  if True then raise ColortermNotFoundError if no suitable Colorterm found;
-            if False then return a null Colorterm
+            if False then return a null Colorterm with filterName as the primary and secondary filter
         @return the appropriate Colorterm
 
         @throw ColortermNotFoundError if no suitable Colorterm found and doRaise true;
@@ -166,7 +167,8 @@ class ColortermLibrary(Config):
             ctDictConfig = self.data.get(refCatName)
             if ctDictConfig is None:
                 # try glob expression
-                matchList = [glob for glob in self.data if fnmatch.fnmatch(refCatName, glob)]
+                matchList = [libRefNameGlob for libRefNameGlob in self.data
+                    if fnmatch.fnmatch(refCatName, libRefNameGlob)]
                 if len(matchList) == 1:
                     trueRefCatName = matchList[0]
                     ctDictConfig = self.data[trueRefCatName]

--- a/python/lsst/pipe/tasks/photoCal.py
+++ b/python/lsst/pipe/tasks/photoCal.py
@@ -66,9 +66,11 @@ class PhotoCalConfig(pexConf.Config):
     )
     applyColorTerms = pexConf.Field(
         doc= "Apply photometric color terms to reference stars? One of: " + \
-            "None: apply if color term correction is available for this camera " + \
-            "(and fail if data is not available for the desired filter); " + \
-            "True: apply, and fail if color term data not available; " + \
+            "None: apply if colorterms is not and photoCatName are not None; " + \
+            "fail if color term data is not available for the specified ref catalog and filter. " + \
+            "True: apply colorterms; fail if colorterms or photoCatName are None " + \
+            " or color term data is not available for the specified reference catalog and filter. " + \
+            "or the specified ; " + \
             "False: do not apply",
         dtype=bool,
         default=None,
@@ -107,15 +109,14 @@ class PhotoCalConfig(pexConf.Config):
         default=20,
     )
     colorterms = pexConf.ConfigField(
-        doc="Library of reference catalog name: color term dict",
+        doc="Library of photometric reference catalog name: color term dict",
         dtype=ColortermLibrary,
     )
-    refCatName = pexConf.Field(
-        doc="Name of reference catalog; used to identify color term dict in colorterms." + \
-            " Ignored if not applying color terms",
+    photoCatName = pexConf.Field(
+        doc="Name of photometric reference catalog; used to select a color term dict in colorterms." + \
+            " see also applyColorTerms",
         dtype=str,
-        default="*",
-        optional=False,
+        optional=True,
     )
 
 
@@ -449,15 +450,18 @@ into your debug.py file and run photoCalTask.py with the \c --debug flag.
         applyColorTerms = self.config.applyColorTerms
         applyCTReason = "config.applyColorTerms is %s" % (self.config.applyColorTerms,)
         if self.config.applyColorTerms is None:
-            # apply color terms if color term data is available
-            applyColorTerms = len(self.config.colorterms.data) > 0
-            applyCTReason += " and data %s available" % ("is" if applyColorTerms else "is not")
+            # apply color terms if color term data is available and photoCatName specified
+            ctDataAvail = len(self.config.colorterms.data) > 0
+            photoCatSpecified = self.config.photoCatName is not None
+            applyCTReason += " and data %s available" % ("is" if ctDataAvail else "is not")
+            applyCTReason += " and photoRefCat %s None" % ("is not" if photoCatSpecified else "is")
+            applyColorTerms = ctDataAvail and photoCatSpecified
 
         if applyColorTerms:
-            self.log.info("Applying color terms for filterName=%r, config.refCatName=%s because %s" %
-                (filterName, self.config.refCatName, applyCTReason))
+            self.log.info("Applying color terms for filterName=%r, config.photoCatName=%s because %s" %
+                (filterName, self.config.photoCatName, applyCTReason))
             ct = self.config.colorterms.getColorterm(
-                filterName=filterName, refCatName=self.config.refCatName, doRaise=True)
+                filterName=filterName, photoCatName=self.config.photoCatName, doRaise=True)
         else:
             self.log.info("Not applying color terms because %s" % (applyCTReason,))
             ct = None

--- a/python/lsst/pipe/tasks/photoCal.py
+++ b/python/lsst/pipe/tasks/photoCal.py
@@ -500,8 +500,8 @@ into your debug.py file and run photoCalTask.py with the \c --debug flag.
             refMagArr1 = np.array([abMagFromFlux(rf1) for rf1 in refFluxArrList[0]]) # primary
             refMagArr2 = np.array([abMagFromFlux(rf2) for rf2 in refFluxArrList[1]]) # secondary
 
-            refMagArr = ct.transformMags(filterName, refMagArr1, refMagArr2)
-            refFluxErrArr = ct.propagateFluxErrors(filterName, refFluxErrArrList[0], refFluxErrArrList[1])
+            refMagArr = ct.transformMags(refMagArr1, refMagArr2)
+            refFluxErrArr = ct.propagateFluxErrors(refFluxErrArrList[0], refFluxErrArrList[1])
         else:
             refMagArr = np.array([abMagFromFlux(rf) for rf in refFluxArrList[0]])
 


### PR DESCRIPTION
PhotoCalTask was mis-calling the Colorterm methods (by providing a filter name,
which is not wanted as of DM-2797).
Also ColortermLibrary.getColorterm was mis-handling glob expressions for the
library name (the arguments to fnmatch.fnmatch were in the wrong order).