### PR TITLE
Change matchMetadata to matchMeta DM-3453

### DIFF
--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -572,7 +572,7 @@ class MeasureMergedCoaddSourcesTask(CmdLineTask):
         result = self.astrometry.loadAndMatch(exposure=exposure, sourceCat=sources)
         if result.matches:
             matches = afwTable.packMatches(result.matches)
-            matches.table.setMetadata(result.matchMetadata)
+            matches.table.setMetadata(result.matchMeta)
             dataRef.put(matches, self.config.coaddName + "Coadd_srcMatch")
 
     def write(self, dataRef, sources):

--- a/python/lsst/pipe/tasks/processImage.py
+++ b/python/lsst/pipe/tasks/processImage.py
@@ -248,7 +248,7 @@ class ProcessImageTask(pipeBase.CmdLineTask):
             return None, None
 
         astromRet = astrometry.loadAndMatch(exposure=exposure, sourceCat=sources)
-        return astromRet.matches, astromRet.matchMetadata
+        return astromRet.matches, astromRet.matchMeta
 
     def propagateCalibFlags(self, icSources, sources, matchRadius=1):
         """Match the icSources and sources, and propagate Interesting Flags (e.g. PSF star) to the sources


### PR DESCRIPTION
Astrometry tasks have standardized on matchMeta instead
of matchMetadata for returned results. Adapt to that change.