### PR TITLE
DM-5385

### DIFF
--- a/python/lsst/pipe/tasks/measurePsf.py
+++ b/python/lsst/pipe/tasks/measurePsf.py
@@ -240,12 +240,10 @@ into your debug.py file and run measurePsfTask.py with the \c --debug flag.
                 doc=("Flag set if the source was actually used for PSF determination, "
                      "as determined by the '%s' PSF determiner.") % self.config.psfDeterminer.name
             )
-            if self.config.reserveFraction > 0:
-                self.reservedKey = schema.addField(
-                    "calib_psfReserved", type="Flag",
-                    doc=("Flag set if the source was selected as a PSF candidate, but was "
-                         "reserved from the PSF fitting."))
-                
+            self.reservedKey = schema.addField(
+                "calib_psfReserved", type="Flag",
+                doc=("Flag set if the source was selected as a PSF candidate, but was "
+                     "reserved from the PSF fitting."))
         else:
             self.candidateKey = None
             self.usedKey = None


### PR DESCRIPTION
The schema, as far as possible, should not depend on configuration
parameters.  Without calib_psfReserved in the schema, we can get
errors/warnings when propagating flags from calib catalogs to deep
catalogs.