### PR TITLE
Update run method call of SourceDeblendTask

### DIFF
--- a/python/lsst/pipe/tasks/detectAndMeasure.py
+++ b/python/lsst/pipe/tasks/detectAndMeasure.py
@@ -186,11 +186,7 @@ class DetectAndMeasureTask(pipeBase.Task):
             background.append(detRes.fpSets.background)
 
         if self.config.doDeblend:
-            self.deblend.run(
-                exposure = exposure,
-                sources = sourceCat,
-                psf = exposure.getPsf(),
-            )
+            self.deblend.run(exposure = exposure, sources = sourceCat,)
 
         self.measure(
             exposure = exposure,

--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -1039,7 +1039,7 @@ class MeasureMergedCoaddSourcesTask(CmdLineTask):
         exposure = patchRef.get(self.config.coaddName + "Coadd_calexp", immediate=True)
         sources = self.readSources(patchRef)
         if self.config.doDeblend:
-            self.deblend.run(exposure, sources, exposure.getPsf())
+            self.deblend.run(exposure, sources)
 
             bigKey = sources.schema["deblend_parentTooBig"].asKey()
             numBig = sum((s.get(bigKey) for s in sources)) # catalog is non-contiguous so can't extract column


### PR DESCRIPTION
The run method of SourceDeblendTask has been updated in the previous
commit to extract the psf from the provided exposure. This commit
updates all calls of the run method to match the new interface.