### PR TITLE
Remove 'flags=sourceWriteFlags' from dataRef.put in CalibrateTask.

### DIFF
--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -510,7 +510,7 @@ class CalibrateTask(pipeBase.CmdLineTask):
         """
         sourceWriteFlags = 0 if self.config.doWriteHeavyFootprintsInSources \
             else afwTable.SOURCE_IO_NO_HEAVY_FOOTPRINTS
-        dataRef.put(sourceCat, "src", flags=sourceWriteFlags)
+        dataRef.put(sourceCat, "src")
         if self.config.doWriteMatches and astromMatches is not None:
             normalizedMatches = afwTable.packMatches(astromMatches)
             normalizedMatches.table.setMetadata(matchMeta)


### PR DESCRIPTION
The Butler 'put' does not support a 'flags' option to pass down
to the underlying catalogs.  This has meant that CalibrateTask
has been broken, but we don't fully test CalibrateTask.

This pull request is just a one-line change to remove the flags option.
