### PR TITLE
Update for exposure time and date not in Calib

### DIFF
--- a/examples/calibrateTask.py
+++ b/examples/calibrateTask.py
@@ -53,11 +53,8 @@ def loadData(pixelScale=1.0):
     mypath = lsst.utils.getPackageDir('afwdata')
     imFile = os.path.join(mypath, "CFHT", "D4", "cal-53535-i-797722_small_1.fits")
 
-    exposure = afwImage.ExposureF(imFile)
-    # set the exposure time
-    calib = afwImage.Calib()
-    calib.setExptime(1.0)
-    exposure.setCalib(calib)
+    visitInfo = afwImage.makeVisitInfo(exposureTime=1.0)
+    exposure = afwImage.ExposureF(imFile, visitInfo)
     # add a filter
     afwImage.Filter.define(afwImage.FilterProperty(FilterName, 600, True))
     exposure.setFilter(afwImage.Filter(FilterName))

--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -538,7 +538,8 @@ class CalibrateTask(pipeBase.CmdLineTask):
 
         # convert zero-point to (mag/sec/adu) for task MAGZERO metadata
         try:
-            magZero = photoRes.zp - 2.5*math.log10(exposure.getCalib().getExptime())
+            exposureTime = exposure.getInfo().getVisitInfo().getExposureTime()
+            magZero = photoRes.zp - 2.5*math.log10(exposureTime)
             self.metadata.set('MAGZERO', magZero)
         except Exception:
             self.log.warn("Could not set normalized MAGZERO in header: no exposure time")


### PR DESCRIPTION
Update all code that used exposure time or date in Calib,
switching to VisitInfo instead.