### PR TITLE
DM-6824: Use meas.algorithms.astrometrySourceSelector in measOptimisticB

### DIFF
--- a/tests/testPhotoCal.py
+++ b/tests/testPhotoCal.py
@@ -67,6 +67,12 @@ class PhotoCalTest(unittest.TestCase):
         testDir = os.path.dirname(__file__)
         self.srcCat = afwTable.SourceCatalog.readFits(
             os.path.join(testDir, "data", "v695833-e0-c000.xy.fits"))
+        # The following block sets the flag deblend_nChild which is required
+        # by the astronomy and matcher sourceSelecctors used in 
+        # matchOptimistcB.
+        aliasMap = self.srcCat.schema.getAliasMap()
+        aliasMap.set("deblend_nChild", "parent")
+
         self.srcCat["slot_ApFlux_fluxSigma"] = 1
         self.srcCat["slot_PsfFlux_fluxSigma"] = 1
 


### PR DESCRIPTION
tests/testPhotoCal.py: Added compliance to this test for use with
the new matcher and astrometry sourceSelectors used in
matchOptimisticB as implimented in ticket DM-6824.