### PR TITLE
pipe_tasks DM-9885: Rename deepCoadd_srcMatch as deepCoadd_measMatch

### DIFF
--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -1151,10 +1151,10 @@ class MeasureMergedCoaddSourcesTask(CmdLineTask):
         if result.matches:
             matches = afwTable.packMatches(result.matches)
             matches.table.setMetadata(result.matchMeta)
-            dataRef.put(matches, self.config.coaddName + "Coadd_srcMatch")
+            dataRef.put(matches, self.config.coaddName + "Coadd_measMatch")
             if self.config.doWriteMatchesDenormalized:
                 denormMatches = denormalizeMatches(result.matches, result.matchMeta)
-                dataRef.put(denormMatches, self.config.coaddName + "Coadd_srcMatchFull")
+                dataRef.put(denormMatches, self.config.coaddName + "Coadd_measMatchFull")
 
 
     def write(self, dataRef, sources):


### PR DESCRIPTION
The naming appears to be an error during the port of functionality
from HSC. Renamed in order to make clearer the relationship with the
deepCoadd_meas catalog.

Also renamed the related deepCoadd_srcMatchFull as
deepCoadd_measMatchFull.