### PR TITLE
Set the PSF-matched coadd's PSF to the model PSF used

### DIFF
--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -619,7 +619,13 @@ discussed in \ref pipeTasks_multiBand (but note that normally, one would use the
             self.inputRecorder.addVisitToCoadd(coaddInputs, tempExp, weight)
         coaddInputs.visits.sort()
         if self.config.doPsfMatch:
-            psf = self.config.modelPsf.apply()
+            # The modelPsf BBox for a psfMatchedWarp/coaddTempExp was dynamically defined by
+            # ModelPsfMatchTask as the square box bounding its spatially-variable, pre-matched WarpedPsf.
+            # Likewise, set the PSF of a PSF-Matched Coadd to the modelPsf
+            # having the maximum width (sufficient because square)
+            modelPsfList = [tempExp.getPsf() for tempExp in tempExpList]
+            modelPsfWidthList = [modelPsf.computeBBox().getWidth() for modelPsf in modelPsfList]
+            psf = modelPsfList[modelPsfWidthList.index(max(modelPsfWidthList))]
         else:
             psf = measAlg.CoaddPsf(coaddInputs.ccds, coaddExposure.getWcs())
         coaddExposure.setPsf(psf)

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -179,6 +179,8 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
                 if numGoodPix > 0 and not didSetMetadata:
                     coaddTempExp.setCalib(exposure.getCalib())
                     coaddTempExp.setFilter(exposure.getFilter())
+                    # PSF replaced with CoaddPsf after loop if and only if creating direct warp
+                    coaddTempExp.setPsf(exposure.getPsf())
                     didSetMetadata = True
             except Exception as e:
                 self.log.warn("Error processing calexp %s; skipping it: %s", calExpRef.dataId, e)
@@ -186,9 +188,8 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
             inputRecorder.addCalExp(calExp, ccdId, numGoodPix)
 
         inputRecorder.finish(coaddTempExp, totGoodPix)
-        if totGoodPix > 0 and didSetMetadata:
-            coaddTempExp.setPsf(modelPsf if self.config.doPsfMatch else
-                                CoaddPsf(inputRecorder.coaddInputs.ccds, skyInfo.wcs))
+        if totGoodPix > 0 and didSetMetadata and not self.config.doPsfMatch:
+            coaddTempExp.setPsf(CoaddPsf(inputRecorder.coaddInputs.ccds, skyInfo.wcs))
 
         self.log.info("coaddTempExp has %d good pixels (%.1f%%)",
                       totGoodPix, 100.0*totGoodPix/skyInfo.bbox.getArea())


### PR DESCRIPTION
MakeCoaddTempExp does not require users to know the dimensions of
the model PSF and automatically adjusts the dimensions to match those of
the Warped PSFs. AssembleCoadd now applies the
dimension-adjusted PSF rather than the user-supplied.