### PR TITLE
Fix sampling of reserved candidates to use expId in photoCal, measurePsf

### DIFF
--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -535,7 +535,7 @@ class CalibrateTask(pipeBase.CmdLineTask):
         # compute photometric calibration
         if self.config.doPhotoCal:
             try:
-                photoRes = self.photoCal.run(exposure, sourceCat=sourceCat)
+                photoRes = self.photoCal.run(exposure, sourceCat=sourceCat, expId=exposureIdInfo.expId)
                 exposure.getCalib().setFluxMag0(photoRes.calib.getFluxMag0())
                 self.log.info("Photometric zero-point: %f" %
                               photoRes.calib.getMagnitude(1.0))

--- a/python/lsst/pipe/tasks/characterizeImage.py
+++ b/python/lsst/pipe/tasks/characterizeImage.py
@@ -498,7 +498,8 @@ class CharacterizeImageTask(pipeBase.CmdLineTask):
                 matches = self.ref_match.loadAndMatch(exposure=exposure, sourceCat=sourceCat).matches
             else:
                 matches = None
-            measPsfRes = self.measurePsf.run(exposure=exposure, sources=sourceCat, matches=matches)
+            measPsfRes = self.measurePsf.run(exposure=exposure, sources=sourceCat, matches=matches,
+                                             expId=exposureIdInfo.expId)
         self.display("measure_iter", exposure=exposure, sourceCat=sourceCat)
 
         return pipeBase.Struct(

--- a/python/lsst/pipe/tasks/measurePsf.py
+++ b/python/lsst/pipe/tasks/measurePsf.py
@@ -20,7 +20,6 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 from __future__ import absolute_import, division, print_function
-import random
 
 import lsst.afw.math as afwMath
 import lsst.afw.display.ds9 as ds9
@@ -278,12 +277,16 @@ into your debug.py file and run measurePsfTask.py with the \c --debug flag.
         reserveList = []
 
         if self.config.reserveFraction > 0:
-            random.seed(self.config.reserveSeed*expId)
-            reserveList = random.sample(psfCandidateList,
-                                        int((self.config.reserveFraction)*len(psfCandidateList)))
-
-            for cand in reserveList:
-                psfCandidateList.remove(cand)
+            # Note that the seed can't be set to 0, so guard against an improper expId.
+            random = afwMath.Random(seed=self.config.reserveSeed*(expId if expId else 1))
+            reserveList = []
+            n = len(psfCandidateList)
+            for i in range(int(n * self.config.reserveFraction)):
+                index = random.uniformInt(n)
+                n -= 1
+                candidate = psfCandidateList[index]
+                psfCandidateList.remove(candidate)
+                reserveList.append(candidate)
 
             if reserveList and self.reservedKey is not None:
                 for cand in reserveList:

--- a/python/lsst/pipe/tasks/measurePsf.py
+++ b/python/lsst/pipe/tasks/measurePsf.py
@@ -281,7 +281,7 @@ into your debug.py file and run measurePsfTask.py with the \c --debug flag.
             random = afwMath.Random(seed=self.config.reserveSeed*(expId if expId else 1))
             reserveList = []
             n = len(psfCandidateList)
-            for i in range(int(n * self.config.reserveFraction)):
+            for i in range(int(n*self.config.reserveFraction)):
                 index = random.uniformInt(n)
                 n -= 1
                 candidate = psfCandidateList[index]

--- a/python/lsst/pipe/tasks/photoCal.py
+++ b/python/lsst/pipe/tasks/photoCal.py
@@ -665,7 +665,7 @@ into your debug.py file and run photoCalTask.py with the \c --debug flag.
 
         res = self.loadAndMatch(exposure, sourceCat)
 
-        # from res.matches, reserve a fraction of the population and mark the sources reserved
+        # from res.matches, reserve a fraction of the sources from res.matches and mark the sources reserved
 
         if self.config.reserveFraction > 0:
             # Note that the seed can't be set to 0, so guard against an improper expId.

--- a/python/lsst/pipe/tasks/photoCal.py
+++ b/python/lsst/pipe/tasks/photoCal.py
@@ -27,15 +27,14 @@ from builtins import input
 from builtins import range
 
 import math
-import random
 import sys
 
 import numpy as np
 
 import lsst.pex.config as pexConf
 import lsst.pipe.base as pipeBase
-import lsst.afw.table as afwTable
 from lsst.afw.image import abMagFromFlux, abMagErrFromFluxErr, fluxFromABMag, Calib
+import lsst.afw.math as afwMath
 from lsst.meas.astrom import RefMatchTask, RefMatchConfig
 import lsst.afw.display.ds9 as ds9
 from lsst.meas.algorithms import getRefFluxField
@@ -74,10 +73,10 @@ class PhotoCalConfig(RefMatchConfig):
         default=-1.0,
     )
     reserveSeed = pexConf.Field(
-        dtype = int,
-        doc = "This number will be multiplied by the exposure ID "
+        dtype=int,
+        doc="This number will be multiplied by the exposure ID "
         "to set the random seed for reserving candidates",
-        default = 1,
+        default=1,
     )
     fluxField = pexConf.Field(
         dtype=str,
@@ -666,15 +665,19 @@ into your debug.py file and run photoCalTask.py with the \c --debug flag.
 
         res = self.loadAndMatch(exposure, sourceCat)
 
-        #from res.matches, reserve a fraction of the population and mark the sources as reserved
+        # from res.matches, reserve a fraction of the population and mark the sources reserved
 
         if self.config.reserveFraction > 0:
-            random.seed(self.config.reserveSeed*expId)
-            reserveList = random.sample(res.matches,
-                                        int((self.config.reserveFraction)*len(res.matches)))
-
-            for candidate in reserveList:
+            # Note that the seed can't be set to 0, so guard against an improper expId.
+            random = afwMath.Random(seed=self.config.reserveSeed*(expId if expId else 1))
+            reserveList = []
+            n = len(res.matches)
+            for i in range(int(n*self.config.reserveFraction)):
+                index = random.uniformInt(n)
+                n -= 1
+                candidate = res.matches[index]
                 res.matches.remove(candidate)
+                reserveList.append(candidate)
 
             if reserveList and self.reservedKey is not None:
                 for candidate in reserveList:

--- a/tests/test_photoCal.py
+++ b/tests/test_photoCal.py
@@ -141,7 +141,7 @@ class PhotoCalTest(unittest.TestCase):
                 self.assertTrue(source.get("calib_photometryCandidate"))
                 used += 1
             self.assertFalse(source.get("calib_photometryReserved"))
-        # test that some very actually used
+        # test that some are actually used
         self.assertGreater(used, 0)
 
     def testReserveFraction(self):

--- a/tests/test_psfCandidateSelection.py
+++ b/tests/test_psfCandidateSelection.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#
+# LSST Data Management System
+# Copyright 2008-2017 AURA/LSST
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+from __future__ import division, print_function, absolute_import
+import os
+import unittest
+
+import lsst.afw.image as afwImage
+import lsst.utils.tests
+from lsst.utils import getPackageDir
+from lsst.obs.base import ExposureIdInfo
+from lsst.log import Log
+from lsst.pipe.tasks.characterizeImage import CharacterizeImageTask
+
+
+class PsfFlagTestCase(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        # Load sample input from disk
+        expPath = os.path.join(getPackageDir("pipe_tasks"), "tests", "data", "v695833-e0-c000-a00.sci.fits")
+        self.exposure = afwImage.ExposureF(expPath)
+        # set log level so that warnings do not display
+        Log.getLogger("characterizeImage").setLevel(Log.ERROR)
+
+    def tearDown(self):
+        del self.exposure
+
+    def testFlags(self):
+        # test that all of the flags are defined and there is no reservation by default
+        # also test that used sources are a subset of candidate sources
+        task = CharacterizeImageTask()
+        results = task.characterize(self.exposure)
+        used = 0
+        reserved = 0
+        for source in results.sourceCat:
+            if source.get("calib_psfUsed"):
+                used += 1
+                self.assertTrue(source.get("calib_psfCandidate"))
+            if source.get("calib_psfReserved"):
+                reserved += 1
+        self.assertGreater(used, 0)
+        self.assertEqual(reserved, 0)
+
+    def testReserveFraction(self):
+        # test that a fraction of the possible candidates can be reserved
+        # and that different expIds can produce a different reserveLists
+        task = CharacterizeImageTask()
+        # set the reserve fraction, and see if the right proportion are reserved.
+        task.measurePsf.config.reserveFraction = .3
+        exposureIdInfo = ExposureIdInfo(12345, expBits=16)
+        results = task.characterize(self.exposure, exposureIdInfo=exposureIdInfo)
+        candidates = 0
+        reservedSources1 = []
+        for source in results.sourceCat:
+            if source.get("calib_psfCandidate"):
+                candidates += 1
+            if source.get("calib_psfReserved"):
+                reservedSources1.append(source.getId())
+        reserved = len(reservedSources1)
+        self.assertEqual(reserved, int(.3 * (candidates + reserved)))
+
+        # try again with a different id, and see if the list is different
+        # but the number of reserved sources is the same
+        exposureIdInfo = ExposureIdInfo(6789, expBits=16)
+        results = task.characterize(self.exposure, exposureIdInfo=exposureIdInfo)
+        reservedSources2 = []
+        for source in results.sourceCat:
+            if source.get("calib_psfReserved"):
+                reservedSources2.append(source.getId())
+        # Length of reserveList should be the same, but specific sources may differ
+        self.assertEqual(len(reservedSources1), len(reservedSources2))
+        self.assertNotEqual(reservedSources1, reservedSources2)
+
+    def testReserveSeedReproducible(self):
+        # test that the same seed twice will produce the same reserve set
+        task = CharacterizeImageTask()
+        task.measurePsf.config.reserveFraction = .3
+        results = task.characterize(self.exposure)
+        reservedSources1 = []
+        for source in results.sourceCat:
+            if source.get("calib_psfReserved"):
+                reservedSources1.append(source.getId())
+
+        # try again with the same seed (the default)
+        results = task.characterize(self.exposure)
+        reservedSources2 = []
+        for source in results.sourceCat:
+            if source.get("calib_psfReserved"):
+                reservedSources2.append(source.getId())
+        # reserveLists should be the same
+        self.assertEqual(reservedSources1, reservedSources2)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_psfCandidateSelection.py
+++ b/tests/test_psfCandidateSelection.py
@@ -46,7 +46,7 @@ class PsfFlagTestCase(lsst.utils.tests.TestCase):
         del self.exposure
 
     def testFlags(self):
-        # test that all of the flags are defined and there is no reservation by default
+        # Test that all of the flags are defined and there is no reservation by default
         # also test that used sources are a subset of candidate sources
         task = CharacterizeImageTask()
         results = task.characterize(self.exposure)
@@ -62,8 +62,9 @@ class PsfFlagTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(reserved, 0)
 
     def testReserveFraction(self):
-        # test that a fraction of the possible candidates can be reserved
-        # and that different expIds can produce a different reserveLists
+        """ Test that a fraction of the possible candidates can be reserved.
+        """
+        # Note that different expIds can produce a different reserveLists
         task = CharacterizeImageTask()
         # set the reserve fraction, and see if the right proportion are reserved.
         task.measurePsf.config.reserveFraction = .3
@@ -77,7 +78,7 @@ class PsfFlagTestCase(lsst.utils.tests.TestCase):
             if source.get("calib_psfReserved"):
                 reservedSources1.append(source.getId())
         reserved = len(reservedSources1)
-        self.assertEqual(reserved, int(.3 * (candidates + reserved)))
+        self.assertEqual(reserved, int(.3*(candidates + reserved)))
 
         # try again with a different id, and see if the list is different
         # but the number of reserved sources is the same
@@ -92,7 +93,8 @@ class PsfFlagTestCase(lsst.utils.tests.TestCase):
         self.assertNotEqual(reservedSources1, reservedSources2)
 
     def testReserveSeedReproducible(self):
-        # test that the same seed twice will produce the same reserve set
+        """ test that the same seed twice will produce the same reserve set.
+        """
         task = CharacterizeImageTask()
         task.measurePsf.config.reserveFraction = .3
         results = task.characterize(self.exposure)


### PR DESCRIPTION
Change random number generator to afwMath.Random. Sample function had to be
simulated using uniformInt.

Change default to expId=1 for run()(seed=0 is not accepted byafwMath.Random)

Add new unit test for measurePsf to check candidate reserving code.
Add new test to existing testPhotoCal to do the same checks.
Unit tests check reserveFraction and that population changes with expId.