### PR TITLE
DM-10785: final correction

### DIFF
--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -784,7 +784,7 @@ discussed in \ref pipeTasks_multiBand (but note that normally, one would use the
                                     afwGeom.PointI(int(center[0] + 0.5*width), int(center[1] + 0.5*height)))
                 spans = afwGeom.SpanSet(bbox)
             elif rec["type"] == "circle":
-                radius = rec["radius"].asArcseconds()/plateScale   # convert to pixels
+                radius = int(rec["radius"].asArcseconds()/plateScale)   # convert to pixels
                 spans = afwGeom.SpanSet.fromShape(radius, offset=center)
             else:
                 self.log.warn("Unexpected region type %s at %s" % rec["type"], center)

--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -789,7 +789,7 @@ discussed in \ref pipeTasks_multiBand (but note that normally, one would use the
             else:
                 self.log.warn("Unexpected region type %s at %s" % rec["type"], center)
                 continue
-            spans.setMask(mask, self.brightObjectBitmask)
+            spans.clippedTo(mask.getBBox()).setMask(mask, self.brightObjectBitmask)
 
     @classmethod
     def _makeArgumentParser(cls):

--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -789,8 +789,7 @@ discussed in \ref pipeTasks_multiBand (but note that normally, one would use the
             else:
                 self.log.warn("Unexpected region type %s at %s" % rec["type"], center)
                 continue
-            foot = afwDetect.Footprint(spans, exposure.getBBox())
-            afwDetect.setMaskFromFootprint(mask, foot, self.brightObjectBitmask)
+            spans.setMask(mask, self.brightObjectBitmask)
 
     @classmethod
     def _makeArgumentParser(cls):


### PR DESCRIPTION
The previously merged solution to DM-10785 fixed the immediate issue but was not a complete solution.  This change allows the bright object masks to actually be set correctly using the new footprint patterns.