### PR TITLE
DM-11136: ingestCalibs: change default mode to 'move'

### DIFF
--- a/python/lsst/pipe/tasks/ingestCalibs.py
+++ b/python/lsst/pipe/tasks/ingestCalibs.py
@@ -183,7 +183,7 @@ class IngestCalibsArgumentParser(InputOnlyArgumentParser):
         InputOnlyArgumentParser.__init__(self, *args, **kwargs)
         self.add_argument("-n", "--dry-run", dest="dryrun", action="store_true",
                           default=False, help="Don't perform any action?")
-        self.add_argument("--mode", choices=["move", "copy", "link", "skip"], default="skip",
+        self.add_argument("--mode", choices=["move", "copy", "link", "skip"], default="move",
                           help="Mode of delivering the files to their destination")
         self.add_argument("--create", action="store_true", help="Create new registry?")
         self.add_argument("--validity", type=int, required=True, help="Calibration validity period (days)")


### PR DESCRIPTION
The standard pattern will be that calibs are created outside the main
calib directory (e.g., in the rerun) so that they are not immediately
available for use by active processes. Then they need to be transferred
into the calib directory; 'move' is better than 'link' because we will
want to blow away the directory where they were originally created.