### PR TITLE
DM-11338: make CoaddPsf configurable

### DIFF
--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -141,6 +141,11 @@ class AssembleCoaddConfig(CoaddBaseTask.ConfigClass):
     brightObjectMaskName = pexConfig.Field(dtype=str, default="BRIGHT_OBJECT",
                                            doc="Name of mask bit used for bright objects")
 
+    coaddPsf = pexConfig.ConfigField(
+        doc="Configuration for CoaddPsf",
+        dtype=measAlg.CoaddPsfConfig,
+    )
+
     def setDefaults(self):
         CoaddBaseTask.ConfigClass.setDefaults(self)
         self.badMaskPlanes = ["NO_DATA", "BAD", "CR", ]
@@ -646,7 +651,8 @@ discussed in \ref pipeTasks_multiBand (but note that normally, one would use the
             modelPsfWidthList = [modelPsf.computeBBox().getWidth() for modelPsf in modelPsfList]
             psf = modelPsfList[modelPsfWidthList.index(max(modelPsfWidthList))]
         else:
-            psf = measAlg.CoaddPsf(coaddInputs.ccds, coaddExposure.getWcs())
+            psf = measAlg.CoaddPsf(coaddInputs.ccds, coaddExposure.getWcs(),
+                                   self.config.coaddPsf.makeControl())
         coaddExposure.setPsf(psf)
         apCorrMap = measAlg.makeCoaddApCorrMap(coaddInputs.ccds, coaddExposure.getBBox(afwImage.PARENT),
                                                coaddExposure.getWcs())

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -27,7 +27,7 @@ import lsst.pex.config as pexConfig
 import lsst.afw.image as afwImage
 import lsst.coadd.utils as coaddUtils
 import lsst.pipe.base as pipeBase
-from lsst.meas.algorithms import CoaddPsf
+from lsst.meas.algorithms import CoaddPsf, CoaddPsfConfig
 from .coaddBase import CoaddBaseTask
 from .warpAndPsfMatch import WarpAndPsfMatchTask
 from .coaddHelpers import groupPatchExposures, getGroupDataRef
@@ -56,6 +56,10 @@ class MakeCoaddTempExpConfig(CoaddBaseTask.ConfigClass):
         doc="Work with a background subtracted calexp?",
         dtype=bool,
         default=True,
+    )
+    coaddPsf = pexConfig.ConfigField(
+        doc="Configuration for CoaddPsf",
+        dtype=CoaddPsfConfig,
     )
 
 ## \addtogroup LSST_task_documentation
@@ -390,7 +394,8 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
                 inputRecorder[warpType].finish(coaddTempExps[warpType], totGoodPix[warpType])
                 if warpType == "direct":
                     coaddTempExps[warpType].setPsf(
-                        CoaddPsf(inputRecorder[warpType].coaddInputs.ccds, skyInfo.wcs))
+                        CoaddPsf(inputRecorder[warpType].coaddInputs.ccds, skyInfo.wcs,
+                                 self.config.coaddPsf.makeControl()))
             else:
                 # No good pixels. Exposure still empty
                 coaddTempExps[warpType] = None


### PR DESCRIPTION
We want to be able to control the warping kernel used by CoaddPsf.
Uses the new CoaddPsfConfig class.