### PR TITLE
DM-11332: use bboxFromMetadata instead of NAXIS1,NAXIS2

### DIFF
--- a/python/lsst/pipe/tasks/coaddBase.py
+++ b/python/lsst/pipe/tasks/coaddBase.py
@@ -271,7 +271,7 @@ class SelectDataIdContainer(pipeBase.DataIdContainer):
             try:
                 md = ref.get("calexp_md", immediate=True)
                 wcs = afwImage.makeWcs(md)
-                data = SelectStruct(dataRef=ref, wcs=wcs, dims=(md.get("NAXIS1"), md.get("NAXIS2")))
+                data = SelectStruct(dataRef=ref, wcs=wcs, bbox=afwImage.bboxFromMetadata(md))
             except FitsError as e:
                 namespace.log.warn("Unable to construct Wcs from %s" % (ref.dataId))
                 continue

--- a/python/lsst/pipe/tasks/makeDiscreteSkyMap.py
+++ b/python/lsst/pipe/tasks/makeDiscreteSkyMap.py
@@ -140,7 +140,7 @@ class MakeDiscreteSkyMapTask(pipeBase.CmdLineTask):
             md = dataRef.get("calexp_md", immediate=True)
             wcs = afwImage.makeWcs(md)
             # nb: don't need to worry about xy0 because Exposure saves Wcs with CRPIX shifted by (-x0, -y0).
-            boxI = afwGeom.Box2I(afwGeom.Point2I(0, 0), afwGeom.Extent2I(md.get("NAXIS1"), md.get("NAXIS2")))
+            boxI = afwImage.bboxFromMetadata(md)
             boxD = afwGeom.Box2D(boxI)
             points.extend(tuple(wcs.pixelToSky(corner).getVector()) for corner in boxD.getCorners())
         if len(points) == 0:

--- a/python/lsst/pipe/tasks/selectImages.py
+++ b/python/lsst/pipe/tasks/selectImages.py
@@ -164,8 +164,8 @@ def _extractKeyValue(dataList, keys=None):
 class SelectStruct(pipeBase.Struct):
     """A container for data to be passed to the WcsSelectImagesTask"""
 
-    def __init__(self, dataRef, wcs, dims):
-        super(SelectStruct, self).__init__(dataRef=dataRef, wcs=wcs, dims=dims)
+    def __init__(self, dataRef, wcs, bbox):
+        super(SelectStruct, self).__init__(dataRef=dataRef, wcs=wcs, bbox=bbox)
 
 
 class WcsSelectImagesTask(BaseSelectImagesTask):
@@ -199,11 +199,10 @@ class WcsSelectImagesTask(BaseSelectImagesTask):
         for data in selectDataList:
             dataRef = data.dataRef
             imageWcs = data.wcs
-            nx, ny = data.dims
+            imageBox = data.bbox
 
-            imageBox = afwGeom.Box2D(afwGeom.Point2D(0, 0), afwGeom.Extent2D(nx, ny))
             try:
-                imageCorners = [imageWcs.pixelToSky(pix) for pix in imageBox.getCorners()]
+                imageCorners = [imageWcs.pixelToSky(pix) for pix in afwGeom.Box2D(imageBox).getCorners()]
             except (pexExceptions.DomainError, pexExceptions.RuntimeError) as e:
                 # Protecting ourselves from awful Wcs solutions in input images
                 self.log.debug("WCS error in testing calexp %s (%s): deselecting", dataRef.dataId, e)

--- a/tests/test_wcsSelectImages.py
+++ b/tests/test_wcsSelectImages.py
@@ -128,7 +128,8 @@ def createImage(
     center = center.clone()  # Ensure user doesn't need it, because we're mangling it
     center.rotate(rotateAxis, rotateAngle)
     wcs = afwImage.makeWcs(center, crpix, scale.asDegrees(), 0.0, 0.0, scale.asDegrees())
-    return SelectStruct(DummyDataRef(dataId), wcs, (dims[0], dims[1]))
+    return SelectStruct(DummyDataRef(dataId), wcs, afwGeom.Box2I(afwGeom.Point2I(0, 0),
+                                                                 afwGeom.Extent2I(dims[0], dims[1])))
 
 
 class WcsSelectImagesTestCase(unittest.TestCase):


### PR DESCRIPTION
Use of NAXIS1,NAXIS2 is being too familiar with the output format.
lsst.afw.image.bboxFromMetadata allows us to abstract the format.
This is especially important once we activate compression.