### PR TITLE
Implement CompareWarpAssembleCoaddTask with artifact rejection

### DIFF
--- a/bin.src/assembleCoadd.py
+++ b/bin.src/assembleCoadd.py
@@ -21,12 +21,14 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 from __future__ import print_function
-from lsst.pipe.tasks.assembleCoadd import AssembleCoaddTask, SafeClipAssembleCoaddTask
+from lsst.pipe.tasks.assembleCoadd import AssembleCoaddTask, SafeClipAssembleCoaddTask,\
+    CompareWarpAssembleCoaddTask
 import sys
 import argparse
 
 parser = argparse.ArgumentParser(add_help=False)
 parser.add_argument('--legacyCoadd', action='store_true', default=False)
+parser.add_argument('--warpCompareCoadd', action='store_true', default=False)
 parser.add_argument('-h', '--help', action='store_true', default=False)
 result, extra = parser.parse_known_args(sys.argv)
 
@@ -44,6 +46,8 @@ if result.help:
     # The appropriate one should be printed
     if result.legacyCoadd:
         AssembleCoaddTask.parseAndRun(args=['--help']+extra[1:])
+    elif result.warpCompareCoadd:
+        CompareWarpAssembleCoaddTask.parseAndRun(args=['--help'] + extra[1:])
     else:
         SafeClipAssembleCoaddTask.parseAndRun(args=['--help']+extra[1:])
 
@@ -61,5 +65,7 @@ if result.legacyCoadd:
     '''
     print(legacy_message)
     AssembleCoaddTask.parseAndRun(args=extra[1:])
+elif result.warpCompareCoadd:
+    CompareWarpAssembleCoaddTask.parseAndRun(args=extra[1:])
 else:
     SafeClipAssembleCoaddTask.parseAndRun(args=extra[1:])

--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -114,7 +114,7 @@ class AssembleCoaddConfig(CoaddBaseTask.ConfigClass):
         doc="Match backgrounds of coadd temp exposures before coadding them? "
         "If False, the coadd temp expsosures must already have been background subtracted or matched",
         dtype=bool,
-        default=True,
+        default=False,
     )
     autoReference = pexConfig.Field(
         doc="Automatically select the coadd temp exposure to use as a reference for background matching? "

--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -25,7 +25,6 @@ from builtins import range
 import numpy
 import lsst.pex.config as pexConfig
 import lsst.pex.exceptions as pexExceptions
-import lsst.afw.detection as afwDetect
 import lsst.afw.geom as afwGeom
 import lsst.afw.image as afwImage
 import lsst.afw.math as afwMath

--- a/python/lsst/pipe/tasks/coaddBase.py
+++ b/python/lsst/pipe/tasks/coaddBase.py
@@ -27,7 +27,6 @@ import lsst.afw.geom as afwGeom
 import lsst.afw.image as afwImage
 import lsst.pipe.base as pipeBase
 import lsst.meas.algorithms as measAlg
-import lsst.log as log
 
 from lsst.afw.fits import FitsError
 from lsst.coadd.utils import CoaddDataIdContainer
@@ -78,27 +77,6 @@ class CoaddBaseConfig(pexConfig.Config):
         doc="Apply meas_mosaic ubercal results to input calexps?",
         default=False
     )
-    makeDirect = pexConfig.Field(
-        doc="Make direct Warp/Coadds",
-        dtype=bool,
-        default=True,
-    )
-    makePsfMatched = pexConfig.Field(
-        doc="Make Psf-Matched Warp/Coadd?",
-        dtype=bool,
-        default=False,
-    )
-
-    def validate(self):
-        pexConfig.Config.validate(self)
-        if not self.makePsfMatched and not self.makeDirect:
-            raise RuntimeError("At least one of config.makePsfMatched and config.makeDirect must be True")
-        if self.doPsfMatch:
-            # Courtesy backwards compatibility.
-            # Configs do not have loggers
-            log.warn("Config doPsfMatch deprecated. Setting makePsfMatched=True and makeDirect=False")
-            self.makePsfMatched = True
-            self.makeDirect = False
 
 
 class CoaddTaskRunner(pipeBase.TaskRunner):
@@ -214,16 +192,6 @@ class CoaddBaseTask(pipeBase.CmdLineTask):
         WarpDatasetName : `string`
         """
         return self.config.coaddName + "Coadd_" + warpType + "Warp"
-
-    def getWarpTypeList(self):
-        """Return list of requested warp types per the config.
-        """
-        warpTypeList = []
-        if self.config.makeDirect:
-            warpTypeList.append("direct")
-        if self.config.makePsfMatched:
-            warpTypeList.append("psfMatched")
-        return warpTypeList
 
     @classmethod
     def _makeArgumentParser(cls):

--- a/python/lsst/pipe/tasks/mocks/mockCoadd.py
+++ b/python/lsst/pipe/tasks/mocks/mockCoadd.py
@@ -246,8 +246,7 @@ class MockCoaddTask(lsst.pipe.base.CmdLineTask):
         elif cls == AssembleCoaddTask:
             config.doMatchBackgrounds = False
             if assemblePsfMatched:
-                config.makePsfMatched = True
-                config.makeDirect = False
+                config.warpType = 'psfMatched'
         return cls(config)
 
     def iterPatchRefs(self, butler, tractInfo):


### PR DESCRIPTION
* Add new task to compare PSF-matched
warps and identify and mask artifacts when coadding.
* Control warpType by config parameter `warpType`