### PR TITLE
Changes to config to make processCcd less prone to failure.

### DIFF
--- a/python/lsst/pipe/tasks/processCcd.py
+++ b/python/lsst/pipe/tasks/processCcd.py
@@ -67,6 +67,7 @@ class ProcessCcdConfig(pexConfig.Config):
         self.charImage.doWriteExposure = False
         self.charImage.detection.doTempLocalBackground = False
         self.calibrate.detection.doTempLocalBackground = False
+        self.calibrate.deblend.maxFootprintSize=2000
 
 ## \addtogroup LSST_task_documentation
 ## \{


### PR DESCRIPTION
Change to maxFootprintSize is to prevent hangs in deblending.