### PR TITLE
DM-6965: DetectCoaddSourcesTask: record variance scaling factor

### DIFF
--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -290,7 +290,8 @@ class DetectCoaddSourcesTask(CmdLineTask):
         - backgrounds: list of backgrounds
         """
         if self.config.doScaleVariance:
-            scaleVariance(exposure.getMaskedImage(), self.config.mask, log=self.log)
+            varScale = scaleVariance(exposure.getMaskedImage(), self.config.mask, log=self.log)
+            self.metadata.add("variance_scale", varScale)
         backgrounds = afwMath.BackgroundList()
         if self.config.doInsertFakes:
             self.insertFakes.run(exposure, background=backgrounds)


### PR DESCRIPTION
Without this value, it's difficult to make simulations with the same noise
properties as our coadds.