### PR TITLE
Tickets/DM-13325: Set visitInfo of warped exposures.

### DIFF
--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -400,6 +400,7 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
                     if numGoodPix[warpType] > 0 and not didSetMetadata[warpType]:
                         coaddTempExp.setCalib(exposure.getCalib())
                         coaddTempExp.setFilter(exposure.getFilter())
+                        coaddTempExp.getInfo().setVisitInfo(exposure.getInfo().getVisitInfo())
                         # PSF replaced with CoaddPsf after loop if and only if creating direct warp
                         coaddTempExp.setPsf(exposure.getPsf())
                         didSetMetadata[warpType] = True


### PR DESCRIPTION
Preserve the visitInfo of an exposure when warping.