### PR TITLE
Change sigmaclip of template coadd to 5 sigma.

### DIFF
--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -1364,7 +1364,7 @@ class CompareWarpAssembleCoaddConfig(AssembleCoaddConfig):
         self.assembleStaticSkyModel.badMaskPlanes = ["NO_DATA", ]
         self.assembleStaticSkyModel.warpType = 'psfMatched'
         self.assembleStaticSkyModel.statistic = 'MEANCLIP'
-        self.assembleStaticSkyModel.sigmaClip = 1.5
+        self.assembleStaticSkyModel.sigmaClip = 5
         self.assembleStaticSkyModel.clipIter = 3
         self.assembleStaticSkyModel.calcErrorFromInputVariance = False
         self.assembleStaticSkyModel.doWrite = False


### PR DESCRIPTION
Because templateCoadd variance is computed as dispersion
of the images, higher sigma will result in a desireable
higher variance in the template.