### PR TITLE
DM-2639: {{Standardize primary method names, run/runDataRef, across PipeTasks}}

### DIFF
--- a/bin.src/dumpTaskMetadata.py
+++ b/bin.src/dumpTaskMetadata.py
@@ -43,7 +43,7 @@ class DumpTaskMetadataTask(pipeBase.CmdLineTask):
     _DefaultName = "DumpTaskMetadata"
 
     @pipeBase.timeMethod
-    def run(self, dataRef):
+    def runDataRef(self, dataRef):
         """Report task metadata
         """
         print("%s for dataId=%s" % (dataRef.butlerSubset.datasetType, dataRef.dataId))

--- a/bin.src/reportImagesInPatch.py
+++ b/bin.src/reportImagesInPatch.py
@@ -57,7 +57,7 @@ class ReportImagesInPatchTask(pipeBase.CmdLineTask):
         self.makeSubtask("select")
 
     @pipeBase.timeMethod
-    def run(self, patchRef):
+    def runDataRef(self, patchRef):
         """Select images for a region and report how many are in each tract and patch
 
         Also report quartiles of FWHM

--- a/bin.src/reportImagesToCoadd.py
+++ b/bin.src/reportImagesToCoadd.py
@@ -68,7 +68,7 @@ class ReportImagesToCoaddTask(pipeBase.CmdLineTask):
         self.makeSubtask("select")
 
     @pipeBase.timeMethod
-    def run(self, dataRef):
+    def runDataRef(self, dataRef):
         """Select images across the sky and report how many are in each tract and patch
 
         Also report quartiles of FWHM

--- a/bin.src/reportPatches.py
+++ b/bin.src/reportPatches.py
@@ -59,7 +59,7 @@ class ReportPatchesTask(pipeBase.CmdLineTask):
         pipeBase.CmdLineTask.__init__(self, *args, **kwargs)
 
     @pipeBase.timeMethod
-    def run(self, dataRef):
+    def runDataRef(self, dataRef):
         """Report tracts and patches that are within a given region of a skymap
 
         @param dataRef: data reference for sky map.

--- a/bin.src/reportTaskTiming.py
+++ b/bin.src/reportTaskTiming.py
@@ -145,7 +145,7 @@ class ReportTaskTimingTask(pipeBase.CmdLineTask):
         pipeBase.CmdLineTask.__init__(self, *args, **kwargs)
 
     @pipeBase.timeMethod
-    def run(self, dataRefList):
+    def runDataRef(self, dataRefList):
         """Report timing statistics for a collection of task metadata
 
         @param dataRefList: a list of data references for task metadata

--- a/doc/old/writeCmdLineTask.dox
+++ b/doc/old/writeCmdLineTask.dox
@@ -37,9 +37,9 @@ Command-line tasks have the following key attributes, in addition to the attribu
     whereas regular tasks are subclasses of \ref lsst.pipe.base.task.Task "lsst.pipe.base.Task".
 - They have an associated \ref pipeTasks_writeCmdLineTask_runScript "run script" to run them from the
     command-line as pipelines (this is common, but not required, for regular tasks).
-- \anchor pipeTasks_writeCmdLineTask_runMethod They have a `run` method which performs the full pipeline
+- \anchor pipeTasks_writeCmdLineTask_runMethod They have a `runDataRef` method which performs the full pipeline
     data processing.
-- By default the `run` method takes exactly one argument: a data reference for the item of data to be
+- By default the `runDataRef` method takes exactly one argument: a data reference for the item of data to be
     processed. Variations are possible, but require that you provide a
     \ref pipeTasks_writeCmdLineTask_customArgumentParser and often a
     \ref pipeTasks_writeCmdLineTask_customTaskRunner.
@@ -48,9 +48,9 @@ Command-line tasks have the following key attributes, in addition to the attribu
 - \anchor pipeTasks_writeCmdLineTask_taskRunner They have an additional
     \ref pipeTasks_writeTask_classVariables "class variable": `RunnerClass', which specifies a "task runner"
     for the task. The task runner takes a parsed command and runs the task. The default task runner
-    will work for any script whose `run` method accepts a single data reference, such as
+    will work for any script whose `runDataRef` method accepts a single data reference, such as
     \ref exampleCmdLineTask.ExampleCmdLineTask "ExampleCmdLineTask".
-    If your task's `run` method needs something else then you will have to provide a
+    If your task's `runDataRef` method needs something else then you will have to provide a
     \ref pipeTasks_writeCmdLineTask_customTaskRunner "custom task runner".
 - \anchor pipeTasks_writeCmdLineTask_canMultiprocess They have an additional
     \ref pipeTasks_writeTask_classVariables "class variable" `canMultiprocess`, which defaults to `True`.
@@ -65,7 +65,7 @@ which merely calls the task's `parseAndRun` method. `parseAndRun` does the follo
 - Parses the command line, which includes determining the 
     \ref pipeTasks_writeTask_configuration "configuration" for the task and which data items to process.
 - Constructs the task.
-- Calls the task's `run` method once for each data item to process.
+- Calls the task's `runDataRef` method once for each data item to process.
 
 `examples/exampleCmdLineTask.py`, the runner script for \ref exampleCmdLineTask.ExampleCmdLineTask "ExampleCmdLineTask", is typical:
 
@@ -83,7 +83,7 @@ Remember to make your run script executable using `chmod +x`.
 
 \section pipeTasks_writeCmdLineTask_readWriteData Reading and Writing Data
 
-The \ref pipeTasks_writeCmdLineTask_runMethod "run method" typically receives a single data reference, as
+The \ref pipeTasks_writeCmdLineTask_runMethod "runDataRef method" typically receives a single data reference, as
 mentioned above. It read and writes data using this data reference (or the underlying butler, if necessary).
 
 \subsection pipeTasks_writeCmdLineTask_addDatasetTypes Adding Dataset Types
@@ -148,7 +148,7 @@ data reference, then it also require a \ref pipeTasks_writeCmdLineTask_customTas
 as well.
 
 Here are some examples:
-- A task's `run` methd requires a data reference of some kind other than a raw or calibrated image.
+- A task's `runDataRef` method requires a data reference of some kind other than a raw or calibrated image.
     This is a common case, and easily solved. For example the processCoadd.ProcessCoaddTask
     processes co-adds, which are specified by \ref skyMap_introduction "sky map patch". Here is
     `ProcessCoaddTask._makeArgumentParser`:
@@ -173,7 +173,7 @@ Here are some examples:
     \ref lsst.coadd.utils.coaddDataIdContainer.CoaddDataIdContainer "CoaddDataIdContainer"
     to see how it works.
 
-- A task's `run` method requires more than one kind of data reference. An example is co-addition,
+- A task's `runDataRef` method requires more than one kind of data reference. An example is co-addition,
     which requires the user to specify the co-add as a \ref skyMap_introduction "sky map patch",
     and optionally allows the user to specify a list of exposures to co-add.
     `CoaddBaseTask._makeArgumentParser` is a straightforward example of specifying two data IDs arguments:
@@ -187,7 +187,7 @@ Here are some examples:
     \ref lsst.pipe.tasks.coaddBase.SelectDataIdContainer "SelectDataIdContainer"
     adds additional information for the task, to save processing time.
 
-- A task's `run` method requires no data references at all. An example is makeSkyMap.MakeSkyMapTask,
+- A task's `runDataRef` method requires no data references at all. An example is makeSkyMap.MakeSkyMapTask,
     which makes a \ref skyMap_introduction "sky map" for a set of co-adds.
     makeSkyMap.MakeSkyMapTask._makeArgumentParser is trivial:
     \dontinclude makeSkyMap.py
@@ -199,13 +199,16 @@ Here are some examples:
 
 The standard \ref pipeTasks_writeCmdLineTask_taskRunner "task runner" is 
 \ref lsst.pipe.base.cmdLineTask.TaskRunner "lsst.pipe.base.TaskRunner".
-It assumes that your task's `run` method wants a single data reference and nothing else. If that is not
-the case then you will have to provide a custom task runner for your task. This involves writing a subclass of
-\ref lsst.pipe.base.cmdLineTask.TaskRunner "lsst.pipe.base.TaskRunner" and specifying it in your task
-using the `RunnerClass` \ref pipeTasks_writeTask_classVariables" class variable".
+It assumes that your task's `runDataref` method wants a single data reference and nothing else. If your
+task uses the pre-2018 naming convention and has a `run` method that operates on a data references instead of
+a `runDataRef` method, you can still use this as a `CmdLineTask` by using the
+\ref lsst.pipe.base.cmdLineTask.LegacyTaskRunner "lsst.pipe.base.LegacyTaskRunner", which will call your task's
+`run` method. If neither of those are the case then you will have to provide a custom task runner for your task. This
+involves writing a subclass of \ref lsst.pipe.base.cmdLineTask.TaskRunner "lsst.pipe.base.TaskRunner" and
+specifying it in your task using the `RunnerClass` \ref pipeTasks_writeTask_classVariables" class variable".
 
 Here are some situations where a custom task runner is required:
-- The task's `run` method requires extra arguments. An example is co-addition, which optionally accepts
+- The task's `runDataRef` method requires extra arguments. An example is co-addition, which optionally accepts
     a list of images to co-add. The custom task runner is coaddBase.CoaddTaskRunner and is pleasantly simple:
     \dontinclude coaddBase.py
     \skip class CoaddTaskRunner

--- a/doc/old/writeTask.dox
+++ b/doc/old/writeTask.dox
@@ -146,11 +146,15 @@ this is strongly recommended, as explained in the next section.
 
 \subsection pipeTasks_writeTask_runMethod The run Method
 
-Most tasks have a `run` method which perform's the task's data processing operation.
-This is required for command-line tasks and strongly recommended for most other tasks.
-One exception is if your task needs different methods to handle different data types
-(C++ handles this using overloaded functions, but the standard technique is Python
-is to provide different methods for different call signatures).
+Most tasks have a `run` method which perform's the task's data
+processing operation.  In addition, command-line tasks require a
+`runDataRef` method that fetches the appropriate data products
+specified by Gen-2 Butler DataRefs.  This is required for command-line
+tasks and strongly recommended for most other tasks.  One exception is
+if your task needs different methods to handle different data types
+(C++ handles this using overloaded functions, but the standard
+technique is Python is to provide different methods for different call
+signatures).
 
 If your task's processing can be divided into logical units, then we recommend that
 you provide methods for each unit. `run` can then call each method to do its work.
@@ -161,17 +165,18 @@ as part of your data processing. Pass data between methods by calling and return
 This makes the task much easier to reason about, since processing one item of data
 cannot affect future items of data.
 
-The `run` method should always return its results in an lsst.pipe.base.struct.Struct object,
-with a named field for each item of data. This is safer than returning a tuple of items,
-and allows adding fields without affecting existing code. Other methods should also
-return Structs if they return more than one or two items.
+The `run` and `runDataRef` methods should always return its results in
+an lsst.pipe.base.struct.Struct object, with a named field for each
+item of data. This is safer than returning a tuple of items, and
+allows adding fields without affecting existing code. Other methods
+should also return Structs if they return more than one or two items.
 
 Any method that is likely to take significant time or memory should be preceded by this python decorator:
 <code>\@lsst.pipe.base.timeMethod</code>. This automatically records the execution time and memory
 of the method in the task's `metadata` attribute.
 
 The example exampleCmdLineTask.ExampleCmdLineTask is so simple that it needs no other methods;
-`run` does everything:
+`runDataRef` does everything:
 \dontinclude tasks/exampleCmdLineTask.py
 \skip class ExampleCmdLineTask
 \skipline pipeBase.timeMethod
@@ -212,7 +217,7 @@ and `pipe/tasks/exampleCmdLineTask.py` provide useful examples and documentation
 
 Content should include:
 - The task's purpose.
-- An overview of the important task methods, including `run` (if present), including links to the detailed documentation for each method.
+- An overview of the important task methods, including `run` and `runDataRef` (if present), including links to the detailed documentation for each method.
 - The detailed documentation for each method must carefully describe its parameters, including data type (unless blindingly obvious). If a method takes a data reference or a butler, describe which dataset types are read and written.
 - A link to the config class, which should have clear help strings for each parameter.
 - A description of debug options.

--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -211,10 +211,10 @@ class CalibrateTask(pipeBase.CmdLineTask):
     @section pipe_tasks_calibrate_IO  Invoking the Task
 
     If you want this task to unpersist inputs or persist outputs, then call
-    the `run` method (a wrapper around the `calibrate` method).
+    the `runDataRef` method (a wrapper around the `run` method).
 
     If you already have the inputs unpersisted and do not want to persist the
-    output then it is more direct to call the `calibrate` method:
+    output then it is more direct to call the `run` method:
 
     @section pipe_tasks_calibrate_Config  Configuration parameters
 
@@ -380,19 +380,19 @@ class CalibrateTask(pipeBase.CmdLineTask):
         self.schema.checkUnits(parse_strict=self.config.checkUnitsParseStrict)
 
     @pipeBase.timeMethod
-    def run(self, dataRef, exposure=None, background=None, icSourceCat=None,
-            doUnpersist=True):
+    def runDataRef(self, dataRef, exposure=None, background=None, icSourceCat=None,
+                   doUnpersist=True):
         """!Calibrate an exposure, optionally unpersisting inputs and
             persisting outputs.
 
-        This is a wrapper around the `calibrate` method that unpersists inputs
+        This is a wrapper around the `run` method that unpersists inputs
         (if `doUnpersist` true) and persists outputs (if `config.doWrite` true)
 
         @param[in] dataRef  butler data reference corresponding to a science
             image
         @param[in,out] exposure  characterized exposure (an
             lsst.afw.image.ExposureF or similar), or None to unpersist existing
-            icExp and icBackground. See calibrate method for details of what is
+            icExp and icBackground. See `run` method for details of what is
             read and written.
         @param[in,out] background  initial model of background already
             subtracted from exposure (an lsst.afw.math.BackgroundList). May be
@@ -425,7 +425,7 @@ class CalibrateTask(pipeBase.CmdLineTask):
 
         exposureIdInfo = dataRef.get("expIdInfo")
 
-        calRes = self.calibrate(
+        calRes = self.run(
             exposure=exposure,
             exposureIdInfo=exposureIdInfo,
             background=background,
@@ -444,8 +444,8 @@ class CalibrateTask(pipeBase.CmdLineTask):
 
         return calRes
 
-    def calibrate(self, exposure, exposureIdInfo=None, background=None,
-                  icSourceCat=None):
+    def run(self, exposure, exposureIdInfo=None, background=None,
+            icSourceCat=None):
         """!Calibrate an exposure (science image or coadd)
 
         @param[in,out] exposure  exposure to calibrate (an

--- a/python/lsst/pipe/tasks/characterizeImage.py
+++ b/python/lsst/pipe/tasks/characterizeImage.py
@@ -206,10 +206,10 @@ class CharacterizeImageTask(pipeBase.CmdLineTask):
     @section pipe_tasks_characterizeImage_IO  Invoking the Task
 
     If you want this task to unpersist inputs or persist outputs, then call
-    the `run` method (a thin wrapper around the `characterize` method).
+    the `runDataRef` method (a thin wrapper around the `run` method).
 
     If you already have the inputs unpersisted and do not want to persist the output
-    then it is more direct to call the `characterize` method:
+    then it is more direct to call the `run` method:
 
     @section pipe_tasks_characterizeImage_Config  Configuration parameters
 
@@ -306,7 +306,7 @@ class CharacterizeImageTask(pipeBase.CmdLineTask):
         self.schema.checkUnits(parse_strict=self.config.checkUnitsParseStrict)
 
     @pipeBase.timeMethod
-    def run(self, dataRef, exposure=None, background=None, doUnpersist=True):
+    def runDataRef(self, dataRef, exposure=None, background=None, doUnpersist=True):
         """!Characterize a science image and, if wanted, persist the results
 
         This simply unpacks the exposure and passes it to the characterize method to do the work.
@@ -343,7 +343,7 @@ class CharacterizeImageTask(pipeBase.CmdLineTask):
 
         exposureIdInfo = dataRef.get("expIdInfo")
 
-        charRes = self.characterize(
+        charRes = self.run(
             exposure=exposure,
             exposureIdInfo=exposureIdInfo,
             background=background,
@@ -358,7 +358,7 @@ class CharacterizeImageTask(pipeBase.CmdLineTask):
         return charRes
 
     @pipeBase.timeMethod
-    def characterize(self, exposure, exposureIdInfo=None, background=None):
+    def run(self, exposure, exposureIdInfo=None, background=None):
         """!Characterize a science image
 
         Peforms the following operations:

--- a/python/lsst/pipe/tasks/dcrAssembleCoadd.py
+++ b/python/lsst/pipe/tasks/dcrAssembleCoadd.py
@@ -161,12 +161,12 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
     _DefaultName = "dcrAssembleCoadd"
 
     @pipeBase.timeMethod
-    def run(self, dataRef, selectDataList=[]):
+    def runDataRef(self, dataRef, selectDataList=[]):
         """Assemble a coadd from a set of warps.
 
         Coadd a set of Warps. Compute weights to be applied to each Warp and
         find scalings to match the photometric zeropoint to a reference Warp.
-        Assemble the Warps using assemble.
+        Assemble the Warps using run method.
         Forward model chromatic effects across multiple subfilters,
         and subtract from the input Warps to build sets of residuals.
         Use the residuals to construct a new ``DcrModel`` for each subfilter,
@@ -194,7 +194,7 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
             - ``dcrCoadds``: `list` of coadded exposures for each subfilter
             - ``dcrNImages``: `list` of exposure count images for each subfilter
         """
-        results = AssembleCoaddTask.run(self, dataRef, selectDataList=selectDataList)
+        results = AssembleCoaddTask.runDataRef(self, dataRef, selectDataList=selectDataList)
         for subfilter in range(self.config.dcrNumSubfilters):
             self.processResults(results.dcrCoadds[subfilter], dataRef)
             if self.config.doWrite:
@@ -259,8 +259,8 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
                                        self.filterInfo)
         return dcrModels
 
-    def assemble(self, skyInfo, tempExpRefList, imageScalerList, weightList,
-                 supplementaryData=None):
+    def run(self, skyInfo, tempExpRefList, imageScalerList, weightList,
+            supplementaryData=None):
         """Assemble the coadd.
 
         Requires additional inputs Struct ``supplementaryData`` to contain a

--- a/python/lsst/pipe/tasks/exampleCmdLineTask.py
+++ b/python/lsst/pipe/tasks/exampleCmdLineTask.py
@@ -74,7 +74,7 @@ class ExampleCmdLineTask(pipeBase.CmdLineTask):
     The image statistics are computed using a subtask, in order to show how to call subtasks and how to
     \ref pipeBase_argumentParser_retargetSubtasks "retarget" (replace) them with variant subtasks.
 
-    The main method is \ref ExampleCmdLineTask.run "run".
+    The main method is \ref ExampleCmdLineTask.runDataRef "runDataRef".
 
     \section pipeTasks_ExampleCmdLineTask_Config    Configuration parameters
 
@@ -113,7 +113,7 @@ class ExampleCmdLineTask(pipeBase.CmdLineTask):
         self.makeSubtask("stats")
 
     @pipeBase.timeMethod
-    def run(self, dataRef):
+    def runDataRef(self, dataRef):
         """!Compute a few statistics on the image plane of an exposure
 
         @param dataRef: data reference for a calibrated science exposure ("calexp")

--- a/python/lsst/pipe/tasks/getRepositoryData.py
+++ b/python/lsst/pipe/tasks/getRepositoryData.py
@@ -54,7 +54,7 @@ class DataRefListRunner(pipeBase.TaskRunner):
             - result: result returned by task runDataRef
         """
         task = self.TaskClass(config=self.config, log=self.log)
-        result = task.run(dataRefList)
+        result = task.runDataRef(dataRefList)
 
         if self.doReturnResults:
             return pipeBase.Struct(
@@ -75,7 +75,7 @@ class GetRepositoryDataTask(pipeBase.CmdLineTask):
         pipeBase.CmdLineTask.__init__(self, *args, **kwargs)
 
     @pipeBase.timeMethod
-    def run(self, dataRefList):
+    def runDataRef(self, dataRefList):
         """Get data from a repository for a collection of data references
 
         @param dataRefList: a list of data references

--- a/python/lsst/pipe/tasks/imageDifference.py
+++ b/python/lsst/pipe/tasks/imageDifference.py
@@ -251,7 +251,7 @@ class ImageDifferenceTask(pipeBase.CmdLineTask):
             self.schema.addField("srcMatchId", "L", "unique id of source match")
 
     @pipeBase.timeMethod
-    def run(self, sensorRef, templateIdList=None):
+    def runDataRef(self, sensorRef, templateIdList=None):
         """Subtract an image from a template coadd and measure the result
 
         Steps include:

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -126,7 +126,7 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
 
     This task is primarily designed to be run from the command line.
 
-    The main method is `run`, which takes a single butler data reference for the patch(es)
+    The main method is `runDataRef`, which takes a single butler data reference for the patch(es)
     to process.
 
     @copydoc run
@@ -252,7 +252,7 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
         self.makeSubtask("warpAndPsfMatch")
 
     @pipeBase.timeMethod
-    def run(self, patchRef, selectDataList=[]):
+    def runDataRef(self, patchRef, selectDataList=[]):
         """!Produce <coaddName>Coadd_<warpType>Warp images by warping and optionally PSF-matching.
 
         @param[in] patchRef: data reference for sky map patch. Must include keys "tract", "patch",
@@ -305,7 +305,7 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
             except (KeyError, ValueError):
                 visitId = i
 
-            exps = self.createTempExp(calexpRefList, skyInfo, visitId).exposures
+            exps = self.run(calexpRefList, skyInfo, visitId).exposures
 
             if any(exps.values()):
                 dataRefList.append(tempExpRef)
@@ -320,7 +320,7 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
 
         return dataRefList
 
-    def createTempExp(self, calexpRefList, skyInfo, visitId=0):
+    def run(self, calexpRefList, skyInfo, visitId=0):
         """Create a Warp from inputs
 
         We iterate over the multiple calexps in a single exposure to construct

--- a/python/lsst/pipe/tasks/makeDiscreteSkyMap.py
+++ b/python/lsst/pipe/tasks/makeDiscreteSkyMap.py
@@ -90,10 +90,10 @@ class MakeDiscreteSkyMapRunner(pipeBase.TaskRunner):
         result = None  # in case the task fails
         exitStatus = 0  # exit status for shell
         if self.doRaise:
-            result = task.run(butler, dataRefList)
+            result = task.runDataRef(butler, dataRefList)
         else:
             try:
-                result = task.run(butler, dataRefList)
+                result = task.runDataRef(butler, dataRefList)
             except Exception as e:
                 task.log.fatal("Failed: %s" % e)
                 exitStatus = 1
@@ -129,7 +129,7 @@ class MakeDiscreteSkyMapTask(pipeBase.CmdLineTask):
         pipeBase.CmdLineTask.__init__(self, **kwargs)
 
     @pipeBase.timeMethod
-    def run(self, butler, dataRefList):
+    def runDataRef(self, butler, dataRefList):
         """!Make a skymap from the bounds of the given set of calexps.
 
         @param[in]  butler        data butler used to save the SkyMap

--- a/python/lsst/pipe/tasks/makeSkyMap.py
+++ b/python/lsst/pipe/tasks/makeSkyMap.py
@@ -59,10 +59,10 @@ class MakeSkyMapRunner(pipeBase.TaskRunner):
         results = None  # in case the task fails
         exitStatus = 0  # exit status for shell
         if self.doRaise:
-            results = task.run(butler)
+            results = task.runDataRef(butler)
         else:
             try:
-                results = task.run(butler)
+                results = task.runDataRef(butler)
             except Exception as e:
                 task.log.fatal("Failed: %s" % e)
                 exitStatus = 1
@@ -94,7 +94,7 @@ class MakeSkyMapTask(pipeBase.CmdLineTask):
         pipeBase.CmdLineTask.__init__(self, **kwargs)
 
     @pipeBase.timeMethod
-    def run(self, butler):
+    def runDataRef(self, butler):
         """!Make a skymap, persist it (optionally) and log some information about it
 
         @param[in]   butler  data butler

--- a/python/lsst/pipe/tasks/mocks/mockCoadd.py
+++ b/python/lsst/pipe/tasks/mocks/mockCoadd.py
@@ -134,7 +134,7 @@ class MockCoaddTask(lsst.pipe.base.CmdLineTask):
 
     def buildSkyMap(self, butler):
         """Build the skymap for the mock dataset."""
-        return self.makeSkyMap.run(butler.dataRef(self.config.coaddName + "Coadd_skyMap")).skyMap
+        return self.makeSkyMap.runDataRef(butler.dataRef(self.config.coaddName + "Coadd_skyMap")).skyMap
 
     def buildTruthCatalog(self, butler=None, skyMap=None, tract=0):
         """Create and save (if butler is not None) a truth catalog containing all the mock objects.
@@ -278,11 +278,11 @@ class MockCoaddTask(lsst.pipe.base.CmdLineTask):
             directCoaddTaskList.append(self.makeCoaddTask(coaddTask))
         assemblePsfMatchedCoaddTask = self.makeCoaddTask(AssembleCoaddTask, assemblePsfMatched=True)
         for patchRef in self.iterPatchRefs(butler, tractInfo):
-            makeCoaddTempExpTask.run(patchRef)
+            makeCoaddTempExpTask.runDataRef(patchRef)
         for patchRef in self.iterPatchRefs(butler, tractInfo):
             for directCoaddTask in directCoaddTaskList:
-                directCoaddTask.run(patchRef)
-            assemblePsfMatchedCoaddTask.run(patchRef)
+                directCoaddTask.runDataRef(patchRef)
+            assemblePsfMatchedCoaddTask.runDataRef(patchRef)
 
     def buildMockCoadd(self, butler, truthCatalog=None, skyMap=None, tract=0):
         """Directly create a simulation of the coadd, using the CoaddPsf (and ModelPsf)

--- a/python/lsst/pipe/tasks/processCcd.py
+++ b/python/lsst/pipe/tasks/processCcd.py
@@ -107,7 +107,7 @@ class ProcessCcdTask(pipeBase.CmdLineTask):
 
     This task is primarily designed to be run from the command line.
 
-    The main method is `run`, which takes a single butler data reference for the raw input data.
+    The main method is `runDataRef`, which takes a single butler data reference for the raw input data.
 
     @section pipe_tasks_processCcd_Config  Configuration parameters
 
@@ -160,7 +160,7 @@ class ProcessCcdTask(pipeBase.CmdLineTask):
                          astromRefObjLoader=astromRefObjLoader, photoRefObjLoader=photoRefObjLoader)
 
     @pipeBase.timeMethod
-    def run(self, sensorRef):
+    def runDataRef(self, sensorRef):
         """Process one CCD
 
         The sequence of operations is:
@@ -182,7 +182,7 @@ class ProcessCcdTask(pipeBase.CmdLineTask):
 
         exposure = self.isr.runDataRef(sensorRef).exposure
 
-        charRes = self.charImage.run(
+        charRes = self.charImage.runDataRef(
             dataRef=sensorRef,
             exposure=exposure,
             doUnpersist=False,
@@ -190,7 +190,7 @@ class ProcessCcdTask(pipeBase.CmdLineTask):
         exposure = charRes.exposure
 
         if self.config.doCalibrate:
-            calibRes = self.calibrate.run(
+            calibRes = self.calibrate.runDataRef(
                 dataRef=sensorRef,
                 exposure=charRes.exposure,
                 background=charRes.background,

--- a/python/lsst/pipe/tasks/transformMeasurement.py
+++ b/python/lsst/pipe/tasks/transformMeasurement.py
@@ -244,7 +244,7 @@ class RunTransformTaskBase(pipeBase.CmdLineTask):
                          outputDataset=self.outputDataset)
 
     @pipeBase.timeMethod
-    def run(self, dataRef):
+    def runDataRef(self, dataRef):
         """!Transform the source catalog referred to by dataRef.
 
         The result is both returned and written as dataset type "transformed_" + the input

--- a/tests/nopytest_test_coadds.py
+++ b/tests/nopytest_test_coadds.py
@@ -163,14 +163,14 @@ def runTaskOnPatches(butler, task, mocksTask, tract=0):
     skyMap = butler.get(mocksTask.config.coaddName + "Coadd_skyMap", immediate=True)
     tractInfo = skyMap[tract]
     for dataRef in mocksTask.iterPatchRefs(butler, tractInfo):
-        task.run(dataRef)
+        task.runDataRef(dataRef)
 
 
 def runTaskOnPatchList(butler, task, mocksTask, tract=0, rerun=None):
     skyMap = butler.get(mocksTask.config.coaddName + "Coadd_skyMap", immediate=True)
     tractInfo = skyMap[tract]
     for dataRef in mocksTask.iterPatchRefs(butler, tractInfo):
-        task.run([dataRef])
+        task.runDataRef([dataRef])
 
 
 def runTaskOnCcds(butler, task, tract=0):
@@ -180,7 +180,7 @@ def runTaskOnCcds(butler, task, tract=0):
     for record in catalog:
         dataRef = butler.dataRef("forced_src", tract=tract, visit=record.getI(visitKey),
                                  ccd=record.getI(ccdKey))
-        task.run(dataRef)
+        task.runDataRef(dataRef)
 
 
 def getObsDict(butler, tract=0):

--- a/tests/test_processCcd.py
+++ b/tests/test_processCcd.py
@@ -277,7 +277,7 @@ class ProcessCcdTestCase(lsst.utils.tests.TestCase):
                 args=[InputDir, "--output", outPath, "--clobber-config", "--doraise", "--id"] + dataIdStrList,
                 doReturnResults=True,
             )
-            icResult2 = charImageTask.characterize(isrResult2.exposure)
+            icResult2 = charImageTask.run(isrResult2.exposure)
             self.assertMaskedImagesEqual(
                 icResult1.parsedCmd.butler.get("icExp", dataId, immediate=True).getMaskedImage(),
                 icResult1.resultList[0].result.exposure.getMaskedImage()
@@ -308,7 +308,7 @@ class ProcessCcdTestCase(lsst.utils.tests.TestCase):
                 args=[InputDir, "--output", outPath, "--clobber-config", "--doraise", "--id"] + dataIdStrList,
                 doReturnResults=True,
             )
-            calResult2 = calibrateTask.calibrate(
+            calResult2 = calibrateTask.run(
                 icResult2.exposure,
                 background=icResult2.background,
                 icSourceCat=icResult2.sourceCat

--- a/tests/test_psfCandidateSelection.py
+++ b/tests/test_psfCandidateSelection.py
@@ -45,7 +45,7 @@ class PsfFlagTestCase(lsst.utils.tests.TestCase):
         # Test that all of the flags are defined and there is no reservation by default
         # also test that used sources are a subset of candidate sources
         task = CharacterizeImageTask()
-        results = task.characterize(self.exposure)
+        results = task.run(self.exposure)
         used = 0
         reserved = 0
         for source in results.sourceCat:


### PR DESCRIPTION
Rename methods according to RFC-352.
Fifteen total repositories with changes.
