### PR TITLE
DM-15531

### DIFF
--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -862,6 +862,10 @@ class DeblendCoaddSourcesConfig(Config):
     simultaneous = Field(dtype=bool, default=False, doc="Simultaneously deblend all bands?")
     coaddName = Field(dtype=str, default="deep", doc="Name of coadd")
 
+    def setDefaults(self):
+        Config.setDefaults(self)
+        self.singleBandDeblend.propagateAllPeaks = True
+
 
 class DeblendCoaddSourcesRunner(MergeSourcesRunner):
     """Task runner for the `MergeSourcesTask`


### PR DESCRIPTION
Set config parameter for single frame deblending

The single frame deblender in DeblendCoaddSourcesTask should be set
to propagate all peaks from the input detection catalog so that
multiband catalogs will have the same number of sources in the same
order.