### PR TITLE
DM-15528: Don't assume Camera iteration matches ccdExposureId ordering.

### DIFF
--- a/python/lsst/pipe/tasks/mocks/mockCoadd.py
+++ b/python/lsst/pipe/tasks/mocks/mockCoadd.py
@@ -165,6 +165,7 @@ class MockCoaddTask(lsst.pipe.base.CmdLineTask):
         catalog = self.mockObservation.run(butler=butler,
                                            n=self.config.nObservations, camera=camera,
                                            tractInfo=skyMap[tract])
+        catalog.sort()
         if butler is not None:
             butler.put(catalog, "observations", tract=tract)
         return catalog


### PR DESCRIPTION
The "observations" catalog used in the coadd tests needs to be sorted for find() to work, but we never actually guaranteed this in the past; the order was set by Camera iteration, which is actually just dict iteration and hence has no guaranteed order.
This broke on DM-15528 when moving the Camera from Python (dict) to C++ (unordered_map) changed that iteration order.