### PR TITLE
DM-16731: Fix DcrCoadd missing mask planes

### DIFF
--- a/python/lsst/pipe/tasks/dcrAssembleCoadd.py
+++ b/python/lsst/pipe/tasks/dcrAssembleCoadd.py
@@ -136,6 +136,7 @@ class DcrAssembleCoaddConfig(CompareWarpAssembleCoaddConfig):
 
     def setDefaults(self):
         CompareWarpAssembleCoaddConfig.setDefaults(self)
+        self.assembleStaticSkyModel.retarget(CompareWarpAssembleCoaddTask)
         self.doNImage = True
         self.warpType = 'direct'
         self.assembleStaticSkyModel.warpType = self.warpType


### PR DESCRIPTION
The mask planes were being cleared in the call to `findArtifacts`, and in `CompareWarpAssembleCoadd` they would get added back in during stacking. In `DcrAssembleCoadd`, however, we want to use the full mask plane from the initial non-DCR coadd throughout, because the masked regions would otherwise grow with every iteration. The simple solution implemented here is to copy the mask plane of the initial coadd before `findArtifacts` is run, and use that as the mask. 

Also, the initial coadd is now set to use `CompareWarpAssembleCoadd`.