### PR TITLE
DM-17871: Add DcrAssembleCoaddTask to the API reference

### DIFF
--- a/doc/lsst.pipe.tasks/index.rst
+++ b/doc/lsst.pipe.tasks/index.rst
@@ -72,3 +72,4 @@ Python API reference
 ====================
 
 .. automodapi:: lsst.pipe.tasks.assembleCoadd
+.. automodapi:: lsst.pipe.tasks.dcrAssembleCoadd


### PR DESCRIPTION
Note that this makes no attempt to clean up the many warnings when building the docs for pipe_tasks, but I don't believe it adds any.