### PR TITLE
DM-17427: objectMasks: update parser to handle Goulding mask format

### DIFF
--- a/python/lsst/pipe/tasks/objectMasks.py
+++ b/python/lsst/pipe/tasks/objectMasks.py
@@ -158,16 +158,22 @@ class ObjectMaskCatalog:
                 # with the format as specified in the above docstring.
                 mat = re.search(r"^\s*(box|circle)"
                                 r"(?:\s+|\s*\(\s*)"   # open paren or space
-                                r"(\d+(?:\.\d*)?([d]*))" r"(?:\s+|\s*,\s*)"
-                                r"([+-]?\d+(?:\.\d*)?)([d]*)" r"(?:\s+|\s*,\s*)"
-                                r"([+-]?\d+(?:\.\d*)?)([d]*)" r"(?:\s+|\s*,\s*)?"
-                                r"(?:([+-]?\d+(?:\.\d*)?)([d]*)"
-                                r"\s*,\s*"
-                                r"([+-]?\d+(?:\.\d*)?)([d]*)"
-                                ")?"
+                                r"([+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?)([d]*)"  # ra + units
+                                r"(?:\s+|\s*,\s*)"  # sep
+                                r"([+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?)([d]*)"  # dec + units
+                                r"(?:\s+|\s*,\s*)"  # sep
+                                r"([+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?)([d]*)"  # param1 + units
+                                r"(?:"  # start optional 1
+                                r"(?:\s+|\s*,\s*)"  # sep
+                                r"([+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?)([d]*)"  # param2 + units
+                                r"(?:"  # start optional 2
+                                r"(?:\s+|\s*,\s*)"  # sep
+                                r"([+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?)([d]*)"  # param3 + units
+                                ")?"  # end optional 2
+                                ")?"  # end optional 1
                                 r"(?:\s*|\s*\)\s*)"   # close paren or space
-                                r"\s*#\s*ID:\s*(\d+)"  # start comment
-                                r"(?:\s*,\s*mag:\s*(\d+\.\d*))?"
+                                r"#\s*ID:[\w\s]*(\d+)"  # start comment, ID
+                                r"(?:\s*,?\s*mag:\s*([+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?))?"
                                 r"\s*$", line)
                 if mat:
                     _type, ra, raUnit, dec, decUnit, \
@@ -186,12 +192,13 @@ class ObjectMaskCatalog:
                     radius = NaN
                     width = NaN
                     height = NaN
-                    angle = NaN
+                    angle = 0.0*afwGeom.degrees
 
                     if _type == "box":
                         width = convertToAngle(param1, param1Unit, "width", fileName, lineNo)
                         height = convertToAngle(param2, param2Unit, "height", fileName, lineNo)
-                        angle = convertToAngle(param3, param3Unit, "angle", fileName, lineNo)
+                        if param3 is not None:
+                            angle = convertToAngle(param3, param3Unit, "angle", fileName, lineNo)
 
                         if angle != 0.0:
                             log.warn("Rotated boxes are not supported: \"%s\" at %s:%d" % (


### PR DESCRIPTION
Andy Goulding has provided new masks based on Gaia DR2, and with a
better tuned size; but the format is subtly different:
* The rotation angle of a 'box' is not specified (it’s supposed to be
  zero anyway).
* The 'ID:' string is replaced with 'Gaia DR2'.
* Floating point values use scientific notation in places.

We've decided that (apart from the lack of "ID:", which we want in
order to be explicit) it's best to update the parser rather than fix
the mask files: the differences from what we have been expecting are
reasonable, and fixing the parser now means we may not have to fix
it much for the next version.

Expanded the regex to support the new format, defaulting the
rotation angle of boxes to 0. Added comments to the regex so it's
easier to understand.