### PR TITLE
Tickets/DM-18742: speed up DcrModel convergence

### DIFF
--- a/python/lsst/pipe/tasks/dcrAssembleCoadd.py
+++ b/python/lsst/pipe/tasks/dcrAssembleCoadd.py
@@ -484,7 +484,7 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
             List of exposure count images for each subfilter
         dcrWeights : `list` of `lsst.afw.image.ImageF`
             Per-pixel weights for each subfilter.
-            Equal to the number of unmasked images contributing to each pixel.
+            Equal to 1/(number of unmasked images contributing to each pixel).
         """
         dcrNImages = [afwImage.ImageU(bbox) for subfilter in range(self.config.dcrNumSubfilters)]
         dcrWeights = [afwImage.ImageF(bbox) for subfilter in range(self.config.dcrNumSubfilters)]
@@ -560,7 +560,7 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
             A reference image used to supply the default pixel values.
         dcrWeights : `list` of `lsst.afw.image.Image`
             Per-pixel weights for each subfilter.
-            Equal to the number of unmasked images contributing to each pixel.
+            Equal to 1/(number of unmasked images contributing to each pixel).
         """
         residualGeneratorList = []
 
@@ -636,7 +636,7 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
             A reference image used to supply the default pixel values.
         dcrWeights : `list` of `lsst.afw.image.Image`
             Per-pixel weights for each subfilter.
-            Equal to the number of unmasked images contributing to each pixel.
+            Equal to 1/(number of unmasked images contributing to each pixel).
 
         Returns
         -------


### PR DESCRIPTION
Add an option that amplifies the differences between DCR model planes to accelerate convergence. With default settings this is only applied within the footprints of detected sources, and only during the iterative forward modeling step of constructing the DcrModel.