### PR TITLE
DM-18394: Crash when running ap_pipe on calexp templates

### DIFF
--- a/python/lsst/pipe/tasks/imageDifference.py
+++ b/python/lsst/pipe/tasks/imageDifference.py
@@ -252,8 +252,9 @@ class ImageDifferenceTask(pipeBase.CmdLineTask):
 
         if self.config.doSelectSources:
             self.makeSubtask("sourceSelector")
-            self.makeSubtask('refObjLoader', butler=butler)
-            self.makeSubtask("astrometer", refObjLoader=self.refObjLoader)
+            if self.config.kernelSourcesFromRef:
+                self.makeSubtask('refObjLoader', butler=butler)
+                self.makeSubtask("astrometer", refObjLoader=self.refObjLoader)
 
         self.algMetadata = dafBase.PropertyList()
         if self.config.doDetection:


### PR DESCRIPTION
This PR changes `ImageDifferenceTask` initialization to only create the `refObjLoader` and `astrometer` subtasks if they will be used. This PR makes no attempt to avoid duplicating the logic that controls which subtasks are used; that's better left to a general refactoring of `ImageDifferenceTask`.