### PR TITLE
DM-20472: measureCoaddSources: fix error from empty matches

### DIFF
--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -1100,8 +1100,16 @@ class MeasureMergedCoaddSourcesTask(PipelineTask, CmdLineTask):
             matches.table.setMetadata(matchResult.matchMeta)
             results.matchResult = matches
             if self.config.doWriteMatchesDenormalized:
-                results.denormMatches = denormalizeMatches(matchResult.matches,
-                                                           matchResult.matchMeta)
+                if matchResult.matches:
+                    denormMatches = denormalizeMatches(matchResult.matches, matchResult.matchMeta)
+                else:
+                    self.log.warn("No matches, so generating dummy denormalized matches file")
+                    denormMatches = afwTable.BaseCatalog(afwTable.Schema())
+                    denormMatches.setMetadata(PropertyList())
+                    denormMatches.getMetadata().add("COMMENT",
+                                                    "This catalog is empty because no matches were found.")
+                    results.denormMatches = denormMatches
+                results.denormMatches = denormMatches
 
         results.outputSources = sources
         return results


### PR DESCRIPTION
We can't generate a denormalised match list from no matches,
because we don't have the schemas (which come from the matches);
so lsst.meas.astrom.denormalizeMatches raises RuntimeError if
there are no matches. We need to catch this case before calling
denormalizeMatches.