### PR TITLE
DM-20705: Set config default to propagate all peaks in coadd deblending.

### DIFF
--- a/python/lsst/pipe/tasks/deblendCoaddSourcesPipeline.py
+++ b/python/lsst/pipe/tasks/deblendCoaddSourcesPipeline.py
@@ -82,6 +82,10 @@ class DeblendCoaddSourcesSingleConfig(DeblendCoaddSourcesBaseConfig):
         storageClass="SourceCatalog"
     )
 
+    def setDefaults(self):
+        super().setDefaults()
+        self.singleBandDeblend.propagateAllPeaks = True
+
 
 class DeblendCoaddSourcesMultiConfig(DeblendCoaddSourcesBaseConfig):
     multibandDeblend = ConfigurableField(


### PR DESCRIPTION
This makes the Gen3 PipelineTask mirror the Gen2 CmdLineTask, and ensures the same objects are deblended in each band.