### PR TITLE
DM-20929: Fix bug in DcrAssembleCoaddTask

### DIFF
--- a/python/lsst/pipe/tasks/dcrAssembleCoadd.py
+++ b/python/lsst/pipe/tasks/dcrAssembleCoadd.py
@@ -337,9 +337,13 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
                 exposure=coaddExposure,
                 exposureId=expId
             )
+            # Measure the PSF on the stacked subfilter coadds if possible.
+            # We should already have a decent estimate of the coadd PSF, however,
+            # so in case of any errors simply log them as a warning and use the
+            # default PSF.
             try:
                 psfResults = self.measurePsf.run(coaddExposure, coaddSources, expId=expId)
-            except RuntimeError as e:
+            except Exception as e:
                 self.log.warn("Unable to calculate PSF, using default coadd PSF: %s" % e)
             else:
                 coaddExposure.setPsf(psfResults.psf)


### PR DESCRIPTION
The old version of this code assumed that there was a unique visit number for each patch, which was true for the test data that had only one CCD. When there are multiple CCDs contributing to a patch, however, they may all have the same visit number and the exposure catalog will have as many entries as the number of visits times the number of CCDs.