### PR TITLE
DM-21186: Use case insensitive instrument consistency check

### DIFF
--- a/python/lsst/pipe/tasks/read_defects.py
+++ b/python/lsst/pipe/tasks/read_defects.py
@@ -66,7 +66,8 @@ def check_metadata(defects, valid_start, instrument, chip_id, f):
     finst = md.get('INSTRUME')
     fchip_id = md.get('DETECTOR')
     fcalib_date = md.get('CALIBDATE')
-    if not (finst, int(fchip_id), fcalib_date) == (instrument, chip_id, valid_start.isoformat()):
+    if not (finst.lower(), int(fchip_id), fcalib_date) == (instrument.lower(),
+                                                           chip_id, valid_start.isoformat()):
         raise ValueError("Path and file metadata do not agree:\n" +
                          "Path metadata: %s, %s, %s\n"%(instrument, chip_id, valid_start.isoformat()) +
                          "File metadata: %s, %s, %s\n"%(finst, fchip_id, fcalib_date) +


### PR DESCRIPTION
We tend to use camelCase for directory names but we want the name of the instrument in the ecsv defect files to match the name of the instrument reported by the translator and/or INSTRUME header.

It seems highly unlikely that we would think it's an error for a LATISS observation to be in a latiss directory so this change lower cases the instrument names before comparing.

This change supports lsst/obs_lsst_data#1