### PR TITLE
Update API for ScarletDeblendTask

### DIFF
--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -28,7 +28,7 @@ from lsst.pex.config import Config, Field, ConfigurableField
 from lsst.meas.algorithms import DynamicDetectionTask, ReferenceObjectLoader
 from lsst.meas.base import SingleFrameMeasurementTask, ApplyApCorrTask, CatalogCalculationTask
 from lsst.meas.deblender import SourceDeblendTask
-from lsst.meas.extensions.scarlet import ScarletDeblendTask
+from lsst.meas.extensions.scarlet.deblend import ScarletDeblendTask
 from lsst.pipe.tasks.coaddBase import getSkyInfo
 from lsst.pipe.tasks.scaleVariance import ScaleVarianceTask
 from lsst.meas.astrom import DirectMatchTask, denormalizeMatches


### PR DESCRIPTION
While porting to scarlet 1.0 `meas_extensions_scarlet` fixed
a bug where the `deblend` module contained a `deblend` function
that overwrote the module. The `__init__.py` was modified to
import the module, not the internal classes and functions into
the root namespace.