### PR TITLE
DM-22952: Gen 3 version of DCR image differencing

### DIFF
--- a/python/lsst/pipe/tasks/dcrAssembleCoadd.py
+++ b/python/lsst/pipe/tasks/dcrAssembleCoadd.py
@@ -553,7 +553,12 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
         self.log.info("Selected parallactic angles:\n%s", angleDict)
         self.log.info("Selected PSF sizes:\n%s", psfSizeDict)
         self.bufferSize = int(np.ceil(np.max(dcrShifts)) + 1)
-        psf = self.selectCoaddPsf(templateCoadd, warpRefList)
+        try:
+            psf = self.selectCoaddPsf(templateCoadd, warpRefList)
+        except Exception as e:
+            self.log.warn("Unable to calculate restricted PSF, using default coadd PSF: %s" % e)
+        else:
+            psf = templateCoadd.psf
         dcrModels = DcrModel.fromImage(templateCoadd.maskedImage,
                                        self.config.dcrNumSubfilters,
                                        filterInfo=filterInfo,


### PR DESCRIPTION
Also includes a small bug fix in `dcrAssembleCoadd` that was necessary for the simplified test dataset to run.