### PR TITLE
DM-24290: Remove if Butler exists checks from bin.src scripts.

### DIFF
--- a/bin.src/makeGen3DcrSubfilters.py
+++ b/bin.src/makeGen3DcrSubfilters.py
@@ -35,11 +35,6 @@ parser.add_argument("-C", "--config-file", dest="configFile",
 
 args = parser.parse_args()
 
-# Verify any supplied paths actually exist on disk
-if not os.path.exists(args.butler):
-    print("Butler path specified does not exists")
-    sys.exit(1)
-
 config = MakeGen3DcrSubfiltersConfig()
 if args.configFile:
     if not os.path.exists(args.configFile):

--- a/bin.src/makeGen3Skymap.py
+++ b/bin.src/makeGen3Skymap.py
@@ -37,11 +37,6 @@ parser.add_argument("-C", "--config-file", dest="configFile",
 
 args = parser.parse_args()
 
-# Verify any supplied paths actually exist on disk
-if not os.path.exists(args.butler):
-    print("Butler path specified does not exists")
-    sys.exit(1)
-
 config = MakeGen3SkyMapConfig()
 if args.configFile:
     if not os.path.exists(args.configFile):


### PR DESCRIPTION
Checks are made against local filesystem only. This stopped being a valid assumption since S3Datastore was implemented as the data repository does not need to be local anymore.

The failure case should be handled internally by Butler itself at instantiation time.

These check currently block executing `makeGen3SkyMap` if the location of the data repository is in S3 (f.e. `s3://bucketname/`). 

The errors raised by the butler are either `RuntimeError` if the butler config file is of unknown format or `FileNotFoundError` if it's not at the given location. I think this is fine, but if required I think it should be possible to reinstate the exact error messages as before by attempting to instantiate a Butler, catching the exceptions and then printing and exiting with error code 1. 