### PR TITLE
DM-15536: Switch postISRCCD to use exposure, not visit.

### DIFF
--- a/python/lsst/pipe/tasks/characterizeImage.py
+++ b/python/lsst/pipe/tasks/characterizeImage.py
@@ -74,6 +74,18 @@ class CharacterizeImageConnections(pipeBase.PipelineTaskConnections,
         storageClass="SourceCatalog",
     )
 
+    def adjustQuantum(self, datasetRefMap: pipeBase.InputQuantizedConnection):
+        # Docstring inherited from PipelineTaskConnections
+        try:
+            return super().adjustQuantum(datasetRefMap)
+        except pipeBase.ScalarError as err:
+            raise pipeBase.ScalarError(
+                f"CharacterizeImageTask can at present only be run on visits that are associated with "
+                f"exactly one exposure.  Either this is not a valid exposure for this pipeline, or the "
+                f"snap-combination step you probably want hasn't been configured to run between ISR and "
+                f"this task (as of this writing, that would be because it hasn't been implemented yet)."
+            ) from err
+
 
 class CharacterizeImageConfig(pipeBase.PipelineTaskConfig,
                               pipelineConnections=CharacterizeImageConnections):

--- a/python/lsst/pipe/tasks/characterizeImage.py
+++ b/python/lsst/pipe/tasks/characterizeImage.py
@@ -48,7 +48,7 @@ class CharacterizeImageConnections(pipeBase.PipelineTaskConnections,
         doc="Input exposure data",
         name="postISRCCD",
         storageClass="ExposureF",
-        dimensions=["instrument", "visit", "detector"],
+        dimensions=["instrument", "exposure", "detector"],
     )
     characterized = cT.Output(
         doc="Output characterized data.",


### PR DESCRIPTION
In Gen3 (at least), visits are on-sky, and possibly combinations of snaps; ISR runs on exposures.