### PR TITLE
DM-22256: Remove skipUnless pyarrow available

### DIFF
--- a/tests/test_functors.py
+++ b/tests/test_functors.py
@@ -32,25 +32,18 @@ import lsst.afw.geom as afwGeom
 import lsst.geom as geom
 import lsst.meas.base as measBase
 import lsst.utils.tests
-
-# TODO: Remove skipUnless and this try block DM-22256
-try:
-    from lsst.pipe.tasks.parquetTable import MultilevelParquetTable
-    from lsst.pipe.tasks.functors import (CompositeFunctor, CustomFunctor, Column, RAColumn,
-                                          DecColumn, Mag, MagDiff, Color, StarGalaxyLabeller,
-                                          DeconvolvedMoments, SdssTraceSize, PsfSdssTraceSizeDiff,
-                                          HsmTraceSize, PsfHsmTraceSizeDiff, HsmFwhm,
-                                          LocalPhotometry, LocalNanojansky, LocalNanojanskyErr,
-                                          LocalMagnitude, LocalMagnitudeErr,
-                                          LocalWcs, ComputePixelScale, ConvertPixelToArcseconds)
-    havePyArrow = True
-except ImportError:
-    havePyArrow = False
+from lsst.pipe.tasks.parquetTable import MultilevelParquetTable
+from lsst.pipe.tasks.functors import (CompositeFunctor, CustomFunctor, Column, RAColumn,
+                                      DecColumn, Mag, MagDiff, Color, StarGalaxyLabeller,
+                                      DeconvolvedMoments, SdssTraceSize, PsfSdssTraceSizeDiff,
+                                      HsmTraceSize, PsfHsmTraceSizeDiff, HsmFwhm,
+                                      LocalPhotometry, LocalNanojansky, LocalNanojanskyErr,
+                                      LocalMagnitude, LocalMagnitudeErr,
+                                      LocalWcs, ComputePixelScale, ConvertPixelToArcseconds)
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
-@unittest.skipUnless(havePyArrow, "Requires pyarrow")
 class FunctorTestCase(unittest.TestCase):
 
     def simulateMultiParquet(self, dataDict):

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -27,21 +27,15 @@ from pandas.util.testing import assert_frame_equal
 
 import lsst.utils.tests
 
-# TODO: Remove skipUnless and this try block DM-22256
-try:
-    import pyarrow as pa
-    import pyarrow.parquet as pq
-    from lsst.pipe.tasks.parquetTable import ParquetTable, MultilevelParquetTable
-    havePyArrow = True
-except ImportError:
-    havePyArrow = False
+import pyarrow as pa
+import pyarrow.parquet as pq
+from lsst.pipe.tasks.parquetTable import ParquetTable, MultilevelParquetTable
 
 
 def setup_module(module):
     lsst.utils.tests.init()
 
 
-@unittest.skipUnless(havePyArrow, "Requires pyarrow")
 class ParquetTableTestCase(unittest.TestCase):
     """Test case for ParquetTable
     """
@@ -92,7 +86,6 @@ class ParquetTableTestCase(unittest.TestCase):
         self.assertTrue(self.parq.toDataFrame(columns=columns + ['hello']).equals(self.df[columns]))
 
 
-@unittest.skipUnless(havePyArrow, "Requires pyarrow")
 class MultilevelParquetTableTestCase(ParquetTableTestCase):
     """Test case for MultilevelParquetTable
     """

--- a/tests/test_transformObject.py
+++ b/tests/test_transformObject.py
@@ -25,16 +25,11 @@ import pandas as pd
 
 import lsst.utils.tests
 
-# TODO: Remove skipUnless and this try block DM-22256
-try:
-    import pyarrow as pa
-    import pyarrow.parquet as pq
-    from lsst.pipe.tasks.parquetTable import MultilevelParquetTable
-    from lsst.pipe.tasks.functors import HsmFwhm
-    from lsst.pipe.tasks.postprocess import TransformObjectCatalogTask, TransformObjectCatalogConfig
-    havePyArrow = True
-except ImportError:
-    havePyArrow = False
+import pyarrow as pa
+import pyarrow.parquet as pq
+from lsst.pipe.tasks.parquetTable import MultilevelParquetTable
+from lsst.pipe.tasks.functors import HsmFwhm
+from lsst.pipe.tasks.postprocess import TransformObjectCatalogTask, TransformObjectCatalogConfig
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
 
@@ -43,7 +38,6 @@ def setup_module(module):
     lsst.utils.tests.init()
 
 
-@unittest.skipUnless(havePyArrow, "Requires pyarrow")
 class TransformObjectCatalogTestCase(unittest.TestCase):
     def setUp(self):
         # Note that this test input includes HSC-G, HSC-R, and HSC-I data


### PR DESCRIPTION
pyarrow was unavailable on macos. This workaround allowed us to
test on linux only, but is no longer necessary.