### PR TITLE
Improve explanation of scaling of PSF kernel to match aperture calibration radius

### DIFF
--- a/python/lsst/pipe/tasks/insertFakes.py
+++ b/python/lsst/pipe/tasks/insertFakes.py
@@ -413,7 +413,7 @@ class InsertFakesTask(PipelineTask, CmdLineTask):
         University of Washington simulations database as default. For more information see the doc strings
         attached to the config options.
 
-        See mkFakeStars doc string for an explanation of calibration to instrumental flux using calibFluxRadius.
+        See mkFakeStars doc string for an explanation of calibration to instrumental flux.
         """
 
         self.log.info("Making %d fake galaxy images" % len(fakeCat))

--- a/python/lsst/pipe/tasks/insertFakes.py
+++ b/python/lsst/pipe/tasks/insertFakes.py
@@ -428,7 +428,7 @@ class InsertFakesTask(PipelineTask, CmdLineTask):
             # And then scale up PSF model so that the PSF is normalized to 1 within the calibration radius
 
             # We put these two PSF calculations within this same try block so that we catch cases
-            # where the object is outside position is outside of the image.
+            # where the object's position is outside of the image.
             try:
                 correctedFlux = psf.computeApertureFlux(self.config.calibFluxRadius, xy)
                 psfKernel = psf.computeKernelImage(xy).getArray()
@@ -500,7 +500,7 @@ class InsertFakesTask(PipelineTask, CmdLineTask):
             # And then scale up PSF model so that the PSF is normalized to 1 within the calibration radius
 
             # We put these two PSF calculations within this same try block so that we catch cases
-            # where the object is outside position is outside of the image.
+            # where the object's position is outside of the image.
             try:
                 correctedFlux = psf.computeApertureFlux(self.config.calibFluxRadius, xy)
                 starIm = psf.computeImage(xy)


### PR DESCRIPTION
Add documentation to `calibFluxRadius` config and code comments explaining scaling of the simulated flux to mach the calibration aperture radius.

The same thing is done for stars and galaxies.  
I put in two identical comment blocks so that this PR is a comment-only change.

Ideally I would have liked to refactor slightly to make one function that's called by each of the mkGalaxies and mkStars method.  Let me know if you want me to go in that direction.