### PR TITLE
DM-17538: Generate stack-produced (rather than CP) calibration products for DECam

### DIFF
--- a/python/lsst/pipe/tasks/ingest.py
+++ b/python/lsst/pipe/tasks/ingest.py
@@ -28,7 +28,6 @@ from glob import glob
 from contextlib import contextmanager
 
 from lsst.pex.config import Config, Field, DictField, ListField, ConfigurableField
-import lsst.pex.exceptions
 from lsst.afw.fits import readMetadata
 from lsst.pipe.base import Task, InputOnlyArgumentParser
 from lsst.afw.fits import DEFAULT_HDU
@@ -105,16 +104,23 @@ class ParseTask(Task):
 
     @staticmethod
     def getExtensionName(md):
-        """ Get the name of an extension.
-        @param md: PropertySet like one obtained from lsst.afw.fits.readMetadata)
-        @return Name of the extension if it exists.  None otherwise.
+        """ Get the name of a FITS extension.
+
+        Parameters
+        ----------
+        md : `lsst.daf.base.PropertySet`
+            FITS header metadata.
+
+        Returns
+        -------
+        result : `str` or `None`
+            The string from the EXTNAME header card if it exists. None otherwise.
         """
         try:
-            # This returns a tuple
-            ext = md.getScalar("EXTNAME")
-            return ext[1]
-        except lsst.pex.exceptions.Exception:
-            return None
+            ext = md["EXTNAME"]
+        except KeyError:
+            ext = None
+        return ext
 
     def getInfoFromMetadata(self, md, info=None):
         """Attempt to pull the desired information out of the header


### PR DESCRIPTION
The getExtension method during ingestion is only used for multi-extension FITS files, and in practice that means DECam. The method was not behaving as advertised and was overridden in both ingest and ingestCalibs in obs_decam. Those overrides have been removed and the method here in pipe_tasks now works as intended.