### PR TITLE
DM-21919: Run ap_verify end-to-end in Gen 3

### DIFF
--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -709,6 +709,7 @@ class AssembleCoaddTask(CoaddBaseTask, pipeBase.PipelineTask):
         statsFlags = afwMath.stringToStatisticsProperty(self.config.statistic)
         return pipeBase.Struct(ctrl=statsCtrl, flags=statsFlags)
 
+    @pipeBase.timeMethod
     def run(self, skyInfo, tempExpRefList, imageScalerList, weightList,
             altMaskList=None, mask=None, supplementaryData=None):
         """Assemble a coadd from input warps
@@ -1422,6 +1423,7 @@ class SafeClipAssembleCoaddTask(AssembleCoaddTask):
         self.makeSubtask("assembleMeanCoadd")
 
     @utils.inheritDoc(AssembleCoaddTask)
+    @pipeBase.timeMethod
     def run(self, skyInfo, tempExpRefList, imageScalerList, weightList, *args, **kwargs):
         """Assemble the coadd for a region.
 
@@ -2075,6 +2077,7 @@ class CompareWarpAssembleCoaddTask(AssembleCoaddTask):
         return message
 
     @utils.inheritDoc(AssembleCoaddTask)
+    @pipeBase.timeMethod
     def run(self, skyInfo, tempExpRefList, imageScalerList, weightList,
             supplementaryData, *args, **kwargs):
         """Assemble the coadd.

--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -636,6 +636,7 @@ class CalibrateTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             outputs.matches = normalizedMatches
         butlerQC.put(outputs, outputRefs)
 
+    @pipeBase.timeMethod
     def run(self, exposure, exposureIdInfo=None, background=None,
             icSourceCat=None):
         """!Calibrate an exposure (science image or coadd)

--- a/python/lsst/pipe/tasks/dcrAssembleCoadd.py
+++ b/python/lsst/pipe/tasks/dcrAssembleCoadd.py
@@ -565,6 +565,7 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
                                        psf=psf)
         return dcrModels
 
+    @pipeBase.timeMethod
     def run(self, skyInfo, warpRefList, imageScalerList, weightList,
             supplementaryData=None):
         """Assemble the coadd.

--- a/python/lsst/pipe/tasks/imageDifference.py
+++ b/python/lsst/pipe/tasks/imageDifference.py
@@ -526,6 +526,7 @@ class ImageDifferenceTask(pipeBase.CmdLineTask, pipeBase.PipelineTask):
             sensorRef.put(results.subtractedExposure, subtractedExposureName)
         return results
 
+    @pipeBase.timeMethod
     def run(self, exposure=None, selectSources=None, templateExposure=None, templateSources=None,
             idFactory=None, calexpBackgroundExposure=None, subtractedExposure=None):
         """PSF matches, subtract two images and perform detection on the difference image.

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -379,6 +379,7 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
 
         return dataRefList
 
+    @pipeBase.timeMethod
     def run(self, calExpList, ccdIdList, skyInfo, visitId=0, dataIdList=None):
         """Create a Warp from inputs
 

--- a/python/lsst/pipe/tasks/transformMeasurement.py
+++ b/python/lsst/pipe/tasks/transformMeasurement.py
@@ -128,6 +128,7 @@ class TransformTask(pipeBase.Task):
         transformedSrc = afwTable.BaseCatalog(self.mapper.getOutputSchema())
         return {self.outputDataset: transformedSrc}
 
+    @pipeBase.timeMethod
     def run(self, inputCat, wcs, photoCalib):
         """!Transform raw source measurements to calibrated quantities.
 


### PR DESCRIPTION
This PR adds `@timeMethod` decorators to the `run` methods of tasks that had them in Gen 2.