### PR TITLE
DM-27003: add difference method to functor, and a test

### DIFF
--- a/python/lsst/pipe/tasks/functors.py
+++ b/python/lsst/pipe/tasks/functors.py
@@ -190,6 +190,11 @@ class Functor(object):
 
         return vals
 
+    def difference(self, parq1, parq2, **kwargs):
+        """Computes difference between functor called on two different ParquetTable objects
+        """
+        return self(parq1, **kwargs) - self(parq2, **kwargs)
+
     def fail(self, df):
         return pd.Series(np.full(len(df), np.nan), index=df.index)
 


### PR DESCRIPTION
This adds a .difference method to Functor, which computes
the difference between the functor called on one ParquetTable
and another.  Will be useful in future for pipe_analysis compare* scripts.