### PR TITLE
DM-26874: rename pipetask2 to pipetask, remove old pipetask

### DIFF
--- a/python/lsst/pipe/tasks/cli/cmd/commands.py
+++ b/python/lsst/pipe/tasks/cli/cmd/commands.py
@@ -23,12 +23,13 @@ import click
 
 from lsst.daf.butler.cli.opt import (repo_argument, config_file_option, options_file_option)
 from lsst.daf.butler.cli.utils import (cli_handle_exception, split_commas, typeStrAcceptsMultiple)
-from lsst.obs.base.cli.opt import instrument_option
+from lsst.obs.base.cli.opt import instrument_argument
 from ... import script
 
 
 @click.command(short_help="Define a discrete skymap from calibrated exposures.")
 @repo_argument(required=True)
+@instrument_argument(required=True)
 @config_file_option(help="Path to a pex_config override to be included after the Instrument config overrides"
                          "are applied.")
 @options_file_option()
@@ -45,7 +46,6 @@ from ... import script
 @click.option("--skymap-id",
               help=("The identifier of the skymap to write."),
               type=str, default="discrete", show_default=True)
-@instrument_option(required=True)
 def make_discrete_skymap(*args, **kwargs):
     """Define a discrete skymap from calibrated exposures in the butler registry."""
     cli_handle_exception(script.makeDiscreteSkyMap, *args, **kwargs)

--- a/tests/test_cliCmdMakeDiscreteSkymap.py
+++ b/tests/test_cliCmdMakeDiscreteSkymap.py
@@ -43,7 +43,7 @@ class DefineMakeDiscreteSkymap(CliCmdTestBase, unittest.TestCase):
         """Test the most basic required arguments."""
         self.run_test(["make-discrete-skymap",
                        "--collections", "foo/bar,baz",
-                       "--instrument", "a.b.c", "here"],
+                       "here", "a.b.c"],
                       self.makeExpected(repo="here",
                                         collections=("foo/bar", "baz"),
                                         out_collection="skymaps",
@@ -53,13 +53,12 @@ class DefineMakeDiscreteSkymap(CliCmdTestBase, unittest.TestCase):
     def test_all(self):
         """Test all the arguments."""
         self.run_test(["make-discrete-skymap",
-                       "--instrument", "a.b.c",
                        "--collections", "foo/bar,baz",
                        "--config-file", "/path/to/config",
                        "--collections", "boz",
                        "--out-collection", "biz",
                        "--skymap-id", "wiz",
-                       "here"],
+                       "here", "a.b.c"],
                       self.makeExpected(repo="here",
                                         instrument="a.b.c",
                                         config_file="/path/to/config",
@@ -73,11 +72,11 @@ class DefineMakeDiscreteSkymap(CliCmdTestBase, unittest.TestCase):
 
     def test_missing(self):
         """test a missing argument"""
-        self.run_missing(["make-discrete-skymap", "--collections", "foo/bar,baz", "--instrument", "a.b.c"],
+        self.run_missing(["make-discrete-skymap", "--collections", "foo/bar,baz"],
                          'Missing argument "REPO"')
         self.run_missing(["make-discrete-skymap", "--collections", "foo/bar,baz", "here"],
-                         'Missing option "-i" / "--instrument"')
-        self.run_missing(["make-discrete-skymap", "--instrument", "a.b.c", "here"],
+                         'Missing argument "INSTRUMENT"')
+        self.run_missing(["make-discrete-skymap", "here", "a.b.c"],
                          'Error: Missing option "--collections".')
 
 


### PR DESCRIPTION
It was changed from an option.