### PR TITLE
DM-27500: add a comment in butler & pipetask subcommand about more options in butler --help

### DIFF
--- a/python/lsst/pipe/tasks/cli/cmd/commands.py
+++ b/python/lsst/pipe/tasks/cli/cmd/commands.py
@@ -22,12 +22,17 @@
 import click
 
 from lsst.daf.butler.cli.opt import (repo_argument, config_file_option, options_file_option)
-from lsst.daf.butler.cli.utils import (cli_handle_exception, split_commas, typeStrAcceptsMultiple)
+from lsst.daf.butler.cli.utils import (
+    ButlerCommand,
+    cli_handle_exception,
+    split_commas,
+    typeStrAcceptsMultiple,
+)
 from lsst.obs.base.cli.opt import instrument_argument
 from ... import script
 
 
-@click.command(short_help="Define a discrete skymap from calibrated exposures.")
+@click.command(cls=ButlerCommand, short_help="Define a discrete skymap from calibrated exposures.")
 @repo_argument(required=True)
 @instrument_argument(required=True)
 @config_file_option(help="Path to a pex_config override to be included after the Instrument config overrides"


### PR DESCRIPTION
Make subclass commands ButlerCommands, which add a note to the
subcommand help that says "See butler --help for more options."