### PR TITLE
Allow a DeferredDatasetHandle to be passed to a Functor

### DIFF
--- a/python/lsst/pipe/tasks/parquetTable.py
+++ b/python/lsst/pipe/tasks/parquetTable.py
@@ -281,7 +281,7 @@ class MultilevelParquetTable(ParquetTable):
                 newColumns = [c for c in columns if c in self.columnIndex]
                 if not newColumns:
                     raise ValueError("None of the requested columns ({}) are available!".format(columns))
-                df = self._df[columns]
+                df = self._df[newColumns]
         else:
             pfColumns = self._stringify(columns)
             try:

--- a/tests/test_functors.py
+++ b/tests/test_functors.py
@@ -399,7 +399,6 @@ class FunctorTestCase(unittest.TestCase):
         """Test a composite functor where one of the functors should be junk.
         """
         self.dataDict["base_PsfFlux_instFlux"] = np.full(self.nRecords, 1000)
-        self.dataDict["base_PsfFlux_instFluxErr"] = np.full(self.nRecords, 10)
         parq = self.simulateMultiParquet(self.dataDict)
 
         funcDict = {'good': Column("base_PsfFlux_instFlux"),

--- a/tests/test_functors.py
+++ b/tests/test_functors.py
@@ -395,6 +395,18 @@ class FunctorTestCase(unittest.TestCase):
         # Covering the code is better than nothing
         df = self._compositeDifferenceVal(CompositeFunctor(funcDict), parq1, parq2)  # noqa
 
+    def testCompositeFail(self):
+        """Test a composite functor where one of the functors should be junk.
+        """
+        self.dataDict["base_PsfFlux_instFlux"] = np.full(self.nRecords, 1000)
+        self.dataDict["base_PsfFlux_instFluxErr"] = np.full(self.nRecords, 10)
+        parq = self.simulateMultiParquet(self.dataDict)
+
+        funcDict = {'good': Column("base_PsfFlux_instFlux"),
+                    'bad': Column('not_a_column')}
+
+        df = self._compositeFuncVal(CompositeFunctor(funcDict), parq)  # noqa
+
     def testLocalPhotometry(self):
         """Test the local photometry functors.
         """


### PR DESCRIPTION
For gen3 compatibility, this allows for a DeferredDatasetHandle to be be passed to a functor's __call__ method, rather than the gen2 parquet interface ParquetTable object.  All currently tested Functor functionality is also tested here for the gen3 model.  Backward compatibility with gen2 is maintained.  N.B.: the gen3 functor performance will likely be slower than the gen2 performance; remains to be seen if this matters at all.

Further note, this commit had previously broken ci_hsc because of one line where I had accidentally left a `raise` instead of continuing on to use a `.fail()` method (had been in there for debugging purposes and removal should pass ci_hsc).