### PR TITLE
DM-28922: Correct functor logic to work with single-level datarefs, and add tests

### DIFF
--- a/python/lsst/pipe/tasks/functors.py
+++ b/python/lsst/pipe/tasks/functors.py
@@ -292,9 +292,11 @@ class Functor(object):
             df = data.toDataFrame(columns=columns)
             return df
 
-        # Get proper multi-level columns specification for this functor
+        # Get proper columns specification for this functor
         if is_multiLevel:
             columns = self.multilevelColumns(data, columnIndex=columnIndex)
+        else:
+            columns = self.columns
 
         if isinstance(data, MultilevelParquetTable):
             # Load in-memory dataframe with appropriate columns the gen2 way
@@ -304,7 +306,9 @@ class Functor(object):
             df = data.get(parameters={"columns": columns})
 
         # Drop unnecessary column levels
-        df = self._setLevels(df)
+        if is_multiLevel:
+            df = self._setLevels(df)
+
         return df
 
     def _setLevels(self, df):


### PR DESCRIPTION
Previous updates to Functor to allow for passing a DeferredDatasetHandle did not have appropriate logic to allow for the handle to point to a dataframe with only a single-level column index.  This corrects that, and adds corresponding tests, which were also missing before (which is why this bug was not caught).