### PR TITLE
DM-28759: Support driver to write new parquet tables from old src tables

### DIFF
--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -225,6 +225,7 @@ class WriteSourceTableTask(CmdLineTask):
         ccdVisitId = dataRef.get('ccdExposureId')
         result = self.run(src, ccdVisitId=ccdVisitId)
         dataRef.put(result.table, 'source')
+        return result
 
     def run(self, catalog, ccdVisitId=None):
         """Convert `src` catalog to parquet

--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -266,7 +266,6 @@ class WriteSourceTableTask(CmdLineTask):
         newCat:  `afwTable.SourceCatalog`
             Source Catalog with requested local calib columns
         """
-        mapper = afwTable.SchemaMapper(catalog.schema)
         measureConfig = SingleFrameMeasurementTask.ConfigClass()
         measureConfig.doReplaceWithNoise = False
 
@@ -274,6 +273,7 @@ class WriteSourceTableTask(CmdLineTask):
         exposure = dataRef.get('calexp_sub',
                                bbox=lsst.geom.Box2I(lsst.geom.Point2I(0, 0), lsst.geom.Point2I(0, 0)))
 
+        aliasMap = catalog.schema.getAliasMap()
         mapper = afwTable.SchemaMapper(catalog.schema)
         mapper.addMinimalSchema(catalog.schema, True)
         schema = mapper.getOutputSchema()
@@ -295,6 +295,7 @@ class WriteSourceTableTask(CmdLineTask):
                 measureConfig.plugins.names.add(plugin)
 
         measurement = SingleFrameMeasurementTask(config=measureConfig, schema=schema)
+        schema.setAliasMap(aliasMap)
         newCat = afwTable.SourceCatalog(schema)
         newCat.extend(catalog, mapper=mapper)
         measurement.run(measCat=newCat, exposure=exposure, exposureId=exposureIdInfo.expId)


### PR DESCRIPTION
We have two specialized use cases for this:
1) Ingesting `src` catalogs for DC2
2) The current HSC data-release is going to be an incremental data release. We will not rerun singleFrameDriver for ccds run in the 2020 data release. 