### PR TITLE
DM-20695: Convert SelectImageTasks to Gen3

### DIFF
--- a/python/lsst/pipe/tasks/coaddBase.py
+++ b/python/lsst/pipe/tasks/coaddBase.py
@@ -128,7 +128,7 @@ class CoaddTaskRunner(pipeBase.TaskRunner):
                                                  **kwargs)
 
 
-class CoaddBaseTask(pipeBase.CmdLineTask):
+class CoaddBaseTask(pipeBase.CmdLineTask, pipeBase.PipelineTask):
     """!Base class for coaddition.
 
     Subclasses must specify _DefaultName


### PR DESCRIPTION
* Refactor SelectImageTasks, adding a run method that takes lists
  of calexp properties. runDataRef remains the Gen2 entry point
  which still takes dataRefs.
* MakeWarp now calls the configured selectImages subtask in
  runQuantum. The calexp list was changed to deferLoad, because the padding
  needed in the gen3 skymap is providing many more calexps than actually
  overlap the patch. Loading is performed after image selection is run,
  so that only the calexps that will be used are loaded into memory.