### PR TITLE
tickets/DM-29031 Add new Config and Field types

### DIFF
--- a/python/lsst/pipe/tasks/configurableActions/__init__.py
+++ b/python/lsst/pipe/tasks/configurableActions/__init__.py
@@ -1,0 +1,23 @@
+# This file is part of pipe_tasks.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from ._configurableAction import *
+from ._configurableActionStructField import *
+from ._configurableActionField import *

--- a/python/lsst/pipe/tasks/configurableActions/_configurableAction.py
+++ b/python/lsst/pipe/tasks/configurableActions/_configurableAction.py
@@ -1,0 +1,49 @@
+# This file is part of pipe_tasks.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ["ConfigurableAction"]
+
+from typing import Any
+
+from lsst.pex.config.config import Config
+
+
+class ConfigurableAction(Config):
+    """A `ConfigurableAction` is an interface that extends a
+    `lsst.pex.config.Config` class to include a `__call__` method.
+
+    This interface is designed to create an action that can be used at
+    runtime with state that is determined during the configuration stage. A
+    single action thus may be assigned multiple times, each with different
+    configurations.
+
+    This allows state to be set and recorded at configuration time,
+    making future reproduction of results easy.
+
+    This class is intended to be an interface only, but because of various
+    inheritance conflicts this class can not be implemented as an Abstract
+    Base Class. Instead, the `__call__` method is purely virtual, meaning that
+    it will raise a `NotImplementedError` when called. Subclasses that
+    represent concrete actions must provide an override.
+    """
+    def __call__(self, *args, **kwargs) -> Any:
+        raise NotImplementedError("This method should be overloaded in subclasses")

--- a/python/lsst/pipe/tasks/configurableActions/_configurableActionField.py
+++ b/python/lsst/pipe/tasks/configurableActions/_configurableActionField.py
@@ -1,0 +1,69 @@
+# This file is part of pipe_tasks.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ("ConfigurableActionField",)
+
+from lsst.pex.config import ConfigField, FieldValidationError
+from lsst.pex.config.config import _typeStr, _joinNamePath
+from lsst.pex.config.callStack import getCallStack
+
+from . import ConfigurableAction
+
+
+class ConfigurableActionField(ConfigField):
+    """`ConfigurableActionField` is a subclass of `~lsst.pex.config.Field` that
+    allows a single `ConfigurableAction` (or a subclass of thus) to be
+    assigned to it. The `ConfigurableAction` is then accessed through this
+    field for further configuration.
+
+    Any configuration that is done prior to reasignment to a new
+    `ConfigurableAction` is forgotten.
+    """
+    # These attributes are dynamically assigned when constructing the base
+    # classes
+    name: str
+
+    def __set__(self, instance, value, at=None, label="assignment"):
+        if instance._frozen:
+            raise FieldValidationError(self, instance,
+                                       "Cannot modify a frozen Config")
+        name = _joinNamePath(prefix=instance._name, name=self.name)
+
+        if not isinstance(value, self.dtype) and not issubclass(value, self.dtype):
+            msg = f"Value {value} is of incorrect type {_typeStr(value)}. Expected {_typeStr(self.dtype)}"
+            raise FieldValidationError(self, instance, msg)
+
+        if at is None:
+            at = getCallStack()
+
+        if isinstance(value, self.dtype):
+            instance._storage[self.name] = type(value)(__name=name, __at=at,
+                                                       __label=label, **value._storage)
+        else:
+            instance._storage[self.name] = value(__name=name, __at=at, __label=label)
+        history = instance._history.setdefault(self.name, [])
+        history.append(("config value set", at, label))
+
+    def __init__(self, doc, dtype=ConfigurableAction, default=None, check=None, deprecated=None):
+        if not issubclass(dtype, ConfigurableAction):
+            raise ValueError("dtype must be a subclass of ConfigurableAction")
+        super().__init__(doc=doc, dtype=dtype, default=default, check=check, deprecated=deprecated)

--- a/python/lsst/pipe/tasks/configurableActions/_configurableActionStructField.py
+++ b/python/lsst/pipe/tasks/configurableActions/_configurableActionStructField.py
@@ -1,0 +1,331 @@
+# This file is part of pipe_tasks.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ("ConfigurableActionStructField", "ConfigurableActionStruct")
+
+from typing import Iterable, Mapping, Optional, TypeVar, Union, Type, Tuple, List, Any, Dict
+
+from lsst.pex.config.config import Config, Field, FieldValidationError, _typeStr, _joinNamePath
+from lsst.pex.config.comparison import compareConfigs, compareScalars, getComparisonName
+from lsst.pex.config.callStack import StackFrame, getCallStack, getStackFrame
+
+from . import ConfigurableAction
+
+
+class ConfigurableActionStructUpdater:
+    """This descriptor exists to abstract the logic of using a dictionary to
+    update a ConfigurableActionStruct through attribute assignment. This is
+    useful in the context of setting configuration through pipelines or on
+    the command line.
+    """
+    def __set__(self, instance: ConfigurableActionStruct,
+                value: Union[Mapping[str, ConfigurableAction], ConfigurableActionStruct]) -> None:
+        if isinstance(value, Mapping):
+            pass
+        elif isinstance(value, ConfigurableActionStruct):
+            # If the update target is a ConfigurableActionStruct, get the
+            # internal dictionary
+            value = value._attrs
+        else:
+            raise ValueError("Can only update a ConfigurableActionStruct with an instance of such, or a "
+                             "mapping")
+        for name, action in value.items():
+            setattr(instance, name, action)
+
+    def __get__(self, instance, objtype=None) -> None:
+        # This descriptor does not support fetching any value
+        return None
+
+
+class ConfigurableActionStructRemover:
+    """This descriptor exists to abstract the logic of removing an interable
+    of action names from a ConfigurableActionStruct at one time using
+    attribute assignment. This is useful in the context of setting
+    configuration through pipelines or on the command line.
+
+    Raises
+    ------
+    AttributeError
+        Raised if an attribute specified for removal does not exist in the
+        ConfigurableActionStruct
+    """
+    def __set__(self, instance: ConfigurableActionStruct,
+                value: Union[str, Iterable[str]]) -> None:
+        # strings are iterable, but not in the way that is intended. If a
+        # single name is specified, turn it into a tuple before attempting
+        # to remove the attribute
+        if isinstance(value, str):
+            value = (value, )
+        for name in value:
+            delattr(instance, name)
+
+    def __get__(self, instance, objtype=None) -> None:
+        # This descriptor does not support fetching any value
+        return None
+
+
+class ConfigurableActionStruct:
+    """A ConfigurableActionStruct is the storage backend class that supports
+    the ConfigurableActionStructField. This class should not be created
+    directly.
+
+    This class allows managing a collection of `ConfigurableActions` with a
+    struct like interface, that is to say in an attribute like notation.
+
+    Attributes can be dynamically added or removed as such:
+
+    ConfigurableActionStructInstance.variable1 = a_configurable_action
+    del ConfigurableActionStructInstance.variable1
+
+    Each action is then available to be individually configured as a normal
+    `lsst.pex.config.Config` object.
+
+    ConfigurableActionStruct supports two special convenance attributes.
+
+    The first is `update`. You may assign a dict of `ConfigurableActions` or
+    a `ConfigurableActionStruct` to this attribute which will update the
+    `ConfigurableActionStruct` on which the attribute is invoked such that it
+    will be updated to contain the entries specified by the structure on the
+    right hand side of the equals sign.
+
+    The second convenience attribute is named remove. You may assign an
+    iterable of strings which correspond to attribute names on the
+    `ConfigurableActionStruct`. All of the corresponding attributes will then
+    be removed. If any attribute does not exist, an `AttributeError` will be
+    raised. Any attributes in the Iterable prior to the name which raises will
+    have been removed from the `ConfigurableActionStruct`
+    """
+    # declare attributes that are set with __setattr__
+    _config: Config
+    _attrs: Dict[str, ConfigurableAction]
+    _field: ConfigurableActionStructField
+    _history: List[tuple]
+
+    # create descriptors to handle special update and remove behavior
+    update = ConfigurableActionStructUpdater()
+    remove = ConfigurableActionStructRemover()
+
+    def __init__(self, config: Config, field: ConfigurableActionStructField,
+                 value: Mapping[str, ConfigurableAction], at: Any, label: str):
+        object.__setattr__(self, '_config', config)
+        object.__setattr__(self, '_attrs', {})
+        object.__setattr__(self, '_field', field)
+        object.__setattr__(self, '_history', [])
+
+        self.history.append(("Struct initialized", at, label))
+
+        if value is not None:
+            for k, v in value.items():
+                setattr(self, k, v)
+
+    @property
+    def history(self) -> List[tuple]:
+        return self._history
+
+    @property
+    def fieldNames(self) -> Iterable[str]:
+        return self._attrs.keys()
+
+    def __setattr__(self, attr: str, value: Union[ConfigurableAction, Type[ConfigurableAction]],
+                    at=None, label='setattr', setHistory=False) -> None:
+
+        if hasattr(self._config, '_frozen') and self._config._frozen:
+            msg = "Cannot modify a frozen Config. "\
+                  f"Attempting to set item {attr} to value {value}"
+            raise FieldValidationError(self._field, self._config, msg)
+
+        if attr not in (self.__dict__.keys() | type(self).__dict__.keys()):
+            name = _joinNamePath(self._config._name, self._field.name, attr)
+            if at is None:
+                at = getCallStack()
+            if isinstance(value, ConfigurableAction):
+                valueInst = type(value)(__name=name, __at=at, __label=label, **value._storage)
+            else:
+                valueInst = value(__name=name, __at=at, __label=label)
+            self._attrs[attr] = valueInst
+        else:
+            super().__setattr__(attr, value)
+
+    def __getattr__(self, attr):
+        if attr in object.__getattribute__(self, '_attrs'):
+            return self._attrs[attr]
+        else:
+            super().__getattribute__(attr)
+
+    def __delattr__(self, name):
+        if name in self._attrs:
+            del self._attrs[name]
+        else:
+            super().__delattr__(name)
+
+    def __iter__(self) -> Iterable[ConfigurableAction]:
+        return iter(self._attrs.values())
+
+    def items(self) -> Iterable[Tuple[str, ConfigurableAction]]:
+        return iter(self._attrs.items())
+
+
+T = TypeVar("T", bound="ConfigurableActionStructField")
+
+
+class ConfigurableActionStructField(Field):
+    r"""`ConfigurableActionStructField` is a `~lsst.pex.config.Field` subclass
+    that allows `ConfigurableAction`\ s to be organized in a
+    `~lsst.pex.config.Config` class in a manor similar to how a
+    `~lsst.pipe.base.Struct` works.
+
+    This class implements a `ConfigurableActionStruct` as an intermediary
+    object to organize the `ConfigurableActions`. See it's documentation for
+    futher information.
+    """
+    # specify StructClass to make this more generic for potential future
+    # inheritance
+    StructClass = ConfigurableActionStruct
+
+    # Explicitly annotate these on the class, they are present in the base
+    # class through injection, so type systems have trouble seeing them.
+    name: str
+    default: Optional[Mapping[str, ConfigurableAction]]
+
+    def __init__(self, doc: str, default: Optional[Mapping[str, ConfigurableAction]] = None,
+                 optional: bool = False,
+                 deprecated=None):
+        source = getStackFrame()
+        self._setup(doc=doc, dtype=self.__class__, default=default, check=None,
+                    optional=optional, source=source, deprecated=deprecated)
+
+    def __set__(self, instance: Config,
+                value: Union[None, Mapping[str, ConfigurableAction], ConfigurableActionStruct],
+                at: Iterable[StackFrame] = None, label: str = 'assigment'):
+        if instance._frozen:
+            msg = "Cannot modify a frozen Config. "\
+                  "Attempting to set field to value %s" % value
+            raise FieldValidationError(self, instance, msg)
+
+        if at is None:
+            at = getCallStack()
+
+        if value is None or value == self.default:
+            value = self.StructClass(instance, self, value, at=at, label=label)
+        else:
+            history = instance._history.setdefault(self.name, [])
+            history.append((value, at, label))
+
+        if not isinstance(value, ConfigurableActionStruct):
+            raise FieldValidationError(self, instance,
+                                       "Can only assign things that are subclasses of Configurable Action")
+        instance._storage[self.name] = value
+
+    def __get__(self: T, instance: Config, owner: None = None, at: Iterable[StackFrame] = None,
+                label: str = "default"
+                ) -> Union[None, T, ConfigurableActionStruct]:
+        if instance is None or not isinstance(instance, Config):
+            return self
+        else:
+            field: Optional[ConfigurableActionStruct] = instance._storage[self.name]
+            return field
+
+    def rename(self, instance: Config):
+        actionStruct: ConfigurableActionStruct = self.__get__(instance)
+        if actionStruct is not None:
+            for k, v in actionStruct.items():
+                fullname = _joinNamePath(instance._name, self.name, k)
+                v._rename(fullname)
+
+    def validate(self, instance):
+        value = self.__get__(instance)
+        if value is not None:
+            for item in value:
+                item.validate()
+
+    def toDict(self, instance):
+        actionStruct = self.__get__(instance)
+        if actionStruct is None:
+            return None
+
+        dict_ = {k: v.toDict() for k, v in actionStruct.items()}
+
+        return dict_
+
+    def save(self, outfile, instance):
+        actionStruct = self.__get__(instance)
+        fullname = _joinNamePath(instance._name, self.name)
+        if actionStruct is None:
+            outfile.write(u"{}={!r}\n".format(fullname, actionStruct))
+            return
+
+        outfile.write(u"{}={!r}\n".format(fullname, {}))
+        for v in actionStruct:
+            outfile.write(u"{}={}()\n".format(v._name, _typeStr(v)))
+            v._save(outfile)
+
+    def freeze(self, instance):
+        actionStruct = self.__get__(instance)
+        if actionStruct is not None:
+            for v in actionStruct:
+                v.freeze()
+
+    def _compare(self, instance1, instance2, shortcut, rtol, atol, output):
+        """Compare two fields for equality.
+
+        Parameters
+        ----------
+        instance1 : `lsst.pex.config.Config`
+            Left-hand side config instance to compare.
+        instance2 : `lsst.pex.config.Config`
+            Right-hand side config instance to compare.
+        shortcut : `bool`
+            If `True`, this function returns as soon as an inequality if found.
+        rtol : `float`
+            Relative tolerance for floating point comparisons.
+        atol : `float`
+            Absolute tolerance for floating point comparisons.
+        output : callable
+            A callable that takes a string, used (possibly repeatedly) to
+            report inequalities.
+
+        Returns
+        -------
+        isEqual : bool
+            `True` if the fields are equal, `False` otherwise.
+
+        Notes
+        -----
+        Floating point comparisons are performed by `numpy.allclose`.
+        """
+        d1: ConfigurableActionStruct = getattr(instance1, self.name)
+        d2: ConfigurableActionStruct = getattr(instance2, self.name)
+        name = getComparisonName(
+            _joinNamePath(instance1._name, self.name),
+            _joinNamePath(instance2._name, self.name)
+        )
+        if not compareScalars(f"keys for {name}", set(d1.fieldNames), set(d2.fieldNames), output=output):
+            return False
+        equal = True
+        for k, v1 in d1.items():
+            v2 = getattr(d2, k)
+            result = compareConfigs(f"{name}.{k}", v1, v2, shortcut=shortcut,
+                                    rtol=rtol, atol=atol, output=output)
+            if not result and shortcut:
+                return False
+            equal = equal and result
+        return equal

--- a/tests/test_configurableActions.py
+++ b/tests/test_configurableActions.py
@@ -1,0 +1,215 @@
+# This file is part of pipe_tasks.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+from io import StringIO
+
+from lsst.pipe.tasks.configurableActions import (ConfigurableActionStructField, ConfigurableAction,
+                                                 ConfigurableActionField)
+from lsst.pex.config import Config, Field, FieldValidationError
+
+
+class TestAction1(ConfigurableAction):
+    var = Field(doc="test field", dtype=int, default=0)
+
+    def __call__(self):
+        return self.var
+
+    def validate(self):
+        assert(self.var is not None)
+
+
+class TestAction2(ConfigurableAction):
+    var = Field(doc="test field", dtype=int, default=1)
+
+    def __call__(self):
+        return self.var
+
+    def validate(self):
+        assert(self.var is not None)
+
+
+class TestAction3(ConfigurableAction):
+    var = Field(doc="test field", dtype=int, default=3)
+
+    def __call__(self):
+        return self.var
+
+    def validate(self):
+        assert(self.var is not None)
+
+
+class ConfigurableActionsTestCase(unittest.TestCase):
+    def _createConfig(self, default=None, singleDefault=None):
+        class TestConfig(Config):
+            actions = ConfigurableActionStructField(doc="Actions to be tested", default=default)
+            singleAction = ConfigurableActionField(doc="A configurable action", default=singleDefault)
+        return TestConfig
+
+    def testConfigInstatiation(self):
+        # This will raise if there is an issue instantiating something
+        configClass = self._createConfig()
+        config = configClass()
+        self.assertTrue(hasattr(config, "actions"))
+        self.assertTrue(hasattr(config, "singleAction"))
+
+        # test again with default values
+        configClass = self._createConfig(default={"test1": TestAction1}, singleDefault=TestAction1)
+        config = configClass()
+
+        # verify the defaults were created
+        self.assertTrue(hasattr(config.actions, "test1"))
+        self.assertTrue(hasattr(config.actions.test1, "var"))
+        self.assertEqual(config.actions.test1.var, 0)
+
+        self.assertTrue(hasattr(config.singleAction, "var"))
+        self.assertEqual(config.singleAction.var, 0)
+
+    def testAssignment(self):
+        # Struct actions
+        # Test that a new action can be added with assignment
+        configClass = self._createConfig(default={"test1": TestAction1})
+        config = configClass()
+        config.actions.test2 = TestAction2
+
+        self.assertEqual(tuple(config.actions.fieldNames), ("test1", "test2"))
+        self.assertEqual(config.actions.test2.var, 1)
+
+        # verify the same as above, but assigning with instances
+        configClass = self._createConfig(default={"test1": TestAction1})
+        config = configClass()
+        config.actions.test3 = TestAction3()
+
+        self.assertEqual(tuple(config.actions.fieldNames), ("test1", "test3"))
+        self.assertEqual(config.actions.test3.var, 3)
+
+        # The following is designed to support pipeline config setting
+        # Test assignment using the update accessor
+        configClass = self._createConfig(default={"test1": TestAction1})
+        config = configClass()
+        config.actions.update = {"test2": TestAction2, "test3": TestAction3}
+
+        self.assertEqual(tuple(config.actions.fieldNames), ("test1", "test2", "test3"))
+
+        configClass = self._createConfig(default={"test1": TestAction1})
+        configClass2 = self._createConfig(default={"test2": TestAction2, "test3": TestAction3})
+        config = configClass()
+        config2 = configClass2()
+        config.actions.update = config2.actions
+
+        self.assertEqual(tuple(config.actions.fieldNames), ("test1", "test2", "test3"))
+
+        # Test remove "assignment" using the remove accessor
+        configClass = self._createConfig(default={"test1": TestAction1, "test2": TestAction2,
+                                                  "test3": TestAction3})
+        config = configClass()
+        config.actions.remove = ("test1", "test2")
+        self.assertEqual(tuple(config.actions.fieldNames), ("test3", ))
+
+        configClass = self._createConfig(default={"test1": TestAction1, "test2": TestAction2,
+                                                  "test3": TestAction3})
+        config = configClass()
+        config.actions.remove = "test1"
+        self.assertEqual(tuple(config.actions.fieldNames), ("test2", "test3"))
+
+        # singleAction
+        # Test that an action can be reassigned
+        configClass = self._createConfig(singleDefault=TestAction1)
+        config = configClass()
+        self.assertEqual(config.singleAction(), 0)
+
+        config.singleAction = TestAction2
+        self.assertEqual(config.singleAction(), 1)
+
+        config.singleAction = TestAction3()
+        self.assertEqual(config.singleAction(), 3)
+
+    def testValidate(self):
+        configClass = self._createConfig(default={"test1": TestAction1, "test2": TestAction2,
+                                                  "test3": TestAction3}, singleDefault=TestAction1)
+        config = configClass()
+        config.validate()
+
+    def testFreeze(self):
+        configClass = self._createConfig(default={"test1": TestAction1, "test2": TestAction2},
+                                         singleDefault=TestAction1)
+        config = configClass()
+        config.freeze()
+
+        with self.assertRaises(FieldValidationError):
+            config.actions.test3 = TestAction3
+
+        with self.assertRaises(FieldValidationError):
+            config.actions.test1.var = 2
+
+        with self.assertRaises(FieldValidationError):
+            config.actions.test2.var = 0
+
+        with self.assertRaises(FieldValidationError):
+            config.singleAction = TestAction2
+
+        with self.assertRaises(FieldValidationError):
+            config.singleAction.var = 3
+
+    def testCompare(self):
+        configClass = self._createConfig(default={"test1": TestAction1, "test2": TestAction2},
+                                         singleDefault=TestAction1)
+        config = configClass()
+        config2 = configClass()
+
+        self.assertTrue(config.compare(config2))
+
+        # Test equality fail for ConfigurableActionsStructField
+        config3 = configClass()
+        config3.actions.test1.var = 99
+        self.assertFalse(config.compare(config3))
+
+        # Test equality fail for ConfigurableActionsField
+        config4 = configClass()
+        config4.singleAction.var = 99
+        self.assertFalse(config.compare(config4))
+
+    def testSave(self):
+        # This method will also test rename, as it is part of the
+        # implementation in pex_config
+        ioObject = StringIO()
+        configClass = self._createConfig(default={"test1": TestAction1},
+                                         singleDefault=TestAction1)
+        config = configClass()
+
+        config.saveToStream(ioObject)
+        loadedConfig = configClass()
+        loadedConfig.loadFromStream(ioObject.read())
+        self.assertTrue(config.compare(loadedConfig))
+        # Be sure that the fields are actually there
+        self.assertEqual(loadedConfig.actions.test1.var, 0)
+        self.assertEqual(loadedConfig.singleAction.var, 0)
+
+    def testToDict(self):
+        """Test the toDict interface"""
+        configClass = self._createConfig(default={"test1": TestAction1},
+                                         singleDefault=TestAction1)
+        config = configClass()
+        self.assertEqual(config.toDict(), {'actions': {'test1': {'var': 0}}, 'singleAction': {'var': 0}})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add new Config and Field types. These config types known as
ConfigurableActions, are callables that can have state specified
at configuration time. Two container Fields,
ConfigurableActionField and ConfigurableActionStructField are
introduced to allow adding ConfigurableActions to Config classes.

These classes are meant to serve as the basis for future work on
specific actions to interact with DataFrames.