### PR TITLE
DM-29583: Create dataset class for extended PSF models

### DIFF
--- a/python/lsst/pipe/tasks/extended_psf.py
+++ b/python/lsst/pipe/tasks/extended_psf.py
@@ -1,0 +1,256 @@
+# This file is part of pipe_tasks.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Read preprocessed bright stars and stack them to build an extended
+PSF model.
+"""
+
+from dataclasses import dataclass
+from typing import List
+
+from lsst.afw import image as afwImage
+from lsst.afw import fits as afwFits
+from lsst.daf.base import PropertyList
+
+
+@dataclass
+class FocalPlaneRegionExtendedPsf:
+    """Single extended PSF over a focal plane region.
+
+    The focal plane region is defined through a list
+    of detectors.
+
+    Parameters
+    ----------
+    extended_psf_image : `lsst.afw.image.MaskedImageF`
+        Image of the extended PSF model.
+    detector_list : `list` [`int`]
+        List of detector IDs that define the focal plane region over which this
+        extended PSF model has been built (and can be used).
+    """
+    extended_psf_image: afwImage.MaskedImageF
+    detector_list: List[int]
+
+
+class ExtendedPsf:
+    """Extended PSF model.
+
+    Each instance may contain a default extended PSF, a set of extended PSFs
+    that correspond to different focal plane regions, or both. At this time,
+    focal plane regions are always defined as a subset of detectors.
+
+    Parameters
+    ----------
+    default_extended_psf : `lsst.afw.image.MaskedImageF`
+        Extended PSF model to be used as default (or only) extended PSF model.
+    """
+    def __init__(self, default_extended_psf=None):
+        self.default_extended_psf = default_extended_psf
+        self.focal_plane_regions = {}
+        self.detectors_focal_plane_regions = {}
+
+    def add_regional_extended_psf(self, extended_psf_image, region_name, detector_list):
+        """Add a new focal plane region, along wit hits extended PSF, to the
+        ExtendedPsf instance.
+
+        Parameters
+        ----------
+        extended_psf_image : `lsst.afw.image.MaskedImageF`
+            Extended PSF model for the region.
+        region_name : `str`
+            Name of the focal plane region. Will be converted to all-uppercase.
+        detector_list : `list` [`int`]
+            List of IDs for the detectors that define the focal plane region.
+        """
+        region_name = region_name.upper()
+        if region_name in self.focal_plane_regions:
+            raise ValueError(f"Region name {region_name} is already used by this ExtendedPsf instance.")
+        self.focal_plane_regions[region_name] = FocalPlaneRegionExtendedPsf(
+            extended_psf_image=extended_psf_image, detector_list=detector_list)
+        for det in detector_list:
+            self.detectors_focal_plane_regions[det] = region_name
+
+    def __call__(self, detector=None):
+        """Return the appropriate extended PSF.
+
+        If the instance contains no extended PSF defined over focal plane
+        regions, the default extended PSF will be returned regardless of
+        whether a detector ID was passed as argument.
+
+        Parameters
+        ----------
+        detector : `int`, optional
+            Detector ID. If focal plane region PSFs are defined, is used to
+            determine which model to return.
+
+        Returns
+        -------
+        extendedPsfImage : `lsst.afw.image.MaskedImageF`
+            The extended PSF model. If this instance contains extended PSFs
+            defined over focal plane regions, the extended PSF model for the
+            region that contains ``detector`` is returned. If not, the default
+            extended PSF is returned.
+        """
+        if detector is None:
+            if self.default_extended_psf is None:
+                raise ValueError("No default extended PSF available; please provide detector number.")
+            return self.default_extended_psf
+        elif not self.focal_plane_regions:
+            return self.default_extended_psf
+        return self.get_regional_extended_psf(detector=detector)
+
+    def __len__(self):
+        """Returns the number of extended PSF models present in the instance.
+
+        Note that if the instance contains both a default model and a set of
+        focal plane region models, the length of the instance will be the
+        number of regional models, plus one (the default). This is true even
+        in the case where the default model is one of the focal plane
+        region-specific models.
+        """
+        n_regions = len(self.focal_plane_regions)
+        if self.default_extended_psf is not None:
+            n_regions += 1
+        return n_regions
+
+    def get_regional_extended_psf(self, region_name=None, detector=None):
+        """Returns the extended PSF for a focal plane region.
+
+        The region can be identified either by name, or through a detector ID.
+
+        Parameters
+        ----------
+        region_name : `str` or `None`, optional
+            Name of the region for which the extended PSF should be retrieved.
+            Ignored if  ``detector`` is provided. Must be provided if
+            ``detector`` is None.
+        detector : `int` or `None`, optional
+            If provided, returns the extended PSF for the focal plane region
+            that includes this detector.
+
+        Raises
+        ------
+        ValueError
+            Raised if neither ``detector`` nor ``regionName`` is provided.
+        """
+        if detector is None:
+            if region_name is None:
+                raise ValueError("One of either a regionName or a detector number must be provided.")
+            return self.focal_plane_regions[region_name].extended_psf_image
+        return self.focal_plane_regions[self.detectors_focal_plane_regions[detector]].extended_psf_image
+
+    def write_fits(self, filename):
+        """Write this object to a file.
+
+        Parameters
+        ----------
+        filename : `str`
+            Name of file to write.
+        """
+        # Create primary HDU with global metadata.
+        metadata = PropertyList()
+        metadata["HAS_DEFAULT"] = self.default_extended_psf is not None
+        if self.focal_plane_regions:
+            metadata["HAS_REGIONS"] = True
+            metadata["REGION_NAMES"] = list(self.focal_plane_regions.keys())
+            for region, e_psf_region in self.focal_plane_regions.items():
+                metadata[region] = e_psf_region.detector_list
+        else:
+            metadata["HAS_REGIONS"] = False
+        fits_primary = afwFits.Fits(filename, "w")
+        fits_primary.createEmpty()
+        fits_primary.writeMetadata(metadata)
+        fits_primary.closeFile()
+        # Write default extended PSF.
+        if self.default_extended_psf is not None:
+            default_hdu_metadata = PropertyList()
+            default_hdu_metadata.update({"REGION": "DEFAULT", "EXTNAME": "IMAGE"})
+            self.default_extended_psf.image.writeFits(filename, metadata=default_hdu_metadata, mode="a")
+            default_hdu_metadata.update({"REGION": "DEFAULT", "EXTNAME": "MASK"})
+            self.default_extended_psf.mask.writeFits(filename, metadata=default_hdu_metadata, mode="a")
+        # Write extended PSF for each focal plane region.
+        for j, (region, e_psf_region) in enumerate(self.focal_plane_regions.items()):
+            metadata = PropertyList()
+            metadata.update({"REGION": region, "EXTNAME": "IMAGE"})
+            e_psf_region.extended_psf_image.image.writeFits(filename, metadata=metadata, mode="a")
+            metadata.update({"REGION": region, "EXTNAME": "MASK"})
+            e_psf_region.extended_psf_image.mask.writeFits(filename, metadata=metadata, mode="a")
+
+    def writeFits(self, filename):
+        """Alias for ``write_fits``; exists for compatibility with the Butler.
+        """
+        self.write_fits(filename)
+
+    @classmethod
+    def read_fits(cls, filename):
+        """Build an instance of this class from a file.
+
+        Parameters
+        ----------
+        filename : `str`
+            Name of the file to read.
+        """
+        # Extract info from metadata.
+        global_metadata = afwFits.readMetadata(filename, hdu=0)
+        has_default = global_metadata.getBool("HAS_DEFAULT")
+        if global_metadata.getBool("HAS_REGIONS"):
+            focal_plane_region_names = global_metadata.getArray("REGION_NAMES")
+        else:
+            focal_plane_region_names = []
+        f = afwFits.Fits(filename, "r")
+        n_extensions = f.countHdus()
+        extended_psf_parts = {}
+        for j in range(1, n_extensions):
+            md = afwFits.readMetadata(filename, hdu=j)
+            if has_default and md["REGION"] == "DEFAULT":
+                if md["EXTNAME"] == "IMAGE":
+                    default_image = afwImage.ImageF(filename, hdu=j)
+                elif md["EXTNAME"] == "MASK":
+                    default_mask = afwImage.MaskX(filename, hdu=j)
+                continue
+            if md["EXTNAME"] == "IMAGE":
+                extended_psf_part = afwImage.ImageF(filename, hdu=j)
+            elif md["EXTNAME"] == "MASK":
+                extended_psf_part = afwImage.MaskX(filename, hdu=j)
+            extended_psf_parts.setdefault(md["REGION"], {})[md["EXTNAME"].lower()] = extended_psf_part
+        # Handle default if present.
+        if has_default:
+            extended_psf = cls(afwImage.MaskedImageF(default_image, default_mask))
+        else:
+            extended_psf = cls()
+        # Ensure we recovered an extended PSF for all focal plane regions.
+        if len(extended_psf_parts) != len(focal_plane_region_names):
+            raise ValueError(f"Number of per-region extended PSFs read ({len(extended_psf_parts)}) does not "
+                             "match with the number of regions recorded in the metadata "
+                             f"({len(focal_plane_region_names)}).")
+        # Generate extended PSF regions mappings.
+        for r_name in focal_plane_region_names:
+            extended_psf_image = afwImage.MaskedImageF(**extended_psf_parts[r_name])
+            detector_list = global_metadata.getArray(r_name)
+            extended_psf.add_regional_extended_psf(extended_psf_image, r_name, detector_list)
+        # Instantiate ExtendedPsf.
+        return extended_psf
+
+    @classmethod
+    def readFits(cls, filename):
+        """Alias for ``readFits``; exists for compatibility with the Butler.
+        """
+        return cls.read_fits(filename)

--- a/tests/test_extended_psf.py
+++ b/tests/test_extended_psf.py
@@ -1,0 +1,148 @@
+# This file is part of pipe_tasks.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+import numpy as np
+import tempfile
+
+from lsst.afw import image as afwImage
+from lsst.pipe.tasks import extended_psf
+import lsst.utils.tests
+
+np.random.seed(51778)
+
+
+def make_extended_psf(n_extended_psf=1):
+    e_psf_images = [afwImage.MaskedImageF(25, 25) for _ in range(n_extended_psf)]
+    for e_psf_im in e_psf_images:
+        e_psf_im.image.array += np.random.rand(25, 25)
+        e_psf_im.mask.array += np.random.choice(3, size=(25, 25))
+    return e_psf_images
+
+
+class ExtendedPsfTestCase(lsst.utils.tests.TestCase):
+    """Test ExtendedPsf.
+    """
+    def setUp(self):
+        self.default_e_psf = make_extended_psf(1)[0]
+        self.constant_e_psf = extended_psf.ExtendedPsf(self.default_e_psf)
+        self.regions = ["NW", "SW", "E"]
+        self.region_detectors = [list(range(10)), list(range(10, 20)), list(range(20, 40))]
+        self.regional_e_psfs = make_extended_psf(3)
+
+    def tearDown(self):
+        del self.default_e_psf
+        del self.regions
+        del self.region_detectors
+        del self.regional_e_psfs
+
+    def test_constant_psf(self):
+        # When calling a constant ExtendedPsf, the same PSF is returned whether
+        # a detector ID is given or not.
+        cons_psf0 = self.constant_e_psf()
+        cons_psf1 = self.constant_e_psf(detector=11)
+        self.assertMaskedImagesAlmostEqual(cons_psf0, self.default_e_psf)
+        self.assertMaskedImagesAlmostEqual(cons_psf1, self.default_e_psf)
+
+    def test_regional_psf_addition(self):
+        # Start with either an empty instance, or one containing a default
+        # extended PSF.
+        starts_empty_e_psf = extended_psf.ExtendedPsf()
+        with_default_e_psf = extended_psf.ExtendedPsf(self.default_e_psf)
+        self.assertEqual(len(starts_empty_e_psf), 0)
+        self.assertEqual(len(with_default_e_psf), 1)
+        # Add a couple of regional PSFs.
+        for j in range(2):
+            starts_empty_e_psf.add_regional_extended_psf(self.regional_e_psfs[j], self.regions[j],
+                                                         self.region_detectors[j])
+            with_default_e_psf.add_regional_extended_psf(self.regional_e_psfs[j], self.regions[j],
+                                                         self.region_detectors[j])
+        self.assertEqual(len(starts_empty_e_psf), 2)
+        self.assertEqual(len(with_default_e_psf), 3)
+        # Ensure we recover the correct regional PSF.
+        for j in range(2):
+            for det in self.region_detectors[j]:
+                # Try it by calling the class directly.
+                reg_psf0, reg_psf1 = starts_empty_e_psf(det), with_default_e_psf(det)
+                self.assertMaskedImagesAlmostEqual(reg_psf0, self.regional_e_psfs[j])
+                self.assertMaskedImagesAlmostEqual(reg_psf1, self.regional_e_psfs[j])
+                # Try it by passing on a detector number to the
+                # get_regional_extended_psf method.
+                reg_psf0 = starts_empty_e_psf.get_regional_extended_psf(detector=det)
+                reg_psf1 = with_default_e_psf.get_regional_extended_psf(detector=det)
+                self.assertMaskedImagesAlmostEqual(reg_psf0, self.regional_e_psfs[j])
+                self.assertMaskedImagesAlmostEqual(reg_psf1, self.regional_e_psfs[j])
+            # Try it by passing on a region name.
+            reg_psf0 = starts_empty_e_psf.get_regional_extended_psf(region_name=self.regions[j])
+            reg_psf1 = with_default_e_psf.get_regional_extended_psf(region_name=self.regions[j])
+            self.assertMaskedImagesAlmostEqual(reg_psf0, self.regional_e_psfs[j])
+            self.assertMaskedImagesAlmostEqual(reg_psf1, self.regional_e_psfs[j])
+        # Ensure we recover the original default PSF.
+        self.assertMaskedImagesAlmostEqual(with_default_e_psf(), self.default_e_psf)
+
+    def test_IO(self):
+        # Test IO with a constant extended PSF.
+        with tempfile.NamedTemporaryFile() as f:
+            self.constant_e_psf.writeFits(f.name)
+            read_e_psf = extended_psf.ExtendedPsf.readFits(f.name)
+            self.assertMaskedImagesAlmostEqual(self.constant_e_psf(), read_e_psf())
+        # Test IO with per-region extended PSFs (with default).
+        per_region_e_psf0 = extended_psf.ExtendedPsf(self.default_e_psf)
+        for j in range(3):
+            per_region_e_psf0.add_regional_extended_psf(self.regional_e_psfs[j], self.regions[j],
+                                                        self.region_detectors[j])
+        with tempfile.NamedTemporaryFile() as f:
+            per_region_e_psf0.writeFits(f.name)
+            read_e_psf0 = extended_psf.ExtendedPsf.readFits(f.name)
+            self.assertEqual(per_region_e_psf0.detectors_focal_plane_regions,
+                             read_e_psf0.detectors_focal_plane_regions)
+            # Check default extended PSF.
+            self.assertMaskedImagesAlmostEqual(per_region_e_psf0(), read_e_psf0())
+            # And per-region extended PSFs.
+            for j in range(3):
+                for det in self.region_detectors[j]:
+                    reg_psf0, read_reg_psf0 = per_region_e_psf0(det), read_e_psf0(det)
+                    self.assertMaskedImagesAlmostEqual(reg_psf0, read_reg_psf0)
+        # Test IO with a single per-region extended PSF.
+        per_region_e_psf1 = extended_psf.ExtendedPsf()
+        per_region_e_psf1.add_regional_extended_psf(self.regional_e_psfs[1], self.regions[1],
+                                                    self.region_detectors[1])
+        with tempfile.NamedTemporaryFile() as f:
+            per_region_e_psf1.writeFits(f.name)
+            read_e_psf1 = extended_psf.ExtendedPsf.readFits(f.name)
+            self.assertEqual(per_region_e_psf0.detectors_focal_plane_regions,
+                             read_e_psf0.detectors_focal_plane_regions)
+            for det in self.region_detectors[1]:
+                reg_psf1, read_reg_psf1 = per_region_e_psf1(det), read_e_psf1(det)
+                self.assertMaskedImagesAlmostEqual(reg_psf1, read_reg_psf1)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
Main PR for [DM-29583](https://jira.lsstcorp.org/browse/DM-29583?jql=assignee%20%3D%20currentUser()%20AND%20resolution%20%3D%20unresolved%20ORDER%20BY%20priority%20DESC%2C%20created%20ASC), the other being in daf_butler.

Jenkins run [#33904](https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/33904/pipeline) contains these changes, plus those of [DM-25305](https://jira.lsstcorp.org/browse/DM-25305) (ticket was split in two).