### PR TITLE
DM-29883: Add keyword to always overwrite existing files.

### DIFF
--- a/python/lsst/pipe/tasks/healSparseMapping.py
+++ b/python/lsst/pipe/tasks/healSparseMapping.py
@@ -72,7 +72,7 @@ class HealSparseMapFormatter(Formatter):
         # Docstring inherited from Formatter.write.
         # Update the location with the formatter-preferred file extension
         self.fileDescriptor.location.updateExtension(self.extension)
-        inMemoryDataset.write(self.fileDescriptor.location.path)
+        inMemoryDataset.write(self.fileDescriptor.location.path, clobber=True)
 
 
 def _is_power_of_two(value):


### PR DESCRIPTION
The butler formatters expect to be able to overwrite data.