### PR TITLE
DM-29344: Investigate the CI differences between Gen 2 and 3 in COSMOS field

### DIFF
--- a/python/lsst/pipe/tasks/imageDifference.py
+++ b/python/lsst/pipe/tasks/imageDifference.py
@@ -154,7 +154,7 @@ class ImageDifferenceConfig(pipeBase.PipelineTaskConfig,
                                     doc="Convolve science image by its PSF before PSF-matching?")
     doScaleTemplateVariance = pexConfig.Field(dtype=bool, default=False,
                                               doc="Scale variance of the template before PSF matching")
-    doScaleDiffimVariance = pexConfig.Field(dtype=bool, default=False,
+    doScaleDiffimVariance = pexConfig.Field(dtype=bool, default=True,
                                             doc="Scale variance of the diffim before PSF matching. "
                                                 "You may do either this or template variance scaling, "
                                                 "or neither. (Doing both is a waste of CPU.)")


### PR DESCRIPTION
This PR makes `doScaleDiffimVarianceTask` True to be the new default behavior in imageDifferenceTask. We won't need to override this config in any pipeline or ap_verify-style dataset to get consistent results.