### PR TITLE
DM-23330: Doxygen warnings in pipe_base

### DIFF
--- a/ups/pipe_tasks.build
+++ b/ups/pipe_tasks.build
@@ -1,2 +1,0 @@
-@LSST BUILD@ &&
-build_lsst @PRODUCT@ @VERSION@ @REPOVERSION@

--- a/ups/pipe_tasks.cfg
+++ b/ups/pipe_tasks.cfg
@@ -4,7 +4,6 @@ import lsst.sconsUtils
 
 dependencies = dict(
     required = [
-        "pipe_base",
         "afw",
         "daf_persistence",
         "log",


### PR DESCRIPTION
This PR fixes a build error caused by converting `pipe_base` to a pure-Python package in lsst/pipe_base#184.