### PR TITLE
DM-30701: Add astromOffsetMean and astromOffsetStd to ExposureSummaryStats.

### DIFF
--- a/python/lsst/pipe/tasks/characterizeImage.py
+++ b/python/lsst/pipe/tasks/characterizeImage.py
@@ -161,11 +161,15 @@ class CharacterizeImageConfig(pipeBase.PipelineTaskConfig,
     doComputeSummaryStats = pexConfig.Field(
         dtype=bool,
         default=True,
-        doc="Run subtask to measure exposure summary statistics"
+        doc="Run subtask to measure exposure summary statistics",
+        deprecated=("This subtask has been moved to CalibrateTask "
+                    "with DM-30701.")
     )
     computeSummaryStats = pexConfig.ConfigurableField(
         target=ComputeExposureSummaryStatsTask,
-        doc="Subtask to run computeSummaryStats on exposure"
+        doc="Subtask to run computeSummaryStats on exposure",
+        deprecated=("This subtask has been moved to CalibrateTask "
+                    "with DM-30701.")
     )
     useSimplePsf = pexConfig.Field(
         dtype=bool,
@@ -375,8 +379,6 @@ class CharacterizeImageTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             self.makeSubtask('measureApCorr', schema=self.schema)
             self.makeSubtask('applyApCorr', schema=self.schema)
         self.makeSubtask('catalogCalculation', schema=self.schema)
-        if self.config.doComputeSummaryStats:
-            self.makeSubtask('computeSummaryStats')
         self._initialFrame = getDebugFrame(self._display, "frame") or 1
         self._frame = self._initialFrame
         self.schema.checkUnits(parse_strict=self.config.checkUnitsParseStrict)
@@ -511,11 +513,6 @@ class CharacterizeImageTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             dmeRes.exposure.getInfo().setApCorrMap(apCorrMap)
             self.applyApCorr.run(catalog=dmeRes.sourceCat, apCorrMap=exposure.getInfo().getApCorrMap())
         self.catalogCalculation.run(dmeRes.sourceCat)
-        if self.config.doComputeSummaryStats:
-            summary = self.computeSummaryStats.run(exposure=dmeRes.exposure,
-                                                   sources=dmeRes.sourceCat,
-                                                   background=dmeRes.background)
-            dmeRes.exposure.getInfo().setSummaryStats(summary)
 
         self.display("measure", exposure=dmeRes.exposure, sourceCat=dmeRes.sourceCat)
 

--- a/python/lsst/pipe/tasks/computeExposureSummaryStats.py
+++ b/python/lsst/pipe/tasks/computeExposureSummaryStats.py
@@ -73,6 +73,8 @@ class ComputeExposureSummaryStatsTask(pipeBase.Task):
     - meanVar
     - raCorners
     - decCorners
+    - astromOffsetMean
+    - astromOffsetStd
     """
     ConfigClass = ComputeExposureSummaryStatsConfig
     _DefaultName = "computeExposureSummaryStats"
@@ -180,6 +182,14 @@ class ComputeExposureSummaryStatsTask(pipeBase.Task):
                                          afwMath.MEANCLIP, statsCtrl)
         meanVar, _ = statObj.getResult(afwMath.MEANCLIP)
 
+        md = exposure.getMetadata()
+        if 'SFM_ASTROM_OFFSET_MEAN' in md:
+            astromOffsetMean = md['SFM_ASTROM_OFFSET_MEAN']
+            astromOffsetStd = md['SFM_ASTROM_OFFSET_STD']
+        else:
+            astromOffsetMean = np.nan
+            astromOffsetStd = np.nan
+
         summary = afwImage.ExposureSummaryStats(psfSigma=float(psfSigma),
                                                 psfArea=float(psfArea),
                                                 psfIxx=float(psfIxx),
@@ -193,6 +203,8 @@ class ComputeExposureSummaryStatsTask(pipeBase.Task):
                                                 skyNoise=float(skyNoise),
                                                 meanVar=float(meanVar),
                                                 raCorners=raCorners,
-                                                decCorners=decCorners)
+                                                decCorners=decCorners,
+                                                astromOffsetMean=astromOffsetMean,
+                                                astromOffsetStd=astromOffsetStd)
 
         return summary

--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -1158,6 +1158,8 @@ class ConsolidateVisitSummaryTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             rec['skyBg'] = summaryStats.skyBg
             rec['skyNoise'] = summaryStats.skyNoise
             rec['meanVar'] = summaryStats.meanVar
+            rec['astromOffsetMean'] = summaryStats.astromOffsetMean
+            rec['astromOffsetStd'] = summaryStats.astromOffsetStd
 
         metadata = dafBase.PropertyList()
         metadata.add("COMMENT", "Catalog id is detector id, sorted.")
@@ -1202,6 +1204,10 @@ class ConsolidateVisitSummaryTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                         doc='Average sky noise (ADU)')
         schema.addField('meanVar', type='F',
                         doc='Mean variance of the weight plane (ADU**2)')
+        schema.addField('astromOffsetMean', type='F',
+                        doc='Mean offset of astrometric calibration matches (arcsec)')
+        schema.addField('astromOffsetStd', type='F',
+                        doc='Standard deviation of offsets of astrometric calibration matches (arcsec)')
 
         return schema
 

--- a/tests/test_processCcd.py
+++ b/tests/test_processCcd.py
@@ -164,8 +164,8 @@ class ProcessCcdTestCase(lsst.utils.tests.TestCase):
                         ("summary_decl", summary.decl, -9.800258687592303),
                         ("summary_zenithDistance", float('%.6f' % (summary.zenithDistance)), 42.361001),
                         ("summary_zeroPoint", summary.zeroPoint, 30.940228147639207),
-                        ("summary_skyBg", summary.skyBg, 191.4352211728692),
-                        ("summary_skyNoise", summary.skyNoise, 12.512330367008024),
+                        ("summary_skyBg", summary.skyBg, 191.37726892903447),
+                        ("summary_skyNoise", summary.skyNoise, 12.512272992606531),
                         ("summary_meanVar", summary.meanVar, 130.61335199119068)
                     ]:
                         self.assertAlmostEqual(var, val, places=expectedPlaces, msg=name)


### PR DESCRIPTION
The ComputeExposureSummaryTask has also been moved from characterize to calibrate, where it should be to have the latest-and-greatest photometric calibration and wcs.  In the previous location it was computing incorrect values.