### PR TITLE
DM-30776: Move MatchApFakesTask to pipe_tasks

### DIFF
--- a/python/lsst/pipe/tasks/matchFakes.py
+++ b/python/lsst/pipe/tasks/matchFakes.py
@@ -19,8 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Methods to match an input catalog to a set of fakes in AP.
-"""
 
 import numpy as np
 from scipy.spatial import cKDTree
@@ -31,19 +29,19 @@ from lsst.pipe.base import PipelineTask, PipelineTaskConnections, Struct
 import lsst.pipe.base.connectionTypes as connTypes
 from lsst.pipe.tasks.insertFakes import InsertFakesConfig
 
-__all__ = ["MatchApFakesTask",
-           "MatchApFakesConfig",
-           "MatchApFakesConnections"]
+__all__ = ["MatchFakesTask",
+           "MatchFakesConfig",
+           "MatchFakesConnections"]
 
 
-class MatchApFakesConnections(PipelineTaskConnections,
-                              defaultTemplates={"coaddName": "deep",
-                                                "fakesType": "fakes_"},
-                              dimensions=("tract",
-                                          "skymap",
-                                          "instrument",
-                                          "visit",
-                                          "detector")):
+class MatchFakesConnections(PipelineTaskConnections,
+                            defaultTemplates={"coaddName": "deep",
+                                              "fakesType": "fakes_"},
+                            dimensions=("tract",
+                                        "skymap",
+                                        "instrument",
+                                        "visit",
+                                        "detector")):
     fakeCat = connTypes.Input(
         doc="Catalog of fake sources to draw inputs from.",
         name="{fakesType}fakeSourceCat",
@@ -71,10 +69,10 @@ class MatchApFakesConnections(PipelineTaskConnections,
     )
 
 
-class MatchApFakesConfig(
+class MatchFakesConfig(
         InsertFakesConfig,
-        pipelineConnections=MatchApFakesConnections):
-    """Config for MatchApFakesTask.
+        pipelineConnections=MatchFakesConnections):
+    """Config for MatchFakesTask.
     """
     matchDistanceArcseconds = pexConfig.RangeField(
         doc="Distance in arcseconds to ",
@@ -85,15 +83,15 @@ class MatchApFakesConfig(
     )
 
 
-class MatchApFakesTask(PipelineTask):
-    """Create and store a set of spatially uniform star fakes over the sphere
-    for use in AP processing. Additionally assign random magnitudes to said
+class MatchFakesTask(PipelineTask):
+    """Create and store a set of spatially uniform star fakes over the sphere.
+    Additionally assign random magnitudes to said
     fakes and assign them to be inserted into either a visit exposure or
     template exposure.
     """
 
-    _DefaultName = "matchApFakes"
-    ConfigClass = MatchApFakesConfig
+    _DefaultName = "matchFakes"
+    ConfigClass = MatchFakesConfig
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         inputs = butlerQC.get(inputRefs)

--- a/tests/test_matchFakes.py
+++ b/tests/test_matchFakes.py
@@ -36,10 +36,10 @@ from lsst.pipe.base import testUtils
 import lsst.skymap as skyMap
 import lsst.utils.tests
 
-from lsst.pipe.tasks.matchApFakes import MatchApFakesTask, MatchApFakesConfig
+from lsst.pipe.tasks.matchFakes import MatchFakesTask, MatchFakesConfig
 
 
-class TestMatchApFakes(lsst.utils.tests.TestCase):
+class TestMatchFakes(lsst.utils.tests.TestCase):
 
     def setUp(self):
         """Create fake data to use in the tests.
@@ -120,7 +120,7 @@ class TestMatchApFakes(lsst.utils.tests.TestCase):
                       "visit": [1234, 4321],
                       "detector": [25, 26]}
         testRepo = butlerTests.makeTestRepo(root, dimensions)
-        matchTask = MatchApFakesTask()
+        matchTask = MatchFakesTask()
         connections = matchTask.config.ConnectionsClass(
             config=matchTask.config)
 
@@ -182,9 +182,9 @@ class TestMatchApFakes(lsst.utils.tests.TestCase):
     def testRun(self):
         """Test the run method.
         """
-        matchFakesConfig = MatchApFakesConfig()
+        matchFakesConfig = MatchFakesConfig()
         matchFakesConfig.matchDistanceArcseconds = 0.1
-        matchFakes = MatchApFakesTask(config=matchFakesConfig)
+        matchFakes = MatchFakesTask(config=matchFakesConfig)
         result = matchFakes.run(self.fakeCat,
                                 self.exposure,
                                 self.sourceCat)
@@ -196,7 +196,7 @@ class TestMatchApFakes(lsst.utils.tests.TestCase):
     def testTrimCat(self):
         """Test that the correct number of sources are in the ccd area.
         """
-        matchTask = MatchApFakesTask()
+        matchTask = MatchFakesTask()
         result = matchTask._trimFakeCat(self.fakeCat, self.exposure)
         self.assertEqual(len(result), self.inExp.sum())
 


### PR DESCRIPTION
This PR moves `MatchApFakesTask` from `ap_pipe` and renames it to `MatchFakesTask` (see lsst/ap_pipe#82).

The one significant change to the code is fe9feef, which rewrites the unit test for `MatchApFakesTask` to not depend on `CreateRandomApFakesTask`. This involves hard-coding some of the details of the fakes catalog schema into the test.