### PR TITLE
DM-30838: Add pipeline contract for bright object mask configs.

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -182,3 +182,13 @@ contracts:
   - imageDifference.connections.subtractedExposure == forcedPhotDiffim.connections.exposure
   - transformDiaSourceCat.connections.diaSourceTable == consolidateDiaSourceTable.connections.inputCatalogs
   - transformDiaSourceCat.connections.diaSourceTable == drpAssociation.connections.diaSourceTables
+  - >
+    (
+      assembleCoadd.doMaskBrightObjects
+      and assembleCoadd.brightObjectMaskName in measure.measurement.plugins['base_PixelFlags'].masksFpCenter
+      and assembleCoadd.brightObjectMaskName in measure.measurement.plugins['base_PixelFlags'].masksFpAnywhere
+    ) or (
+      not assembleCoadd.doMaskBrightObjects
+      and assembleCoadd.brightObjectMaskName not in measure.measurement.plugins['base_PixelFlags'].masksFpCenter
+      and assembleCoadd.brightObjectMaskName not in measure.measurement.plugins['base_PixelFlags'].masksFpAnywhere
+    )


### PR DESCRIPTION
This is by far our most complex contract yet; let's hope it works (`ci_imsim` seems to be okay with it).