### PR TITLE
DM-30349: Documentation fixes

### DIFF
--- a/doc/lsst.pipe.tasks/tasks/lsst.pipe.tasks.postprocess.WriteSourceTableTask.rst
+++ b/doc/lsst.pipe.tasks/tasks/lsst.pipe.tasks.postprocess.WriteSourceTableTask.rst
@@ -4,8 +4,8 @@
 WriteSourceTableTask
 ####################
 
-``WriteSourceTableTask`` converts table of sources measured on a calexp (dataset `src`) to a
-parquet file. All data is copied without transformation, and column names are unchanged.
+``WriteSourceTableTask`` converts table of sources measured on a calexp (dataset `src`) to a parquet file.
+All data is copied without transformation, and column names are unchanged, except for the ``"id"`` column, which is replaced by a `~pandas.DataFrame` index.
 
 It is the first of three postprocessing tasks to convert a `src` table to a
 per-visit Source Table that conforms to the standard data model. The second is

--- a/python/lsst/pipe/tasks/matchFakes.py
+++ b/python/lsst/pipe/tasks/matchFakes.py
@@ -43,7 +43,7 @@ class MatchFakesConnections(PipelineTaskConnections,
                                         "visit",
                                         "detector")):
     fakeCat = connTypes.Input(
-        doc="Catalog of fake sources to draw inputs from.",
+        doc="Catalog of fake sources inserted into an image.",
         name="{fakesType}fakeSourceCat",
         storageClass="DataFrame",
         dimensions=("tract", "skymap")
@@ -55,14 +55,16 @@ class MatchFakesConnections(PipelineTaskConnections,
         dimensions=("instrument", "visit", "detector"),
     )
     associatedDiaSources = connTypes.Input(
-        doc="Optional output storing the DiaSource catalog after matching and "
-            "SDMification.",
+        doc="A DiaSource catalog to match against fakeCat. Assumed "
+            "to be SDMified.",
         name="{fakesType}{coaddName}Diff_assocDiaSrc",
         storageClass="DataFrame",
         dimensions=("instrument", "visit", "detector"),
     )
     matchedDiaSources = connTypes.Output(
-        doc="",
+        doc="A catalog of those fakeCat sources that have a match in "
+            "associatedDiaSources. The schema is the union of the schemas for "
+            "``fakeCat`` and ``associatedDiaSources``.",
         name="{fakesType}{coaddName}Diff_matchDiaSrc",
         storageClass="DataFrame",
         dimensions=("instrument", "visit", "detector"),
@@ -75,7 +77,7 @@ class MatchFakesConfig(
     """Config for MatchFakesTask.
     """
     matchDistanceArcseconds = pexConfig.RangeField(
-        doc="Distance in arcseconds to ",
+        doc="Distance in arcseconds to match within.",
         dtype=float,
         default=0.5,
         min=0,
@@ -84,10 +86,8 @@ class MatchFakesConfig(
 
 
 class MatchFakesTask(PipelineTask):
-    """Create and store a set of spatially uniform star fakes over the sphere.
-    Additionally assign random magnitudes to said
-    fakes and assign them to be inserted into either a visit exposure or
-    template exposure.
+    """Match a pre-existing catalog of fakes to a catalog of detections on
+    a difference image.
     """
 
     _DefaultName = "matchFakes"
@@ -107,7 +107,7 @@ class MatchFakesTask(PipelineTask):
         fakeCat : `pandas.DataFrame`
             Catalog of fakes to match to detected diaSources.
         diffIm : `lsst.afw.image.Exposure`
-            Difference image where ``associatedDiaSources`` were detected in.
+            Difference image where ``associatedDiaSources`` were detected.
         associatedDiaSources : `pandas.DataFrame`
             Catalog of difference image sources detected in ``diffIm``.
 

--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -266,7 +266,8 @@ class WriteSourceTableConnections(pipeBase.PipelineTaskConnections,
         dimensions=("instrument", "visit", "detector")
     )
     outputCatalog = connectionTypes.Output(
-        doc="Catalog of sources, `src` in Parquet format",
+        doc="Catalog of sources, `src` in Parquet format. The 'id' column is "
+            "replaced with an index; all other columns are unchanged.",
         name="{catalogType}source",
         storageClass="DataFrame",
         dimensions=("instrument", "visit", "detector")


### PR DESCRIPTION
This PR fixes some incorrect documentation for `MatchFakesTask` and `WriteSourceTableTask` found while working on DM-30349.