### PR TITLE
Dm-31360 Explicitly put each Scarlet catalog

### DIFF
--- a/python/lsst/pipe/tasks/deblendCoaddSourcesPipeline.py
+++ b/python/lsst/pipe/tasks/deblendCoaddSourcesPipeline.py
@@ -199,15 +199,10 @@ class DeblendCoaddSourcesMultiTask(DeblendCoaddSourcesBaseTask):
         inputs["idFactory"] = exposureIdInfo.makeSourceIdFactory()
         inputs["filters"] = [dRef.dataId["band"] for dRef in inputRefs.coadds]
         outputs = self.run(**inputs)
-        sortedTemplateCatalogs = []
         for outRef in outputRefs.templateCatalogs:
             band = outRef.dataId['band']
-            # use the .get method because if the key does not exist, it will return
-            # None, putting None is the same as not putting something, and down-stream
-            # tasks can use that as a signal the dataset was not processed
-            sortedTemplateCatalogs.append(outputs.templateCatalogs.get(band))
-        outputs.templateCatalogs = sortedTemplateCatalogs
-        butlerQC.put(outputs, outputRefs)
+            if (catalog := outputs.templateCatalogs.get(band)) is not None:
+                butlerQC.put(catalog, outRef)
 
     def run(self, coadds, filters, mergedDetections, idFactory):
         sources = self._makeSourceCatalog(mergedDetections, idFactory)


### PR DESCRIPTION
When deblending it is possible some inputs were not produced in
previous steps, and thus no outputs were created corresponding
to those inputs. Explicitly call put on the outputs that could
be produced.