### PR TITLE
DM-31376: :assembleCoadd can't handle when selectVisit selects a visit with no Warp

### DIFF
--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -1332,7 +1332,8 @@ class AssembleCoaddTask(CoaddBaseTask, pipeBase.PipelineTask):
         inputWarpDict = {inputRef.ref.dataId['visit']: inputRef for inputRef in inputs}
         filteredInputs = []
         for visit in goodVisits.keys():
-            filteredInputs.append(inputWarpDict[visit])
+            if visit in inputWarpDict:
+                filteredInputs.append(inputWarpDict[visit])
         return filteredInputs
 
 


### PR DESCRIPTION
The situation can occur where a given visit specified in the list
of selected visits is missing from the inputWarpDict for a given
tract/patch dataRef.  Thus, check that the visit actually exists
in the inputWarpDict before trying to append it to the filtered
inputs list.