### PR TITLE
DM-31765: Transform forced sources on diaObjects during DRP

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -104,6 +104,25 @@ tasks:
       connections.measCat: forced_diff_diaObject
       connections.outputSchema:  forced_diff_diaObject_schema
       connections.exposure: goodSeeingDiff_differenceExp
+  writeForcedSourceOnDiaObjectTable:
+    class: lsst.pipe.tasks.postprocess.WriteForcedSourceTableTask
+    config:
+      key: diaObjectId
+      connections.inputCatalogDiff: forced_diff_diaObject
+      connections.inputCatalog: forced_src_diaObject
+      connections.outputCatalog: forcedSourceOnDiaObject
+  transformForcedSourceOnDiaObjectTable:
+    class: lsst.pipe.tasks.postprocess.TransformForcedSourceTableTask
+    config:
+      referenceColumns: []
+      connections.inputCatalogs: forcedSourceOnDiaObject
+      connections.outputCatalog: forcedSourceOnDiaObjectTable
+      connections.referenceCatalog: goodSeeingDiff_fullDiaObjTable
+  consolidateForcedSourceOnDiaObjectTable:
+    class: lsst.pipe.tasks.postprocess.ConsolidateForcedSourceTableTask
+    config:
+      connections.inputCatalogs: forcedSourceOnDiaObjectTable
+      connections.outputCatalog: forcedSourceOnDiaObjectTable_tract
 subsets:
   processCcd:
     subset:

--- a/python/lsst/pipe/tasks/functors.py
+++ b/python/lsst/pipe/tasks/functors.py
@@ -487,8 +487,11 @@ class CompositeFunctor(Functor):
                         df[f.multilevelColumns(data, returnTuple=True, columnIndex=columnIndex)]
                     )
                     valDict[k] = f._func(subdf)
-                except Exception:
-                    valDict[k] = f.fail(subdf)
+                except Exception as e:
+                    try:
+                        valDict[k] = f.fail(subdf)
+                    except NameError:
+                        raise e
 
         else:
             if isinstance(data, DeferredDatasetHandle):


### PR DESCRIPTION
- Generalize the write|transform|consolidateForcedSourceTasks to
work regardless of reference catalog used to seed the forced phot.
- Make the error message more clear if a requested column is missing.