### PR TITLE
DM-31825: Implement RFC-807 on  DRP DataFrame consistency

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -64,6 +64,7 @@ tasks:
   transformDiaSourceCat:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
+      doPackFlags: false
       connections.coaddName: goodSeeing
       connections.diaSourceSchema: goodSeeingDiff_diaSrc_schema
       connections.diaSourceCat: goodSeeingDiff_diaSrc

--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -88,6 +88,16 @@ tasks:
       connections.assocDiaSourceTable: goodSeeingDiff_assocDiaSrcTable
       connections.diaObjectTable: goodSeeingDiff_diaObjTable
       connections.fullDiaObjectTable: goodSeeingDiff_fullDiaObjTable
+  consolidateAssocDiaSourceTable:
+    class: lsst.pipe.tasks.postprocess.ConsolidateTractTask
+    config:
+      connections.inputCatalogs: goodSeeingDiff_assocDiaSrcTable
+      connections.outputCatalog: diaSourceTable_tract
+  consolidateFullDiaObjectTable:
+    class: lsst.pipe.tasks.postprocess.ConsolidateTractTask
+    config:
+      connections.inputCatalogs: goodSeeingDiff_fullDiaObjTable
+      connections.outputCatalog: diaObjectTable_tract
   forcedPhotDiffim:
     class: lsst.meas.base.ForcedPhotCcdTask
     config:
@@ -96,7 +106,11 @@ tasks:
       connections.exposure: goodSeeingDiff_differenceExp
   writeForcedSourceTable: lsst.pipe.tasks.postprocess.WriteForcedSourceTableTask
   transformForcedSourceTable: lsst.pipe.tasks.postprocess.TransformForcedSourceTableTask
-  consolidateForcedSourceTable: lsst.pipe.tasks.postprocess.ConsolidateForcedSourceTableTask
+  consolidateForcedSourceTable:
+    class: lsst.pipe.tasks.postprocess.ConsolidateTractTask
+    config:
+      connections.inputCatalogs: forcedSourceTable
+      connections.outputCatalog: forcedSourceTable_tract
   forcedPhotCcdOnDiaObjects:
     class: lsst.meas.base.ForcedPhotCcdFromDataFrameTask
   forcedPhotDiffOnDiaObjects:
@@ -122,7 +136,7 @@ tasks:
       connections.outputCatalog: forcedSourceOnDiaObjectTable
       connections.referenceCatalog: goodSeeingDiff_fullDiaObjTable
   consolidateForcedSourceOnDiaObjectTable:
-    class: lsst.pipe.tasks.postprocess.ConsolidateForcedSourceTableTask
+    class: lsst.pipe.tasks.postprocess.ConsolidateTractTask
     config:
       connections.inputCatalogs: forcedSourceOnDiaObjectTable
       connections.outputCatalog: forcedSourceOnDiaObjectTable_tract

--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -116,6 +116,8 @@ tasks:
     class: lsst.pipe.tasks.postprocess.TransformForcedSourceTableTask
     config:
       referenceColumns: []
+      keyRef: diaObjectId
+      key: forcedSourceOnDiaObjectId
       connections.inputCatalogs: forcedSourceOnDiaObject
       connections.outputCatalog: forcedSourceOnDiaObjectTable
       connections.referenceCatalog: goodSeeingDiff_fullDiaObjTable

--- a/python/lsst/pipe/tasks/drpAssociationPipe.py
+++ b/python/lsst/pipe/tasks/drpAssociationPipe.py
@@ -195,7 +195,7 @@ class DrpAssociationPipeTask(pipeBase.PipelineTask):
         self.log.info("Associated DiaSources into %i DiaObjects",
                       len(assocResult.diaObjects))
 
-        if self.config.doAddDiaObjectCoords:
+        if self.config.doAddDiaObjectCoords and not assocResult.diaObjects.empty:
             assocResult.assocDiaSources = self._addDiaObjectCoords(assocResult.diaObjects,
                                                                    assocResult.assocDiaSources)
 

--- a/python/lsst/pipe/tasks/drpAssociationPipe.py
+++ b/python/lsst/pipe/tasks/drpAssociationPipe.py
@@ -82,6 +82,12 @@ class DrpAssociationPipeConfig(
         target=SimpleAssociationTask,
         doc="Task used to associate DiaSources with DiaObjects.",
     )
+    doAddDiaObjectCoords = pexConfig.Field(
+        dtype=bool,
+        default=True,
+        doc="Do pull diaObject's average coordinate as coord_ra and coord_dec"
+            "Duplicates information, but needed for bulk ingest into qserv."
+    )
 
 
 class DrpAssociationPipeTask(pipeBase.PipelineTask):
@@ -189,9 +195,18 @@ class DrpAssociationPipeTask(pipeBase.PipelineTask):
         self.log.info("Associated DiaSources into %i DiaObjects",
                       len(assocResult.diaObjects))
 
+        if self.config.doAddDiaObjectCoords:
+            assocResult.assocDiaSources = self._addDiaObjectCoords(assocResult.diaObjects,
+                                                                   assocResult.assocDiaSources)
+
         return pipeBase.Struct(
             diaObjectTable=assocResult.diaObjects,
             assocDiaSourceTable=assocResult.assocDiaSources)
+
+    def _addDiaObjectCoords(self, objects, sources):
+        obj = objects[['ra', 'decl']].rename(columns={"ra": "coord_ra", "decl": "coord_dec"})
+        df = pd.merge(sources, obj, left_on='diaObjectId', right_index=True, how='inner')
+        return df
 
     def _trimToPatch(self, cat, innerPatchBox, wcs):
         """Create generator testing if a set of DiaSources are in the

--- a/python/lsst/pipe/tasks/drpDiaCalculationPipe.py
+++ b/python/lsst/pipe/tasks/drpDiaCalculationPipe.py
@@ -134,6 +134,6 @@ class DrpDiaCalculationPipeTask(pipeBase.PipelineTask):
         result = self.diaCalculation.run(
             diaObjectTable,
             assocDiaSourceTable,
-            diaObjectTable["diaObjectId"].to_numpy(),
+            diaObjectTable.index.to_numpy(),
             self.config.filterNames)
         return pipeBase.Struct(fullDiaObjectTable=result.updatedDiaObjects)

--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -788,7 +788,7 @@ class TransformObjectCatalogConfig(TransformCatalogBaseConfig,
     )
     camelCase = pexConfig.Field(
         dtype=bool,
-        default=True,
+        default=False,
         doc=("Write per-band columns names with camelCase, else underscore "
              "For example: gPsFlux instead of g_PsFlux.")
     )

--- a/python/lsst/pipe/tasks/simpleAssociation.py
+++ b/python/lsst/pipe/tasks/simpleAssociation.py
@@ -95,6 +95,7 @@ class SimpleAssociationTask(pipeBase.Task):
         """
         # Sort by ccdVisit and diaSourceId to get a reproducible ordering for
         # the association.
+        diaSources.reset_index(inplace=True)
         diaSources.set_index(["ccdVisitId", "diaSourceId"], inplace=True)
 
         # Empty lists to store matching and location data.
@@ -184,12 +185,19 @@ class SimpleAssociationTask(pipeBase.Task):
                                          idCat,
                                          diaObjectCoords,
                                          healPixIndices)
+
         # Drop indices before returning associated diaSource catalog.
         diaSources.reset_index(inplace=True)
+        diaSources.set_index("diaSourceId", inplace=True, verify_integrity=True)
+
+        diaObjects = pd.DataFrame(data=diaObjectCat)
+        diaSources.reset_index(inplace=True)
+        if "diaObjectId" in diaObjects.columns:
+            diaObjects.set_index("diaObjectId", inplace=True, verify_integrity=True)
 
         return pipeBase.Struct(
             assocDiaSources=diaSources,
-            diaObjects=pd.DataFrame(data=diaObjectCat))
+            diaObjects=diaObjects)
 
     def addNewDiaObject(self,
                         diaSrc,

--- a/tests/test_simpleAssociation.py
+++ b/tests/test_simpleAssociation.py
@@ -115,9 +115,10 @@ class TestSimpleAssociation(lsst.utils.tests.TestCase):
         # Test the number of expected DiaObjects are created.
         self.assertEqual(len(result.diaObjects),
                          self.nDiaObjects + self.nNewDiaSources)
+
         # Test that DiaSources are assigned the correct ``diaObjectId``
-        assocDiaObjects = result.diaObjects.set_index(["diaObjectId"])
-        assocDiaSources = result.assocDiaSources.set_index(["diaObjectId", "diaSourceId"])
+        assocDiaObjects = result.diaObjects
+        assocDiaSources = result.assocDiaSources.reset_index().set_index(["diaObjectId", "diaSourceId"])
         for idx, (diaObjId, diaObj) in enumerate(assocDiaObjects.iterrows()):
             if idx < 10:
                 self.assertEqual(len(assocDiaSources.loc[diaObjId]), 2)

--- a/tests/test_transformObject.py
+++ b/tests/test_transformObject.py
@@ -55,6 +55,7 @@ class TransformObjectCatalogTestCase(unittest.TestCase):
         exist in the input data.
         """
         config = TransformObjectCatalogConfig()
+        config.camelCase = True
         # Want y band columns despite the input data do not have them
         # Exclude g band columns despite the input data have them
         config.outputBands = ["r", "i", "y"]


### PR DESCRIPTION
* all dataframes have primary keys as index only
* all final parquet table dataset names start with lowercase and end with `Table_visit` or `Table_tract` depending if its a visit or tract level dataset 
* object table columns look like `g_apFlux` instead of `gApFlux`
* All per-patch datasets are consolidated into a per-tract dataset


I promise to squash these before merging