### PR TITLE
DM-32124: Include tract in dimensions of intermediate forcedSource

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -126,14 +126,14 @@ tasks:
       key: diaObjectId
       connections.inputCatalogDiff: forced_diff_diaObject
       connections.inputCatalog: forced_src_diaObject
-      connections.outputCatalog: forcedSourceOnDiaObject
+      connections.outputCatalog: mergedForcedSourceOnDiaObject
   transformForcedSourceOnDiaObjectTable:
     class: lsst.pipe.tasks.postprocess.TransformForcedSourceTableTask
     config:
       referenceColumns: []
       keyRef: diaObjectId
       key: forcedSourceOnDiaObjectId
-      connections.inputCatalogs: forcedSourceOnDiaObject
+      connections.inputCatalogs: mergedForcedSourceOnDiaObject
       connections.outputCatalog: forcedSourceOnDiaObjectTable
       connections.referenceCatalog: goodSeeingDiff_fullDiaObjTable
   consolidateForcedSourceOnDiaObjectTable:

--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -1578,9 +1578,9 @@ class WriteForcedSourceTableConnections(pipeBase.PipelineTaskConnections,
     )
     outputCatalog = connectionTypes.Output(
         doc="InputCatalogs horizonatally joined on `objectId` in Parquet format",
-        name="forcedSource",
+        name="mergedForcedSource",
         storageClass="DataFrame",
-        dimensions=("instrument", "visit", "detector")
+        dimensions=("instrument", "visit", "detector", "skymap", "tract")
     )
 
 
@@ -1595,6 +1595,14 @@ class WriteForcedSourceTableConfig(WriteSourceTableConfig,
 
 class WriteForcedSourceTableTask(pipeBase.PipelineTask):
     """Merge and convert per-detector forced source catalogs to parquet
+
+    Because the predecessor ForcedPhotCcdTask operates per-detector,
+    per-tract, (i.e., it has tract in its dimensions), detectors
+    on the tract boundary may have multiple forced source catalogs.
+
+    The successor task TransformForcedSourceTable runs per-patch
+    and temporally-aggregates overlapping mergedForcedSource catalogs from all
+    available multiple epochs.
     """
     _DefaultName = "writeForcedSourceTable"
     ConfigClass = WriteForcedSourceTableConfig
@@ -1628,9 +1636,9 @@ class TransformForcedSourceTableConnections(pipeBase.PipelineTaskConnections,
 
     inputCatalogs = connectionTypes.Input(
         doc="Parquet table of merged ForcedSources produced by WriteForcedSourceTableTask",
-        name="forcedSource",
+        name="mergedForcedSource",
         storageClass="DataFrame",
-        dimensions=("instrument", "visit", "detector"),
+        dimensions=("instrument", "visit", "detector", "skymap", "tract"),
         multiple=True,
         deferLoad=True
     )


### PR DESCRIPTION
ForcedPhotCcdTask includes tract in its dimensions which means
that it produces an output catalog per-detector, per-tract.
WriteForcedSourceTableTask which merges catalogs of forced measurements from
calexps and diffims should do the same. TransformForcedSource temporally
aggregates the forcedSource catalogs per-patch anyway.

-rename forcedSourceTable to mergedForcedSourceTable because you cannot
change the dimensions  of an already registerd datasetType