### PR TITLE
DM-29955: Add ExposureInfo id getter

### DIFF
--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -451,6 +451,7 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
                                    dataId, numGoodPix[warpType],
                                    100.0*numGoodPix[warpType]/skyInfo.bbox.getArea(), warpType)
                     if numGoodPix[warpType] > 0 and not didSetMetadata[warpType]:
+                        coaddTempExp.info.id = exposure.info.id
                         coaddTempExp.setPhotoCalib(exposure.getPhotoCalib())
                         coaddTempExp.setFilterLabel(exposure.getFilterLabel())
                         coaddTempExp.getInfo().setVisitInfo(exposure.getInfo().getVisitInfo())

--- a/tests/test_coaddInputs.py
+++ b/tests/test_coaddInputs.py
@@ -95,6 +95,7 @@ class MockExposure:
         exp.setDetector(detector)
 
         expInfo = exp.getInfo()
+        expInfo.id = 10313423
         scale = 5.1e-5*lsst.geom.degrees
         cdMatrix = lsst.afw.geom.makeCdMatrix(scale=scale)
         wcs = lsst.afw.geom.makeSkyWcs(


### PR DESCRIPTION
This PR uses the `id` component added on lsst/afw#613.