### PR TITLE
DM-32124-v23: Include tract in dimensions of intermediate forcedSource

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -126,14 +126,14 @@ tasks:
       key: diaObjectId
       connections.inputCatalogDiff: forced_diff_diaObject
       connections.inputCatalog: forced_src_diaObject
-      connections.outputCatalog: forcedSourceOnDiaObject
+      connections.outputCatalog: mergedForcedSourceOnDiaObject
   transformForcedSourceOnDiaObjectTable:
     class: lsst.pipe.tasks.postprocess.TransformForcedSourceTableTask
     config:
       referenceColumns: []
       keyRef: diaObjectId
       key: forcedSourceOnDiaObjectId
-      connections.inputCatalogs: forcedSourceOnDiaObject
+      connections.inputCatalogs: mergedForcedSourceOnDiaObject
       connections.outputCatalog: forcedSourceOnDiaObjectTable
       connections.referenceCatalog: goodSeeingDiff_fullDiaObjTable
   consolidateForcedSourceOnDiaObjectTable:


### PR DESCRIPTION
ForcedPhotCcdTask includes tract in its dimensions which means
that it produces an output catalog per-detector, per-tract.
WriteForcedSourceTableTask which merges catalogs of forced measurements from
calexps and diffims should do the same. TransformForcedSource temporally
aggregates the forcedSource catalogs per-patch anyway.

-rename forcedSourceTable to mergedForcedSourceTable because you cannot
change the dimensions  of an already registerd datasetType