### PR TITLE
DM-13943: Deprecate VisitInfo.getExposureId()

### DIFF
--- a/python/lsst/pipe/tasks/imageDifference.py
+++ b/python/lsst/pipe/tasks/imageDifference.py
@@ -1038,7 +1038,7 @@ class ImageDifferenceTask(pipeBase.CmdLineTask, pipeBase.PipelineTask):
             if self.config.doSkySources:
                 skySourceFootprints = self.skySources.run(
                     mask=detectionExposure.mask,
-                    seed=detectionExposure.getInfo().getVisitInfo().getExposureId())
+                    seed=detectionExposure.info.id)
                 if skySourceFootprints:
                     for foot in skySourceFootprints:
                         s = diaSources.addNew()


### PR DESCRIPTION
This PR removes uses of `VisitInfo.getExposureId()`, which was deprecated in lsst/afw#614.