### PR TITLE
DM-32549: Supply position for psf shape computations

### DIFF
--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -915,7 +915,8 @@ class AssembleCoaddTask(CoaddBaseTask, pipeBase.PipelineTask):
             # Likewise, set the PSF of a PSF-Matched Coadd to the modelPsf
             # having the maximum width (sufficient because square)
             modelPsfList = [tempExp.getPsf() for tempExp in tempExpList]
-            modelPsfWidthList = [modelPsf.computeBBox().getWidth() for modelPsf in modelPsfList]
+            modelPsfWidthList = [modelPsf.computeBBox(modelPsf.getAveragePosition()).getWidth()
+                                 for modelPsf in modelPsfList]
             psf = modelPsfList[modelPsfWidthList.index(max(modelPsfWidthList))]
         else:
             psf = measAlg.CoaddPsf(coaddInputs.ccds, coaddExposure.getWcs(),

--- a/python/lsst/pipe/tasks/characterizeImage.py
+++ b/python/lsst/pipe/tasks/characterizeImage.py
@@ -493,8 +493,10 @@ class CharacterizeImageTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             )
 
             psf = dmeRes.exposure.getPsf()
-            psfSigma = psf.computeShape().getDeterminantRadius()
-            psfDimensions = psf.computeImage().getDimensions()
+            # Just need a rough estimate; average positions are fine
+            psfAvgPos = psf.getAveragePosition()
+            psfSigma = psf.computeShape(psfAvgPos).getDeterminantRadius()
+            psfDimensions = psf.computeImage(psfAvgPos).getDimensions()
             medBackground = np.median(dmeRes.background.getImage().getArray())
             self.log.info("iter %s; PSF sigma=%0.2f, dimensions=%s; median background=%0.2f",
                           i + 1, psfSigma, psfDimensions, medBackground)

--- a/python/lsst/pipe/tasks/dcrAssembleCoadd.py
+++ b/python/lsst/pipe/tasks/dcrAssembleCoadd.py
@@ -543,7 +543,9 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
                 visitInfo = warpExpRef.get(tempExpName + "_visitInfo")
                 psf = warpExpRef.get(tempExpName).getPsf()
             visit = warpExpRef.dataId["visit"]
-            psfSize = psf.computeShape().getDeterminantRadius()*sigma2fwhm
+            # Just need a rough estimate; average positions are fine
+            psfAvgPos = psf.getAveragePosition()
+            psfSize = psf.computeShape(psfAvgPos).getDeterminantRadius()*sigma2fwhm
             airmass = visitInfo.getBoresightAirmass()
             parallacticAngle = visitInfo.getBoresightParAngle().asDegrees()
             airmassDict[visit] = airmass
@@ -1319,7 +1321,10 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
         # Note: ``ccds`` is a `lsst.afw.table.ExposureCatalog` with one entry per ccd and per visit
         # If there are multiple ccds, it will have that many times more elements than ``warpExpRef``
         ccds = templateCoadd.getInfo().getCoaddInputs().ccds
-        psfRefSize = templateCoadd.getPsf().computeShape().getDeterminantRadius()*sigma2fwhm
+        templatePsf = templateCoadd.getPsf()
+        # Just need a rough estimate; average positions are fine
+        templateAvgPos = templatePsf.getAveragePosition()
+        psfRefSize = templatePsf.computeShape(templateAvgPos).getDeterminantRadius()*sigma2fwhm
         psfSizes = np.zeros(len(ccds))
         ccdVisits = np.array(ccds["visit"])
         for warpExpRef in warpRefList:
@@ -1330,7 +1335,8 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
                 # Gen 2 API. Delete this when Gen 2 retired
                 psf = warpExpRef.get(tempExpName).getPsf()
             visit = warpExpRef.dataId["visit"]
-            psfSize = psf.computeShape().getDeterminantRadius()*sigma2fwhm
+            psfAvgPos = psf.getAveragePosition()
+            psfSize = psf.computeShape(psfAvgPos).getDeterminantRadius()*sigma2fwhm
             psfSizes[ccdVisits == visit] = psfSize
         # Note that the input PSFs include DCR, which should be absent from the DcrCoadd
         # The selected PSFs are those that have a FWHM less than or equal to the smaller

--- a/python/lsst/pipe/tasks/selectImages.py
+++ b/python/lsst/pipe/tasks/selectImages.py
@@ -589,7 +589,9 @@ class BestSeeingWcsSelectImagesTask(WcsSelectImagesTask):
 
             # if min/max PSF values are defined, remove images out of bounds
             pixToArcseconds = cal.getWcs().getPixelScale().asArcseconds()
-            psfSize = cal.getPsf().computeShape().getDeterminantRadius()*pixToArcseconds
+            # Just need a rough estimate; average positions are fine
+            psfAvgPos = cal.getPsf().getAveragePosition()
+            psfSize = cal.getPsf().computeShape(psfAvgPos).getDeterminantRadius()*pixToArcseconds
             sizeFwhm = psfSize * np.sqrt(8.*np.log(2.))
             if self.config.maxPsfFwhm and sizeFwhm > self.config.maxPsfFwhm:
                 continue

--- a/tests/surveyPropertyMapsTestUtils.py
+++ b/tests/surveyPropertyMapsTestUtils.py
@@ -169,7 +169,8 @@ def makeMockVisitSummary(visit,
         # Generate a PSF and set values accordingly
         psf = GaussianPsf(15, 15, psf_sigma)
         row.setPsf(psf)
-        shape = psf.computeShape()
+        psfAvgPos = psf.getAveragePosition()
+        shape = psf.computeShape(psfAvgPos)
         row['psfSigma'] = psf.getSigma()
         row['psfIxx'] = shape.getIxx()
         row['psfIyy'] = shape.getIyy()

--- a/tests/test_coaddInputs.py
+++ b/tests/test_coaddInputs.py
@@ -199,8 +199,8 @@ class CoaddInputsTestCase(lsst.utils.tests.TestCase):
         del self.exposures
 
     def assertPsfsAlmostEqual(self, psf1, psf2):
-        im1 = psf1.computeImage()
-        im2 = psf2.computeImage()
+        im1 = psf1.computeImage(psf1.getAveragePosition())
+        im2 = psf2.computeImage(psf2.getAveragePosition())
         self.assertImagesAlmostEqual(im1, im2)
 
     def getCoaddPath(self, version):

--- a/tests/test_processCcd.py
+++ b/tests/test_processCcd.py
@@ -117,7 +117,9 @@ class ProcessCcdTestCase(lsst.utils.tests.TestCase):
 
                 summary = exposure.getInfo().getSummaryStats()
 
-                psfShape = exposure.getPsf().computeShape()
+                psf = exposure.getPsf()
+                psfAvgPos = psf.getAveragePosition()
+                psfShape = psf.computeShape(psfAvgPos)
                 psfIxx = psfShape.getIxx()
                 psfIyy = psfShape.getIyy()
                 psfIxy = psfShape.getIxy()


### PR DESCRIPTION
Note that the changes to ImageDifferenceTask are being done separately on DM-31777.