### PR TITLE
DM-32649: Add psf size and shape residual statistics to visitSummary

### DIFF
--- a/python/lsst/pipe/tasks/computeExposureSummaryStats.py
+++ b/python/lsst/pipe/tasks/computeExposureSummaryStats.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import warnings
 import numpy as np
+from scipy.stats import median_abs_deviation as sigmaMad
 import astropy.units as units
 from astropy.time import Time
 from astropy.coordinates import AltAz, SkyCoord, EarthLocation
@@ -53,6 +54,21 @@ class ComputeExposureSummaryStatsConfig(pexConfig.Config):
         doc="Mask planes that, if set, the associated pixel should not be included sky noise calculation.",
         default=("NO_DATA", "SUSPECT"),
     )
+    starSelection = pexConfig.Field(
+        doc="Field to select sources to be used in the PSF statistics computation.",
+        dtype=str,
+        default="calib_psf_used"
+    )
+    starShape = pexConfig.Field(
+        doc="Base name of columns to use for the source shape in the PSF statistics computation.",
+        dtype=str,
+        default="base_SdssShape"
+    )
+    psfShape = pexConfig.Field(
+        doc="Base name of columns to use for the PSF shape in the PSF statistics computation.",
+        dtype=str,
+        default="base_SdssShape_psf"
+    )
 
 
 class ComputeExposureSummaryStatsTask(pipeBase.Task):
@@ -76,6 +92,15 @@ class ComputeExposureSummaryStatsTask(pipeBase.Task):
     - decCorners
     - astromOffsetMean
     - astromOffsetStd
+
+    These additional quantities are computed from the stars in the detector:
+    - psfStarDeltaE1Median
+    - psfStarDeltaE2Median
+    - psfStarDeltaE1Scatter
+    - psfStarDeltaE2Scatter
+    - psfStarDeltaSizeMedian
+    - psfStarDeltaSizeScatter
+    - psfStarScaledDeltaSizeScatter
     """
     ConfigClass = ComputeExposureSummaryStatsConfig
     _DefaultName = "computeExposureSummaryStats"
@@ -191,21 +216,113 @@ class ComputeExposureSummaryStatsTask(pipeBase.Task):
             astromOffsetMean = np.nan
             astromOffsetStd = np.nan
 
-        summary = afwImage.ExposureSummaryStats(psfSigma=float(psfSigma),
-                                                psfArea=float(psfArea),
-                                                psfIxx=float(psfIxx),
-                                                psfIyy=float(psfIyy),
-                                                psfIxy=float(psfIxy),
-                                                ra=float(ra),
-                                                decl=float(decl),
-                                                zenithDistance=float(zenithDistance),
-                                                zeroPoint=float(zeroPoint),
-                                                skyBg=float(skyBg),
-                                                skyNoise=float(skyNoise),
-                                                meanVar=float(meanVar),
-                                                raCorners=raCorners,
-                                                decCorners=decCorners,
-                                                astromOffsetMean=astromOffsetMean,
-                                                astromOffsetStd=astromOffsetStd)
+        psfStats = self._computePsfStats(sources)
+
+        # Note that all numpy values have to be explicitly converted to
+        # python floats for yaml serialization.
+        summary = afwImage.ExposureSummaryStats(
+            psfSigma=float(psfSigma),
+            psfArea=float(psfArea),
+            psfIxx=float(psfIxx),
+            psfIyy=float(psfIyy),
+            psfIxy=float(psfIxy),
+            ra=float(ra),
+            decl=float(decl),
+            zenithDistance=float(zenithDistance),
+            zeroPoint=float(zeroPoint),
+            skyBg=float(skyBg),
+            skyNoise=float(skyNoise),
+            meanVar=float(meanVar),
+            raCorners=raCorners,
+            decCorners=decCorners,
+            astromOffsetMean=astromOffsetMean,
+            astromOffsetStd=astromOffsetStd,
+            nPsfStar=psfStats.nPsfStar,
+            psfStarDeltaE1Median=psfStats.psfStarDeltaE1Median,
+            psfStarDeltaE2Median=psfStats.psfStarDeltaE2Median,
+            psfStarDeltaE1Scatter=psfStats.psfStarDeltaE1Scatter,
+            psfStarDeltaE2Scatter=psfStats.psfStarDeltaE2Scatter,
+            psfStarDeltaSizeMedian=psfStats.psfStarDeltaSizeMedian,
+            psfStarDeltaSizeScatter=psfStats.psfStarDeltaSizeScatter,
+            psfStarScaledDeltaSizeScatter=psfStats.psfStarScaledDeltaSizeScatter
+        )
 
         return summary
+
+    def _computePsfStats(self, sources):
+        """Compute psf residual statistics.
+
+        All residuals are computed using median statistics on the difference
+        between the sources and the models.
+
+        Parameters
+        ----------
+        sources : `lsst.afw.table.SourceCatalog`
+            Source catalog on which to measure the PSF statistics.
+
+        Returns
+        -------
+        psfStats : `lsst.pipe.base.Struct`
+            Struct with various psf stats.
+        """
+        psfStats = pipeBase.Struct(nPsfStar=0,
+                                   psfStarDeltaE1Median=float(np.nan),
+                                   psfStarDeltaE2Median=float(np.nan),
+                                   psfStarDeltaE1Scatter=float(np.nan),
+                                   psfStarDeltaE2Scatter=float(np.nan),
+                                   psfStarDeltaSizeMedian=float(np.nan),
+                                   psfStarDeltaSizeScatter=float(np.nan),
+                                   psfStarScaledDeltaSizeScatter=float(np.nan))
+
+        if sources is None:
+            # No sources are available (as in some tests)
+            return psfStats
+
+        names = sources.schema.getNames()
+        if self.config.starSelection not in names or self.config.starShape + '_flag' not in names:
+            # The source catalog does not have the necessary fields (as in some tests)
+            return psfStats
+
+        mask = sources[self.config.starSelection] & (~sources[self.config.starShape + '_flag'])
+        nPsfStar = mask.sum()
+
+        if nPsfStar == 0:
+            # No stars to measure statistics, so we must return the defaults
+            # of 0 stars and NaN values.
+            return psfStats
+
+        starXX = sources[self.config.starShape + '_xx'][mask]
+        starYY = sources[self.config.starShape + '_yy'][mask]
+        starXY = sources[self.config.starShape + '_xy'][mask]
+        psfXX = sources[self.config.psfShape + '_xx'][mask]
+        psfYY = sources[self.config.psfShape + '_yy'][mask]
+        psfXY = sources[self.config.psfShape + '_xy'][mask]
+
+        starSize = (starXX*starYY - starXY**2.)**0.25
+        starE1 = (starXX - starYY)/(starXX + starYY)
+        starE2 = 2*starXY/(starXX + starYY)
+        starSizeMedian = np.median(starSize)
+
+        psfSize = (psfXX*psfYY - psfXY**2)**0.25
+        psfE1 = (psfXX - psfYY)/(psfXX + psfYY)
+        psfE2 = 2*psfXY/(psfXX + psfYY)
+
+        psfStarDeltaE1Median = np.median(starE1 - psfE1)
+        psfStarDeltaE1Scatter = sigmaMad(starE1 - psfE1, scale='normal')
+        psfStarDeltaE2Median = np.median(starE2 - psfE2)
+        psfStarDeltaE2Scatter = sigmaMad(starE2 - psfE2, scale='normal')
+
+        psfStarDeltaSizeMedian = np.median(starSize - psfSize)
+        psfStarDeltaSizeScatter = sigmaMad(starSize - psfSize, scale='normal')
+        psfStarScaledDeltaSizeScatter = psfStarDeltaSizeScatter/starSizeMedian**2.
+
+        psfStats.nPsfStar = int(nPsfStar)
+        psfStats.psfStarDeltaE1Median = float(psfStarDeltaE1Median)
+        psfStats.psfStarDeltaE2Median = float(psfStarDeltaE2Median)
+        psfStats.psfStarDeltaE1Scatter = float(psfStarDeltaE1Scatter)
+        psfStats.psfStarDeltaE2Scatter = float(psfStarDeltaE2Scatter)
+        psfStats.psfStarDeltaSizeMedian = float(psfStarDeltaSizeMedian)
+        psfStats.psfStarDeltaSizeScatter = float(psfStarDeltaSizeScatter)
+        psfStats.psfStarScaledDeltaSizeScatter = float(psfStarScaledDeltaSizeScatter)
+
+        return psfStats

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -675,7 +675,7 @@ class MakeWarpConnections(pipeBase.PipelineTaskConnections,
     )
     visitSummary = connectionTypes.Input(
         doc="Consolidated exposure metadata from ConsolidateVisitSummaryTask",
-        name="visitSummary",
+        name="{calexpType}visitSummary",
         storageClass="ExposureCatalog",
         dimensions=("instrument", "visit",),
     )

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -673,12 +673,11 @@ class MakeWarpConnections(pipeBase.PipelineTaskConnections,
         dimensions=("instrument", "visit", "detector"),
         multiple=True,
     )
-    srcList = connectionTypes.Input(
-        doc="src catalogs used by PsfWcsSelectImages subtask to further select on PSF stability",
-        name="src",
-        storageClass="SourceCatalog",
-        dimensions=("instrument", "visit", "detector"),
-        multiple=True,
+    visitSummary = connectionTypes.Input(
+        doc="Consolidated exposure metadata from ConsolidateVisitSummaryTask",
+        name="visitSummary",
+        storageClass="ExposureCatalog",
+        dimensions=("instrument", "visit",),
     )
 
     def __init__(self, *, config=None):
@@ -708,9 +707,8 @@ class MakeWarpConnections(pipeBase.PipelineTaskConnections,
         if not config.makePsfMatched:
             self.outputs.remove("psfMatched")
         # TODO DM-28769: add connection per selectImages connections
-        # instead of removing if not PsfWcsSelectImagesTask here:
         if config.select.target != lsst.pipe.tasks.selectImages.PsfWcsSelectImagesTask:
-            self.inputs.remove("srcList")
+            self.inputs.remove("visitSummary")
 
 
 class MakeWarpConfig(pipeBase.PipelineTaskConfig, MakeCoaddTempExpConfig,

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -680,13 +680,6 @@ class MakeWarpConnections(pipeBase.PipelineTaskConnections,
         dimensions=("instrument", "visit", "detector"),
         multiple=True,
     )
-    psfList = connectionTypes.Input(
-        doc="PSF models used by BestSeeingWcsSelectImages subtask to futher select on seeing",
-        name="{calexpType}calexp.psf",
-        storageClass="Psf",
-        dimensions=("instrument", "visit", "detector"),
-        multiple=True,
-    )
 
     def __init__(self, *, config=None):
         super().__init__(config=config)
@@ -718,8 +711,6 @@ class MakeWarpConnections(pipeBase.PipelineTaskConnections,
         # instead of removing if not PsfWcsSelectImagesTask here:
         if config.select.target != lsst.pipe.tasks.selectImages.PsfWcsSelectImagesTask:
             self.inputs.remove("srcList")
-        if config.select.target != lsst.pipe.tasks.selectImages.BestSeeingWcsSelectImagesTask:
-            self.inputs.remove("psfList")
 
 
 class MakeWarpConfig(pipeBase.PipelineTaskConfig, MakeCoaddTempExpConfig,

--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -1244,6 +1244,14 @@ class ConsolidateVisitSummaryTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             rec['meanVar'] = summaryStats.meanVar
             rec['astromOffsetMean'] = summaryStats.astromOffsetMean
             rec['astromOffsetStd'] = summaryStats.astromOffsetStd
+            rec['nPsfStar'] = summaryStats.nPsfStar
+            rec['psfStarDeltaE1Median'] = summaryStats.psfStarDeltaE1Median
+            rec['psfStarDeltaE2Median'] = summaryStats.psfStarDeltaE2Median
+            rec['psfStarDeltaE1Scatter'] = summaryStats.psfStarDeltaE1Scatter
+            rec['psfStarDeltaE2Scatter'] = summaryStats.psfStarDeltaE2Scatter
+            rec['psfStarDeltaSizeMedian'] = summaryStats.psfStarDeltaSizeMedian
+            rec['psfStarDeltaSizeScatter'] = summaryStats.psfStarDeltaSizeScatter
+            rec['psfStarScaledDeltaSizeScatter'] = summaryStats.psfStarScaledDeltaSizeScatter
 
         metadata = dafBase.PropertyList()
         metadata.add("COMMENT", "Catalog id is detector id, sorted.")
@@ -1292,6 +1300,21 @@ class ConsolidateVisitSummaryTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                         doc='Mean offset of astrometric calibration matches (arcsec)')
         schema.addField('astromOffsetStd', type='F',
                         doc='Standard deviation of offsets of astrometric calibration matches (arcsec)')
+        schema.addField('nPsfStar', type='I', doc='Number of stars used for PSF model')
+        schema.addField('psfStarDeltaE1Median', type='F',
+                        doc='Median E1 residual (starE1 - psfE1) for psf stars')
+        schema.addField('psfStarDeltaE2Median', type='F',
+                        doc='Median E2 residual (starE2 - psfE2) for psf stars')
+        schema.addField('psfStarDeltaE1Scatter', type='F',
+                        doc='Scatter (via MAD) of E1 residual (starE1 - psfE1) for psf stars')
+        schema.addField('psfStarDeltaE2Scatter', type='F',
+                        doc='Scatter (via MAD) of E2 residual (starE2 - psfE2) for psf stars')
+        schema.addField('psfStarDeltaSizeMedian', type='F',
+                        doc='Median size residual (starSize - psfSize) for psf stars (pixel)')
+        schema.addField('psfStarDeltaSizeScatter', type='F',
+                        doc='Scatter (via MAD) of size residual (starSize - psfSize) for psf stars (pixel)')
+        schema.addField('psfStarScaledDeltaSizeScatter', type='F',
+                        doc='Scatter (via MAD) of size residual scaled by median size squared')
 
         return schema
 


### PR DESCRIPTION
This PR moves the gen3 `PsfWcsSelectImagesTask` to using the visitSummary table and removes the source connection, which should speed up i/o.  

For gen2, we don't have the visitSummary tables so I left in the legacy computation, and this can be removed with the rest of the gen2 code when the time comes.