### PR TITLE
DM-31964: Fixup dimensions on ProcessCcdWithFakesTask/MatchFakesTask

### DIFF
--- a/python/lsst/pipe/tasks/matchFakes.py
+++ b/python/lsst/pipe/tasks/matchFakes.py
@@ -157,8 +157,8 @@ class MatchFakesTask(PipelineTask):
         trimmedFakes = self._trimFakeCat(fakeCat, diffIm)
         nPossibleFakes = len(trimmedFakes)
 
-        fakeVects = self._getVectors(trimmedFakes[self.config.raColName],
-                                     trimmedFakes[self.config.decColName])
+        fakeVects = self._getVectors(trimmedFakes[self.config.ra_col],
+                                     trimmedFakes[self.config.dec_col])
         diaSrcVects = self._getVectors(
             np.radians(associatedDiaSources.loc[:, "ra"]),
             np.radians(associatedDiaSources.loc[:, "decl"]))

--- a/python/lsst/pipe/tasks/matchFakes.py
+++ b/python/lsst/pipe/tasks/matchFakes.py
@@ -233,8 +233,8 @@ class MatchFakesTask(PipelineTask):
         bbox = Box2D(image.getBBox())
 
         def trim(row):
-            coord = SpherePoint(row[self.config.raColName],
-                                row[self.config.decColName],
+            coord = SpherePoint(row[self.config.ra_col],
+                                row[self.config.dec_col],
                                 radians)
             cent = wcs.skyToPixel(coord)
             return bbox.contains(cent)

--- a/python/lsst/pipe/tasks/matchFakes.py
+++ b/python/lsst/pipe/tasks/matchFakes.py
@@ -204,8 +204,8 @@ class MatchFakesTask(PipelineTask):
             tractId = fakeCatRef.dataId["tract"]
             # Make sure all data is within the inner part of the tract.
             outputCat.append(cat[
-                skyMap.findTractIdArray(cat[self.config.raColName],
-                                        cat[self.config.decColName],
+                skyMap.findTractIdArray(cat[self.config.ra_col],
+                                        cat[self.config.dec_col],
                                         degrees=False)
                 == tractId])
 

--- a/python/lsst/pipe/tasks/matchFakes.py
+++ b/python/lsst/pipe/tasks/matchFakes.py
@@ -21,12 +21,15 @@
 
 import astropy.units as u
 import numpy as np
+import pandas as pd
 from scipy.spatial import cKDTree
 
 from lsst.geom import Box2D, radians, SpherePoint
 import lsst.pex.config as pexConfig
 from lsst.pipe.base import PipelineTask, PipelineTaskConnections, Struct
 import lsst.pipe.base.connectionTypes as connTypes
+from lsst.skymap import BaseSkyMap
+
 from lsst.pipe.tasks.insertFakes import InsertFakesConfig
 
 __all__ = ["MatchFakesTask",
@@ -38,16 +41,23 @@ __all__ = ["MatchFakesTask",
 class MatchFakesConnections(PipelineTaskConnections,
                             defaultTemplates={"coaddName": "deep",
                                               "fakesType": "fakes_"},
-                            dimensions=("tract",
-                                        "skymap",
-                                        "instrument",
+                            dimensions=("instrument",
                                         "visit",
                                         "detector")):
-    fakeCat = connTypes.Input(
+    skyMap = connTypes.Input(
+        doc="Input definition of geometry/bbox and projection/wcs for "
+        "template exposures. Needed to test which tract to generate ",
+        name=BaseSkyMap.SKYMAP_DATASET_TYPE_NAME,
+        dimensions=("skymap",),
+        storageClass="SkyMap",
+    )
+    fakeCats = connTypes.Input(
         doc="Catalog of fake sources inserted into an image.",
         name="{fakesType}fakeSourceCat",
         storageClass="DataFrame",
-        dimensions=("tract", "skymap")
+        dimensions=("tract", "skymap"),
+        deferLoad=True,
+        multiple=True
     )
     diffIm = connTypes.Input(
         doc="Difference image on which the DiaSources were detected.",
@@ -98,13 +108,33 @@ class MatchFakesTask(PipelineTask):
     _DefaultName = "matchFakes"
     ConfigClass = MatchFakesConfig
 
-    def runQuantum(self, butlerQC, inputRefs, outputRefs):
-        inputs = butlerQC.get(inputRefs)
+    def run(self, fakeCats, skyMap, diffIm, associatedDiaSources):
+        """Compose fakes into a single catalog and match fakes to detected
+        diaSources within a difference image bound.
 
-        outputs = self.run(**inputs)
-        butlerQC.put(outputs, outputRefs)
+        Parameters
+        ----------
+        fakeCats : `pandas.DataFrame`
+            List of catalog of fakes to match to detected diaSources.
+        skyMap : `lsst.skymap.SkyMap`
+            SkyMap defining the tracts and patches the fakes are stored over.
+        diffIm : `lsst.afw.image.Exposure`
+            Difference image where ``associatedDiaSources`` were detected.
+        associatedDiaSources : `pandas.DataFrame`
+            Catalog of difference image sources detected in ``diffIm``.
 
-    def run(self, fakeCat, diffIm, associatedDiaSources):
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            Results struct with components.
+
+            - ``matchedDiaSources`` : Fakes matched to input diaSources. Has
+              length of ``fakeCat``. (`pandas.DataFrame`)
+        """
+        fakeCat = self.composeFakeCat(fakeCats, skyMap)
+        return self._processFakes(fakeCat, diffIm, associatedDiaSources)
+
+    def _processFakes(self, fakeCat, diffIm, associatedDiaSources):
         """Match fakes to detected diaSources within a difference image bound.
 
         Parameters
@@ -148,6 +178,39 @@ class MatchFakesTask(PipelineTask):
                 associatedDiaSources.reset_index(drop=True), on="diaSourceId", how="left")
         )
 
+    def composeFakeCat(self, fakeCats, skyMap):
+        """Concatenate the fakeCats from tracts that may cover the exposure.
+
+        Parameters
+        ----------
+        fakeCats : `list` of `lst.daf.butler.DeferredDatasetHandle`
+            Set of fake cats to concatenate.
+        skyMap : `lsst.skymap.SkyMap`
+            SkyMap defining the geometry of the tracts and patches.
+
+        Returns
+        -------
+        combinedFakeCat : `pandas.DataFrame`
+            All fakes that cover the inner polygon of the tracts in this
+            quantum.
+        """
+        if len(fakeCats) == 1:
+            return fakeCats[0].get(
+                datasetType=self.config.connections.fakeCats)
+        outputCat = []
+        for fakeCatRef in fakeCats:
+            cat = fakeCatRef.get(
+                datasetType=self.config.connections.fakeCats)
+            tractId = fakeCatRef.dataId["tract"]
+            # Make sure all data is within the inner part of the tract.
+            outputCat.append(cat[
+                skyMap.findTractIdArray(cat[self.config.raColName],
+                                        cat[self.config.decColName],
+                                        degrees=False)
+                == tractId])
+
+        return pd.concat(outputCat)
+
     def _trimFakeCat(self, fakeCat, image):
         """Trim the fake cat to about the size of the input image.
 
@@ -157,10 +220,12 @@ class MatchFakesTask(PipelineTask):
             The catalog of fake sources to be input
         image : `lsst.afw.image.exposure.exposure.ExposureF`
             The image into which the fake sources should be added
+        skyMap : `lsst.skymap.SkyMap`
+            SkyMap defining the tracts and patches the fakes are stored over.
 
         Returns
         -------
-        fakeCat : `pandas.core.frame.DataFrame`
+        fakeCats : `pandas.core.frame.DataFrame`
             The original fakeCat trimmed to the area of the image
         """
         wcs = image.getWcs()
@@ -235,7 +300,7 @@ class MatchVariableFakesTask(MatchFakesTask):
         outputs = self.run(**inputs)
         butlerQC.put(outputs, outputRefs)
 
-    def run(self, fakeCat, ccdVisitFakeMagnitudes, diffIm, associatedDiaSources, band):
+    def run(self, fakeCats, ccdVisitFakeMagnitudes, skyMap, diffIm, associatedDiaSources, band):
         """Match fakes to detected diaSources within a difference image bound.
 
         Parameters
@@ -255,8 +320,9 @@ class MatchVariableFakesTask(MatchFakesTask):
             - ``matchedDiaSources`` : Fakes matched to input diaSources. Has
               length of ``fakeCat``. (`pandas.DataFrame`)
         """
+        fakeCat = self.composeFakeCat(fakeCats, skyMap)
         self.computeExpectedDiffMag(fakeCat, ccdVisitFakeMagnitudes, band)
-        return super().run(fakeCat, diffIm, associatedDiaSources)
+        return self._processFakes(fakeCat, diffIm, associatedDiaSources)
 
     def computeExpectedDiffMag(self, fakeCat, ccdVisitFakeMagnitudes, band):
         """Compute the magnitude expected in the difference image for this

--- a/python/lsst/pipe/tasks/processCcdWithFakes.py
+++ b/python/lsst/pipe/tasks/processCcdWithFakes.py
@@ -378,8 +378,9 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
                     break
             if externalSkyWcsCatalog is None:
                 usedTract = externalSkyWcsCatalogList[-1].dataId["tract"]
-                self.log.warn(f"Warning, external SkyWcs for tract {tractId} not "
-                               "found. Using tract {usedTract} instead.")
+                self.log.warn(
+                    f"Warning, external SkyWcs for tract {tractId} not found. Using tract {usedTract} "
+                    "instead.")
                 externalSkyWcsCatalog = externalSkyWcsCatalogList[-1].get(
                     datasetType=self.config.connections.externalSkyWcsTractCatalog)
             row = externalSkyWcsCatalog.find(detectorId)
@@ -401,8 +402,9 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
                     break
             if externalPhotoCalibCatalog is None:
                 usedTract = externalPhotoCalibCatalogList[-1].dataId["tract"]
-                self.log.warn(f"Warning, external PhotoCalib for tract {tractId} not "
-                               "found. Using tract {usedTract} instead.")
+                self.log.warn(
+                    f"Warning, external PhotoCalib for tract {tractId} not found. Using tract {usedTract} "
+                    "instead.")
                 externalPhotoCalibCatalog = externalPhotoCalibCatalogList[-1].get(
                     datasetType=self.config.connections.externalPhotoCalibCatalog)
             row = externalPhotoCalibCatalog.find(detectorId)

--- a/python/lsst/pipe/tasks/processCcdWithFakes.py
+++ b/python/lsst/pipe/tasks/processCcdWithFakes.py
@@ -378,7 +378,7 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
                     break
             if externalSkyWcsCatalog is None:
                 usedTract = externalSkyWcsCatalogList[-1].dataId["tract"]
-                self.log.warn(f"Warning, PhotoCalib for tract {tractId} not "
+                self.log.warn(f"Warning, SkyWcs for tract {tractId} not "
                                "found. Using tract {usedTract} instead.")
                 externalSkyWcsCatalog = externalSkyWcsCatalogList[-1].get(
                     datasetType=self.config.connections.externalSkyWcsTractCatalog)

--- a/python/lsst/pipe/tasks/processCcdWithFakes.py
+++ b/python/lsst/pipe/tasks/processCcdWithFakes.py
@@ -378,7 +378,7 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
                     break
             if externalSkyWcsCatalog is None:
                 usedTract = externalSkyWcsCatalogList[-1].dataId["tract"]
-                self.log.warn(f"Warning, SkyWcs for tract {tractId} not "
+                self.log.warn(f"Warning, external SkyWcs for tract {tractId} not "
                                "found. Using tract {usedTract} instead.")
                 externalSkyWcsCatalog = externalSkyWcsCatalogList[-1].get(
                     datasetType=self.config.connections.externalSkyWcsTractCatalog)
@@ -401,7 +401,7 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
                     break
             if externalPhotoCalibCatalog is None:
                 usedTract = externalPhotoCalibCatalogList[-1].dataId["tract"]
-                self.log.warn(f"Warning, PhotoCalib for tract {tractId} not "
+                self.log.warn(f"Warning, external PhotoCalib for tract {tractId} not "
                                "found. Using tract {usedTract} instead.")
                 externalPhotoCalibCatalog = externalPhotoCalibCatalogList[-1].get(
                     datasetType=self.config.connections.externalPhotoCalibCatalog)

--- a/python/lsst/pipe/tasks/processCcdWithFakes.py
+++ b/python/lsst/pipe/tasks/processCcdWithFakes.py
@@ -398,7 +398,7 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
             for externalPhotoCalibCatalogRef in externalPhotoCalibCatalogList:
                 if externalPhotoCalibCatalogRef.dataId["tract"] == tractId:
                     externalPhotoCalibCatalog = externalPhotoCalibCatalogRef.get(
-                        datasetType=self.config.connections.externalPhotoCalibCatalog)
+                        datasetType=self.config.connections.externalPhotoCalibTractCatalog)
                     break
             if externalPhotoCalibCatalog is None:
                 usedTract = externalPhotoCalibCatalogList[-1].dataId["tract"]
@@ -406,7 +406,7 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
                     f"Warning, external PhotoCalib for tract {tractId} not found. Using tract {usedTract} "
                     "instead.")
                 externalPhotoCalibCatalog = externalPhotoCalibCatalogList[-1].get(
-                    datasetType=self.config.connections.externalPhotoCalibCatalog)
+                    datasetType=self.config.connections.externalPhotoCalibTractCatalog)
             row = externalPhotoCalibCatalog.find(detectorId)
             inputs["photoCalib"] = row.getPhotoCalib()
 

--- a/python/lsst/pipe/tasks/processCcdWithFakes.py
+++ b/python/lsst/pipe/tasks/processCcdWithFakes.py
@@ -36,6 +36,7 @@ from lsst.obs.base import ExposureIdInfo
 from lsst.pipe.base import PipelineTask, PipelineTaskConfig, CmdLineTask, PipelineTaskConnections
 import lsst.pipe.base.connectionTypes as cT
 import lsst.afw.table as afwTable
+from lsst.skymap import BaseSkyMap
 from lsst.pipe.tasks.calibrate import CalibrateTask
 
 __all__ = ["ProcessCcdWithFakesConfig", "ProcessCcdWithFakesTask",
@@ -43,11 +44,18 @@ __all__ = ["ProcessCcdWithFakesConfig", "ProcessCcdWithFakesTask",
 
 
 class ProcessCcdWithFakesConnections(PipelineTaskConnections,
-                                     dimensions=("skymap", "tract", "instrument", "visit", "detector"),
+                                     dimensions=("instrument", "visit", "detector"),
                                      defaultTemplates={"coaddName": "deep",
                                                        "wcsName": "jointcal",
                                                        "photoCalibName": "jointcal",
                                                        "fakesType": "fakes_"}):
+    skyMap = cT.Input(
+        doc="Input definition of geometry/bbox and projection/wcs for "
+        "template exposures. Needed to test which tract to generate ",
+        name=BaseSkyMap.SKYMAP_DATASET_TYPE_NAME,
+        dimensions=("skymap",),
+        storageClass="SkyMap",
+    )
 
     exposure = cT.Input(
         doc="Exposure into which fakes are to be added.",
@@ -56,11 +64,15 @@ class ProcessCcdWithFakesConnections(PipelineTaskConnections,
         dimensions=("instrument", "visit", "detector")
     )
 
-    fakeCat = cT.Input(
-        doc="Catalog of fake sources to draw inputs from.",
+    fakeCats = cT.Input(
+        doc="Set of catalogs of fake sources to draw inputs from. We will "
+            "from one of these that fully contains our exposure or the is "
+            "closest the visit boresight.",
         name="{fakesType}fakeSourceCat",
         storageClass="DataFrame",
-        dimensions=("tract", "skymap")
+        dimensions=("tract", "skymap"),
+        deferLoad=True,
+        multiple=True,
     )
 
     externalSkyWcsTractCatalog = cT.Input(
@@ -69,6 +81,8 @@ class ProcessCcdWithFakesConnections(PipelineTaskConnections,
         name="{wcsName}SkyWcsCatalog",
         storageClass="ExposureCatalog",
         dimensions=("instrument", "visit", "tract", "skymap"),
+        deferLoad=True,
+        multiple=True,
     )
 
     externalSkyWcsGlobalCatalog = cT.Input(
@@ -86,6 +100,8 @@ class ProcessCcdWithFakesConnections(PipelineTaskConnections,
         name="{photoCalibName}PhotoCalibCatalog",
         storageClass="ExposureCatalog",
         dimensions=("instrument", "visit", "tract"),
+        deferLoad=True,
+        multiple=True,
     )
 
     externalPhotoCalibGlobalCatalog = cT.Input(
@@ -343,29 +359,38 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
             expId, expBits = butlerQC.quantum.dataId.pack("visit_detector", returnMaxBits=True)
             inputs['exposureIdInfo'] = ExposureIdInfo(expId, expBits)
 
+        expWcs = inputs["exposure"].getWcs()
+        tractId = inputs["skyMap"].findTract(
+            expWcs.pixelToSky(inputs["exposure"].getBBox().getCenter())).tract_id
         if not self.config.doApplyExternalGlobalSkyWcs and not self.config.doApplyExternalTractSkyWcs:
-            inputs["wcs"] = inputs["exposure"].getWcs()
-
+            inputs["wcs"] = expWcs
         elif self.config.doApplyExternalGlobalSkyWcs:
             externalSkyWcsCatalog = inputs["externalSkyWcsGlobalCatalog"]
             row = externalSkyWcsCatalog.find(detectorId)
             inputs["wcs"] = row.getWcs()
-
         elif self.config.doApplyExternalTractSkyWcs:
-            externalSkyWcsCatalog = inputs["externalSkyWcsTractCatalog"]
+            externalSkyWcsCatalogList = inputs["externalSkyWcsTractCatalog"]
+            for externalSkyWcsCatalogRef in externalSkyWcsCatalogList:
+                if externalSkyWcsCatalogRef.dataId["tract"] == tractId:
+                    externalSkyWcsCatalog = externalSkyWcsCatalogRef.get(
+                        datasetType=self.config.connections.externalSkyWcsTractCatalog)
+                    break
             row = externalSkyWcsCatalog.find(detectorId)
             inputs["wcs"] = row.getWcs()
 
         if not self.config.doApplyExternalGlobalPhotoCalib and not self.config.doApplyExternalTractPhotoCalib:
             inputs["photoCalib"] = inputs["exposure"].getPhotoCalib()
-
         elif self.config.doApplyExternalGlobalPhotoCalib:
             externalPhotoCalibCatalog = inputs["externalPhotoCalibGlobalCatalog"]
             row = externalPhotoCalibCatalog.find(detectorId)
             inputs["photoCalib"] = row.getPhotoCalib()
-
         elif self.config.doApplyExternalTractPhotoCalib:
-            externalPhotoCalibCatalog = inputs["externalPhotoCalibTractCatalog"]
+            externalPhotoCalibCatalogList = inputs["externalPhotoCalibTractCatalog"]
+            for externalPhotoCalibCatalogRef in externalPhotoCalibCatalogList:
+                if externalPhotoCalibCatalogRef.dataId["tract"] == tractId:
+                    externalPhotoCalibCatalog = externalPhotoCalibCatalogRef.get(
+                        datasetType=self.config.connections.externalSkyWcsTractCatalog)
+                    break
             row = externalPhotoCalibCatalog.find(detectorId)
             inputs["photoCalib"] = row.getPhotoCalib()
 
@@ -380,9 +405,10 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
                                ContainerClass=PerTractCcdDataIdContainer)
         return parser
 
-    def run(self, fakeCat, exposure, wcs=None, photoCalib=None, exposureIdInfo=None, icSourceCat=None,
-            sfdSourceCat=None, externalSkyWcsGlobalCatalog=None, externalSkyWcsTractCatalog=None,
-            externalPhotoCalibGlobalCatalog=None, externalPhotoCalibTractCatalog=None):
+    def run(self, fakeCats, exposure, skyMap, wcs=None, photoCalib=None, exposureIdInfo=None,
+            icSourceCat=None, sfdSourceCat=None, externalSkyWcsGlobalCatalog=None,
+            externalSkyWcsTractCatalog=None, externalPhotoCalibGlobalCatalog=None,
+            externalPhotoCalibTractCatalog=None):
         """Add fake sources to a calexp and then run detection, deblending and measurement.
 
         Parameters
@@ -391,6 +417,8 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
                     The catalog of fake sources to add to the exposure
         exposure : `lsst.afw.image.exposure.exposure.ExposureF`
                     The exposure to add the fake sources to
+        skyMap : `lsst.skymap.SkyMap`
+            SkyMap defining the tracts and patches the fakes are stored over.
         wcs : `lsst.afw.geom.SkyWcs`
                     WCS to use to add fake sources
         photoCalib : `lsst.afw.image.photoCalib.PhotoCalib`
@@ -425,6 +453,7 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
 
         If exposureIdInfo is not provided then the SourceCatalog IDs will not be globally unique.
         """
+        fakeCat = self.composeFakeCat(fakeCats, skyMap)
 
         if wcs is None:
             wcs = exposure.getWcs()
@@ -444,6 +473,39 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
 
         resultStruct = pipeBase.Struct(outputExposure=exposure, outputCat=sourceCat)
         return resultStruct
+
+    def composeFakeCat(self, fakeCats, skyMap):
+        """Concatenate the fakeCats from tracts that may cover the exposure.
+
+        Parameters
+        ----------
+        fakeCats : `list` of `lst.daf.butler.DeferredDatasetHandle`
+            Set of fake cats to concatenate.
+        skyMap : `lsst.skymap.SkyMap`
+            SkyMap defining the geometry of the tracts and patches.
+
+        Returns
+        -------
+        combinedFakeCat : `pandas.DataFrame`
+            All fakes that cover the inner polygon of the tracts in this
+            quantum.
+        """
+        if len(fakeCats) == 1:
+            return fakeCats[0].get(
+                datasetType=self.config.connections.fakeCats)
+        outputCat = []
+        for fakeCatRef in fakeCats:
+            cat = fakeCatRef.get(
+                datasetType=self.config.connections.fakeCats)
+            tractId = fakeCatRef.dataId["tract"]
+            # Make sure all data is within the inner part of the tract.
+            outputCat.append(cat[
+                skyMap.findTractIdArray(cat[self.config.insertFakes.raColName],
+                                        cat[self.config.insertFakes.decColName],
+                                        degrees=False)
+                == tractId])
+
+        return pd.concat(outputCat)
 
     def copyCalibrationFields(self, calibCat, sourceCat, fieldsToCopy):
         """Match sources in calibCat and sourceCat and copy the specified fields
@@ -566,8 +628,8 @@ class ProcessCcdWithVariableFakesTask(ProcessCcdWithFakesTask):
     _DefaultName = "processCcdWithVariableFakes"
     ConfigClass = ProcessCcdWithVariableFakesConfig
 
-    def run(self, fakeCat, exposure, wcs=None, photoCalib=None, exposureIdInfo=None, icSourceCat=None,
-            sfdSourceCat=None):
+    def run(self, fakeCats, exposure, skyMap, wcs=None, photoCalib=None, exposureIdInfo=None,
+            icSourceCat=None, sfdSourceCat=None):
         """Add fake sources to a calexp and then run detection, deblending and measurement.
 
         Parameters
@@ -576,6 +638,8 @@ class ProcessCcdWithVariableFakesTask(ProcessCcdWithFakesTask):
                     The catalog of fake sources to add to the exposure
         exposure : `lsst.afw.image.exposure.exposure.ExposureF`
                     The exposure to add the fake sources to
+        skyMap : `lsst.skymap.SkyMap`
+            SkyMap defining the tracts and patches the fakes are stored over.
         wcs : `lsst.afw.geom.SkyWcs`
                     WCS to use to add fake sources
         photoCalib : `lsst.afw.image.photoCalib.PhotoCalib`
@@ -616,6 +680,8 @@ class ProcessCcdWithVariableFakesTask(ProcessCcdWithFakesTask):
 
         If exposureIdInfo is not provided then the SourceCatalog IDs will not be globally unique.
         """
+        fakeCat = self.composeFakeCat(fakeCats, skyMap)
+
         if wcs is None:
             wcs = exposure.getWcs()
 

--- a/python/lsst/pipe/tasks/processCcdWithFakes.py
+++ b/python/lsst/pipe/tasks/processCcdWithFakes.py
@@ -370,11 +370,18 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
             inputs["wcs"] = row.getWcs()
         elif self.config.doApplyExternalTractSkyWcs:
             externalSkyWcsCatalogList = inputs["externalSkyWcsTractCatalog"]
+            externalSkyWcsCatalog = None
             for externalSkyWcsCatalogRef in externalSkyWcsCatalogList:
                 if externalSkyWcsCatalogRef.dataId["tract"] == tractId:
                     externalSkyWcsCatalog = externalSkyWcsCatalogRef.get(
                         datasetType=self.config.connections.externalSkyWcsTractCatalog)
                     break
+            if externalSkyWcsCatalog is None:
+                usedTract = externalSkyWcsCatalogList[-1].dataId["tract"]
+                self.log.warn(f"Warning, PhotoCalib for tract {tractId} not "
+                               "found. Using tract {usedTract} instead.")
+                externalSkyWcsCatalog = externalSkyWcsCatalogList[-1].get(
+                    datasetType=self.config.connections.externalSkyWcsTractCatalog)
             row = externalSkyWcsCatalog.find(detectorId)
             inputs["wcs"] = row.getWcs()
 
@@ -386,11 +393,18 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
             inputs["photoCalib"] = row.getPhotoCalib()
         elif self.config.doApplyExternalTractPhotoCalib:
             externalPhotoCalibCatalogList = inputs["externalPhotoCalibTractCatalog"]
+            externalPhotoCalibCatalog = None
             for externalPhotoCalibCatalogRef in externalPhotoCalibCatalogList:
                 if externalPhotoCalibCatalogRef.dataId["tract"] == tractId:
                     externalPhotoCalibCatalog = externalPhotoCalibCatalogRef.get(
                         datasetType=self.config.connections.externalPhotoCalibCatalog)
                     break
+            if externalPhotoCalibCatalog is None:
+                usedTract = externalPhotoCalibCatalogList[-1].dataId["tract"]
+                self.log.warn(f"Warning, PhotoCalib for tract {tractId} not "
+                               "found. Using tract {usedTract} instead.")
+                externalPhotoCalibCatalog = externalPhotoCalibCatalogList[-1].get(
+                    datasetType=self.config.connections.externalPhotoCalibCatalog)
             row = externalPhotoCalibCatalog.find(detectorId)
             inputs["photoCalib"] = row.getPhotoCalib()
 

--- a/python/lsst/pipe/tasks/processCcdWithFakes.py
+++ b/python/lsst/pipe/tasks/processCcdWithFakes.py
@@ -65,9 +65,9 @@ class ProcessCcdWithFakesConnections(PipelineTaskConnections,
     )
 
     fakeCats = cT.Input(
-        doc="Set of catalogs of fake sources to draw inputs from. We will "
-            "from one of these that fully contains our exposure or the is "
-            "closest the visit boresight.",
+        doc="Set of catalogs of fake sources to draw inputs from. We "
+            "concatenate the tract catalogs for detectorVisits that cover "
+            "multiple tracts.",
         name="{fakesType}fakeSourceCat",
         storageClass="DataFrame",
         dimensions=("tract", "skymap"),
@@ -389,7 +389,7 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
             for externalPhotoCalibCatalogRef in externalPhotoCalibCatalogList:
                 if externalPhotoCalibCatalogRef.dataId["tract"] == tractId:
                     externalPhotoCalibCatalog = externalPhotoCalibCatalogRef.get(
-                        datasetType=self.config.connections.externalSkyWcsTractCatalog)
+                        datasetType=self.config.connections.externalPhotoCalibCatalog)
                     break
             row = externalPhotoCalibCatalog.find(detectorId)
             inputs["photoCalib"] = row.getPhotoCalib()
@@ -413,8 +413,9 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
 
         Parameters
         ----------
-        fakeCat : `pandas.core.frame.DataFrame`
-                    The catalog of fake sources to add to the exposure
+        fakeCats : `list` of `lsst.daf.butler.DeferredDatasetHandle`
+                    Set of tract level fake catalogs that potentially cover
+                    this detectorVisit.
         exposure : `lsst.afw.image.exposure.exposure.ExposureF`
                     The exposure to add the fake sources to
         skyMap : `lsst.skymap.SkyMap`
@@ -500,8 +501,8 @@ class ProcessCcdWithFakesTask(PipelineTask, CmdLineTask):
             tractId = fakeCatRef.dataId["tract"]
             # Make sure all data is within the inner part of the tract.
             outputCat.append(cat[
-                skyMap.findTractIdArray(cat[self.config.insertFakes.raColName],
-                                        cat[self.config.insertFakes.decColName],
+                skyMap.findTractIdArray(cat[self.config.insertFakes.ra_col],
+                                        cat[self.config.insertFakes.dec_col],
                                         degrees=False)
                 == tractId])
 

--- a/tests/test_matchFakes.py
+++ b/tests/test_matchFakes.py
@@ -124,8 +124,7 @@ class TestMatchFakes(lsst.utils.tests.TestCase):
         """Test that the correct number of sources are in the ccd area.
         """
         matchTask = MatchFakesTask()
-        result = matchTask._trimFakeCat(
-            self.fakeCat, self.exposure)
+        result = matchTask._trimFakeCat(self.fakeCat, self.exposure)
         self.assertEqual(len(result), self.inExp.sum())
 
 

--- a/tests/test_matchFakes.py
+++ b/tests/test_matchFakes.py
@@ -63,8 +63,8 @@ class TestMatchFakes(lsst.utils.tests.TestCase):
         self.fakeCat = pd.DataFrame({
             "fakeId": [uuid.uuid4().int & (1 << 64) - 1 for n in range(targetSources)],
             # Quick-and-dirty values for testing
-            "raJ2000": bCenter.getLon().asRadians() + bRadius * (2.0 * self.rng.random(targetSources) - 1.0),
-            "decJ2000": bCenter.getLat().asRadians() + bRadius * (2.0 * self.rng.random(targetSources) - 1.0),
+            "ra": bCenter.getLon().asRadians() + bRadius * (2.0 * self.rng.random(targetSources) - 1.0),
+            "dec": bCenter.getLat().asRadians() + bRadius * (2.0 * self.rng.random(targetSources) - 1.0),
             "isVisitSource": np.concatenate([np.ones(targetSources//2, dtype="bool"),
                                              np.zeros(targetSources - targetSources//2, dtype="bool")]),
             "isTemplateSource": np.concatenate([np.zeros(targetSources//2, dtype="bool"),
@@ -87,8 +87,8 @@ class TestMatchFakes(lsst.utils.tests.TestCase):
         self.inExp = np.zeros(len(self.fakeCat), dtype=bool)
         bbox = geom.Box2D(self.exposure.getBBox())
         for idx, row in self.fakeCat.iterrows():
-            coord = geom.SpherePoint(row["raJ2000"],
-                                     row["decJ2000"],
+            coord = geom.SpherePoint(row["ra"],
+                                     row["dec"],
                                      geom.radians)
             cent = self.exposure.getWcs().skyToPixel(coord)
             self.inExp[idx] = bbox.contains(cent)
@@ -96,8 +96,8 @@ class TestMatchFakes(lsst.utils.tests.TestCase):
         tmpCat = self.fakeCat[self.inExp].iloc[:int(self.inExp.sum() / 2)]
         extraColumnData = self.rng.integers(0, 100, size=len(tmpCat))
         self.sourceCat = pd.DataFrame(
-            data={"ra": np.degrees(tmpCat["raJ2000"]),
-                  "decl": np.degrees(tmpCat["decJ2000"]),
+            data={"ra": np.degrees(tmpCat["ra"]),
+                  "decl": np.degrees(tmpCat["dec"]),
                   "diaObjectId": np.arange(1, len(tmpCat) + 1, dtype=int),
                   "filterName": "g",
                   "diaSourceId": np.arange(1, len(tmpCat) + 1, dtype=int),


### PR DESCRIPTION
Add code to concatenate fake catalogs.

Fix linting.

Add compose fakes to variablity code.

Debug matchFakes.

Add docs

Simplify unittests.

Remove unnessecary runQuantum test.

Change coding dimensions.

Fix linting.

Output tract numbers.

Fix linting.

Access tractId

Access tractId

Fix ra/decColName usage.