### PR TITLE
DM-32827-v23: Explicitly apply operations to calexp.maskedImage. 

### DIFF
--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -857,9 +857,8 @@ class MakeWarpTask(MakeCoaddTempExpTask):
         for index, (calexp, background, skyCorr) in enumerate(zip(calExpList,
                                                                   backgroundList,
                                                                   skyCorrList)):
-            mi = calexp.maskedImage
             if not self.config.bgSubtracted:
-                mi += background.getImage()
+                calexp.maskedImage += background.getImage()
 
             if externalSkyWcsCatalog is not None or externalPhotoCalibCatalog is not None:
                 detectorId = calexp.getInfo().getDetector().getId()
@@ -913,7 +912,7 @@ class MakeWarpTask(MakeCoaddTempExpTask):
 
             # Apply skycorr
             if self.config.doApplySkyCorr:
-                mi -= skyCorr.getImage()
+                calexp.maskedImage -= skyCorr.getImage()
 
             indices.append(index)
 


### PR DESCRIPTION
The mi reference was being superseded by the application of the photometric
calibration, and thus the skyCorr correction was applied to a ghost image
array and not to the returned calexp.