### PR TITLE
DM-13899: Fix AstrometryTask API in ImageDifferenceTask

### DIFF
--- a/python/lsst/pipe/tasks/imageDifference.py
+++ b/python/lsst/pipe/tasks/imageDifference.py
@@ -1109,7 +1109,7 @@ class ImageDifferenceTask(pipeBase.CmdLineTask, pipeBase.PipelineTask):
                 # Create key,val pair where key=diaSourceId and val=refId
                 refAstromConfig = AstrometryConfig()
                 refAstromConfig.matcher.maxMatchDistArcSec = matchRadAsec
-                refAstrometer = AstrometryTask(refAstromConfig)
+                refAstrometer = AstrometryTask(self.refObjLoader, config=refAstromConfig)
                 astromRet = refAstrometer.run(exposure=exposure, sourceCat=diaSources)
                 refMatches = astromRet.matches
                 if refMatches is None:


### PR DESCRIPTION
This could also have been written to instead use `self.astrometer`, though that would not pick up the custom config value for the matcher.