### PR TITLE
DM-33279: Add IsolatedStarAssociationTask

### DIFF
--- a/doc/lsst.pipe.tasks/tasks/lsst.pipe.tasks.isolatedStarAssociation.IsolatedStarAssociationTask.rst
+++ b/doc/lsst.pipe.tasks/tasks/lsst.pipe.tasks.isolatedStarAssociation.IsolatedStarAssociationTask.rst
@@ -1,0 +1,44 @@
+.. lsst-task-topic:: lsst.pipe.tasks.isolatedStarAssociation.IsolatedStarAssociationTask
+
+###########################
+IsolatedStarAssociationTask
+###########################
+
+``IsolatedStarAssociationTask`` matches unresolved star sources from the ``sourceTable_visit`` datasets into a pure (but not complete) catalog of isolated stars.
+The output datasets are a catalog of isolated stars (dataset ``isolated_star_cat``) and the associated sources with configured columns from the input catalogs (dataset ``isolated_star_sources``).
+
+.. _lsst.pipe.tasks.isolatedStarAssociation.IsolatedStarAssociationTask-summary:
+
+Processing summary
+==================
+
+``IsolatedStarAssociationTask`` reads in all the visit-level source table parquet catalogs in a given tract and matches (associates) the sources together.
+In particular:
+
+- All ``sourceTable_visit`` catalogs overlapping a given tract are used as inputs.
+  The configuration variable ``extra_columns`` can be used to specify which columns from the inputs are persisted (in addition to the default flux column, input row number, and source id).
+- Unflagged, unresolved stars above a configured signal-to-noise are selected from each input catalog.
+- The input stars are associated within a configured ``match_radius`` arcseconds.
+  This association is done band-by-band (with the order configured by ``band_order``), and then each band is matched such that all sources are associated with a unique list of stars which cover all the bands in the tract.
+- The star catalog is matched against itself, and groups of stars that match neighbor(s) within ``isolation_radius`` arcseconds are removed from the final isolated star catalog (``isolated_star_cat``).
+- All individual sources are associated with the isolated star catalog within ``match_radius``, to create the ``isolated_star_sources``.
+- The data are collated such that each isolated star has an index to the ``isolated_star_sources`` table for quick access of all the individual sources for that star.
+
+.. _lsst.pipe.tasks.isolatedStarAssociation.IsolatedStarAssociationTask-api:
+
+Python API summary
+==================
+
+.. lsst-task-api-summary:: lsst.pipe.tasks.isolatedStarAssociation.IsolatedStarAssociationTask
+
+Retargetable subtasks
+=====================
+
+.. lsst-task-config-subtasks:: lsst.pipe.tasks.isolatedStarAssociation.IsolatedStarAssociationTask
+
+.. _lsst.pipe.tasks.isolatedStarAssociation.IsolatedStarAssociationTask-configs:
+
+Configuration fields
+====================
+
+.. lsst-task-config-fields:: lsst.pipe.tasks.isolatedStarAssociation.IsolatedStarAssociationTask

--- a/python/lsst/pipe/tasks/isolatedStarAssociation.py
+++ b/python/lsst/pipe/tasks/isolatedStarAssociation.py
@@ -1,0 +1,588 @@
+#
+# LSST Data Management System
+# Copyright 2008-2021 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+import numpy as np
+import pandas as pd
+from smatch.matcher import Matcher
+
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+from lsst.skymap import BaseSkyMap
+from lsst.meas.algorithms.sourceSelector import sourceSelectorRegistry
+
+
+__all__ = ['IsolatedStarAssociationConnections',
+           'IsolatedStarAssociationConfig',
+           'IsolatedStarAssociationTask']
+
+
+class IsolatedStarAssociationConnections(pipeBase.PipelineTaskConnections,
+                                         dimensions=('instrument', 'tract',),
+                                         defaultTemplates={}):
+    source_table_visit = pipeBase.connectionTypes.Input(
+        doc='Source table in parquet format, per visit',
+        name='sourceTable_visit',
+        storageClass='DataFrame',
+        dimensions=('instrument', 'visit'),
+        deferLoad=True,
+        multiple=True,
+    )
+    skymap = pipeBase.connectionTypes.Input(
+        doc="Input definition of geometry/bbox and projection/wcs for warped exposures",
+        name=BaseSkyMap.SKYMAP_DATASET_TYPE_NAME,
+        storageClass="SkyMap",
+        dimensions=("skymap",),
+    )
+    isolated_star_observations = pipeBase.connectionTypes.Output(
+        doc='Catalog of isolated star observations',
+        name='isolated_star_observations',
+        storageClass='DataFrame',
+        dimensions=('instrument', 'tract'),
+    )
+    isolated_star_cat = pipeBase.connectionTypes.Output(
+        doc='Catalog of isolated stars',
+        name='isolated_star_cat',
+        storageClass='DataFrame',
+        dimensions=('instrument', 'tract'),
+    )
+
+
+class IsolatedStarAssociationConfig(pipeBase.PipelineTaskConfig,
+                                    pipelineConnections=IsolatedStarAssociationConnections):
+    """Configuration for IsolatedStarAssociationTask."""
+
+    inst_flux_field = pexConfig.Field(
+        doc=('Full name of instFlux field to use for s/n selection and persistence. '
+             'The associated flag will be implicity included in bad_flags.'),
+        dtype=str,
+        default='apFlux_12_0_instFlux',
+    )
+    match_radius = pexConfig.Field(
+        doc='Match radius (arcseconds)',
+        dtype=float,
+        default=1.0,
+    )
+    isolation_radius = pexConfig.Field(
+        doc='Isolation radius (arcseconds).  Should be at least 2x match_radius.',
+        dtype=float,
+        default=2.0,
+    )
+    band_order = pexConfig.ListField(
+        doc=('Order of bands to do "primary" matching.  Any bands not specified '
+             'will be used alphabetically.'),
+        dtype=str,
+        default=['i', 'z', 'r', 'g', 'y', 'u'],
+    )
+    id_column = pexConfig.Field(
+        doc='Name of column with source id.',
+        dtype=str,
+        default='sourceId',
+    )
+    ra_column = pexConfig.Field(
+        doc='Name of column with right ascension.',
+        dtype=str,
+        default='ra',
+    )
+    dec_column = pexConfig.Field(
+        doc='Name of column with declination.',
+        dtype=str,
+        default='decl',
+    )
+    physical_filter_column = pexConfig.Field(
+        doc='Name of column with physical filter name',
+        dtype=str,
+        default='physical_filter',
+    )
+    band_column = pexConfig.Field(
+        doc='Name of column with band name',
+        dtype=str,
+        default='band',
+    )
+    extra_columns = pexConfig.ListField(
+        doc='Extra names of columns to read and persist (beyond instFlux and error).',
+        dtype=str,
+        default=['x',
+                 'y',
+                 'apFlux_17_0_instFlux',
+                 'apFlux_17_0_instFluxErr',
+                 'apFlux_17_0_flag',
+                 'localBackground_instFlux',
+                 'localBackground_flag']
+    )
+    source_selector = sourceSelectorRegistry.makeField(
+        doc='How to select sources',
+        default='science'
+    )
+
+    def setDefaults(self):
+        super().setDefaults()
+
+        source_selector = self.source_selector['science']
+
+        flux_flag_name = self.inst_flux_field[0: -len('instFlux')] + 'flag'
+
+        source_selector.flags.bad = ['pixelFlags_edge',
+                                     'pixelFlags_interpolatedCenter',
+                                     'pixelFlags_saturatedCenter',
+                                     'pixelFlags_crCenter',
+                                     'pixelFlags_bad',
+                                     'pixelFlags_interpolated',
+                                     'pixelFlags_saturated',
+                                     'centroid_flag',
+                                     flux_flag_name]
+
+        source_selector.signalToNoise.fluxField = self.inst_flux_field
+        source_selector.signalToNoise.errField = self.inst_flux_field + 'Err'
+
+        source_selector.isolated.parentName = 'parentSourceId'
+        source_selector.isolated.nChildName = 'deblend_nChild'
+
+        source_selector.unresolved.name = 'extendedness'
+
+
+class IsolatedStarAssociationTask:
+    """Match isolated stars and suchlike.
+    """
+    ConfigClass = IsolatedStarAssociationConfig
+    _DefaultName = 'isolatedStarAssociation'
+
+    def runQuantum(self, butlerQC, inputRefs, outputRefs):
+        input_ref_dict = butlerQC.get(inputRefs)
+
+        tract = butlerQC.quantum.dataId['tract']
+
+        source_table_refs = input_ref_dict['sourceTable_visit']
+
+        self.log.info('Running with %d sourceTable_visit dataRefs',
+                      len(source_table_refs))
+
+        source_table_ref_dict_temp = {source_table_ref.dataId['visit']: source_table_ref for
+                                      source_table_ref in source_table_refs}
+
+        # Need to sort by visit
+        source_table_ref_dict = {visit: source_table_ref_dict_temp[visit] for
+                                 visit in sorted(source_table_ref_dict_temp.keys())}
+
+        # struct = self.run(tract_info, source_table_ref_dict)
+        struct = self.run(input_ref_dict['skymap'], tract, source_table_ref_dict)
+
+        butlerQC.put(pd.DataFrame(struct.star_obs_cat),
+                     outputRefs.isolated_star_observations)
+        butlerQC.put(pd.DataFrame(struct.star_cat),
+                     outputRefs.isolated_star_cat)
+
+    def run(self, skymap, tract, source_table_ref_dict):
+        """Run the isolated star association task.
+
+        Parameters
+        ----------
+        skymap : `lsst.skymap.SkyMap`
+            Skymap object.
+        tract : `int`
+            Tract number.
+        source_table_ref_dict : `dict`
+            Dictionary of source_table refs.  Key is visit, value is dataref.
+
+        Returns
+        -------
+        struct : `lsst.pipe.base.struct`
+            Struct with outputs for persistence.
+        """
+        star_obs_cat = self.make_all_star_obs(skymap[tract], source_table_ref_dict)
+
+        star_obs_cat, star_cat = self.match_star_obs(star_obs_cat)
+
+        return pipeBase.Struct(star_obs_cat=star_obs_cat,
+                               star_cat=star_cat)
+
+    def make_all_star_obs(self, tract_info, source_table_ref_dict):
+        """Make a catalog of all the star observations.
+
+        Parameters
+        ----------
+        tract_info : `lsst.skymap.TractInfo`
+            Information about the tract.
+        source_table_ref_dict : `dict`
+            Dictionary of source_table refs.  Key is visit, value is dataref.
+
+        Returns
+        -------
+        star_obs_cat : `np.ndarray`
+            Catalog of star observations.
+        """
+        # Internally, we use a numpy recarray, they are by far the fastest
+        # option in testing for relatively narrow tables.
+        # (have not tested wide tables)
+        all_columns, persist_columns = self._get_source_table_visit_columns()
+        poly = tract_info.getOuterSkyPolygon()
+
+        tables = []
+        for visit in source_table_ref_dict:
+            source_table_ref = source_table_ref_dict[visit]
+            df = source_table_ref.get(parameters={'columns': all_columns})
+
+            goodSrc = self.sourceSelector.selectSources(df)
+
+            table = df[persist_columns][goodSrc.selected].to_records()
+
+            # Append columns that include the row in the source table
+            # and the matched object index (to be filled later).
+            table = np.lib.recfunctions.append_fields(table,
+                                                      ['source_row',
+                                                       'obj_index'],
+                                                      [np.where(goodSrc.selected)[0],
+                                                       np.zeros(goodSrc.selected.sum(), dtype=np.int32)],
+                                                      dtypes=['i4', 'i4'],
+                                                      usemask=False)
+
+            # We cut to the outer tract polygon to ensure consistent matching
+            # from tract to tract.
+            tract_use = poly.contains(np.deg2rad(table[self.config.ra_column]),
+                                      np.deg2rad(table[self.config.dec_column]))
+
+            tables.append(table[tract_use])
+
+        # Combine tables
+        star_obs_cat = np.concatenate(tables)
+
+        return star_obs_cat
+
+    def match_star_obs(self, skymap, tract, star_obs_cat):
+        """Match the star observations.
+
+        Parameters
+        ----------
+        skymap : `lsst.skymap.SkyMap`
+            Skymap object.
+        tract : `int`
+            Tract number.
+        star_obs_cat : `np.ndarray`
+            Star observation catalog.
+
+        Returns
+        -------
+        star_obs_cat : `np.ndarray`
+            Sorted and cropped star observation catalog.
+        star_cat : `np.ndarray`
+            Catalog of stars and indexes.
+        """
+        # Figure out band order.
+        bands = np.sort(np.unique(star_obs_cat['band']))
+        primary_bands = self._primary_band_order(self.config.band_order, bands)
+
+        # Do primary matching
+        primary_star_cat = self._match_primary_stars(primary_bands, star_obs_cat)
+
+        primary_star_cat = self._remove_neighbors(primary_star_cat)
+
+        # Crop to the inner tract.
+        inner_tract_ids = skymap.findTractIdArray(primary_star_cat[self.config.ra_column],
+                                                  primary_star_cat[self.config.dec_column],
+                                                  degrees=True)
+        use = (inner_tract_ids == tract)
+        self.log.info('Total of %d isolated stars in inner tract.', use.sum())
+
+        primary_star_cat = primary_star_cat[use]
+
+        # Set the unique ids here.
+        primary_star_cat['isolated_star_id'] = self._compute_unique_ids(skymap,
+                                                                        tract,
+                                                                        len(primary_star_cat))
+
+        star_obs_cat, primary_star_cat = self._match_observations(bands, star_obs_cat, primary_star_cat)
+
+    def _get_source_table_visit_columns(self):
+        """Get the list of sourceTable_visit columns from the config.
+
+        Returns
+        -------
+        all_columns : `list` [`str`]
+            All columns to read
+        persist_columns : `list` [`str`]
+            Columns to persist (excluding selection columns)
+        """
+        columns = [self.config.id_column,
+                   'visit', 'detector',
+                   self.config.ra_column, self.config.dec_column,
+                   self.config.physical_filter_column, self.config.band_column,
+                   self.config.inst_flux_field, self.config.inst_flux_field + 'Err']
+        columns.extend(self.config.extra_columns)
+
+        all_columns = columns.copy()
+        if self.source_selector.config.doFlags:
+            all_columns.extend(self.source_selector.config.flags.bad)
+        if self.source_selector.config.doUnresolved:
+            all_columns.append(self.source_selector.config.unresolved.name)
+        if self.source_selector.config.doIsolated:
+            all_columns.append(self.source_selector.config.isolated.parentName)
+            all_columns.append(self.source_selector.config.isolated.nChildName)
+
+        return all_columns, columns
+
+    @staticmethod
+    def _primary_band_order(band_order, bands):
+        """Compute order of primary bands.
+
+        This will return ordered list of bands according to band_order,
+        with extra bands left in input order (typically alphabetically).
+
+        Parameters
+        ----------
+        band_order : `list` [`str`]
+            Preferred order of bands.
+        bands : `list` [`str`]
+            List of unique bands to put in order.
+
+        Returns
+        -------
+        primary_band_order : `list` [`str`]
+            Ordered list of bands.
+        """
+        primary_bands = []
+        # Put bands in the configured band order
+        for band in band_order:
+            if band in bands:
+                primary_bands.append(band)
+        # For any remaining bands not configured, leave in order.
+        for band in bands:
+            if band not in primary_bands:
+                primary_bands.append(band)
+
+        return primary_bands
+
+    def _match_primary_stars(self, primary_bands, star_obs_cat):
+        """Match primary stars.
+
+        Parameters
+        ----------
+        primary_bands : `list` [`str`]
+            Ordered list of primary bands.
+        star_obs_cat : `np.ndarray`
+            Catalog of star observations.
+
+        Returns
+        -------
+        primary_star_cat : `np.ndarray`
+            Catalog of primary star positions
+        """
+        ra_col = self.config.ra_column
+        dec_col = self.config.dec_column
+
+        max_len = max([len(primary_band) for primary_band in primary_bands])
+
+        dtype = [('isolated_star_id', 'i8'),
+                 (ra_col, 'f8'),
+                 (dec_col, 'f8'),
+                 ('primary_band', f'U{max_len}'),
+                 ('obs_cat_index', 'i4'),
+                 ('nobs', 'i4')]
+
+        for band in primary_bands:
+            dtype.append((f'obs_cat_index_{band}', 'i4'))
+            dtype.append((f'nobs_{band}', 'i4'))
+
+        primary_star_cat = None
+        for primary_band in primary_bands:
+            use = (star_obs_cat['band'] == primary_band)
+
+            ra = star_obs_cat[ra_col][use]
+            dec = star_obs_cat[dec_col][use]
+
+            with Matcher(ra, dec) as matcher:
+                idx = matcher.query_self(self.config.match_radius/3600., min_match=1)
+
+            count = len(idx)
+
+            if count == 0:
+                self.log.info('Found 0 primary stars in %s band.', band)
+                continue
+
+            band_cat = np.zeros(count, dtype=dtype)
+            band_cat['primary_band'] = primary_band
+
+            # rotate if necessary
+            rotated = False
+            if ra.min() < 60.0 and ra.max() > 300.0:
+                ra_temp = (ra + 180.0) % 360. - 180.
+                rotated = True
+            else:
+                ra_temp = ra
+
+            # Compute mean position for each primary star
+            for i, row in enumerate(idx):
+                row = np.array(row)
+                band_cat[ra_col][i] = np.sum(ra_temp[row])/len(row)
+                band_cat[dec_col][i] = np.sum(dec[row])/len(row)
+
+            if rotated:
+                band_cat[ra_col] %= 360.0
+
+            # Match to previous band catalog(s), and remove duplicates.
+            if primary_star_cat is None or len(primary_star_cat) == 0:
+                primary_star_cat = band_cat
+            else:
+                with Matcher(band_cat[ra_col], band_cat[dec_col]) as matcher:
+                    idx = matcher.query_radius(primary_star_cat[ra_col],
+                                               primary_star_cat[dec_col],
+                                               self.config.match_radius/3600.)
+                # Any object with a match should be removed.
+                match_indices = np.array([i for i in range(len(idx)) if len(idx[i]) > 0])
+                band_cat = np.delete(band_cat, match_indices)
+
+                primary_star_cat = np.append(primary_star_cat, band_cat)
+            self.log.info('Found %d primary stars in %s band.', len(band_cat), primary_band)
+
+        return primary_star_cat
+
+    def _remove_neighbors(self, primary_star_cat):
+        """Remove neighbors from the primary star catalog.
+
+        Parameters
+        ----------
+        primary_star_cat : `np.ndarray`
+            Primary star catalog.
+
+        Returns
+        -------
+        primary_star_cat_cut : `np.ndarray`
+            Primary star cat with neighbors removed.
+        """
+        ra_col = self.config.ra_column
+        dec_col = self.config.dec_column
+
+        with Matcher(primary_star_cat[ra_col], primary_star_cat[dec_col]) as matcher:
+            # By setting min_match=2 objects that only match to themselves
+            # will not be recorded.
+            idx = matcher.query_self(self.config.isolation_radius/3600., min_match=2)
+
+        neighbor_indices = []
+        for row in idx:
+            neighbor_indices.extend(row)
+
+        if len(neighbor_indices) > 0:
+            neighbored = np.unique(neighbor_indices)
+            self.log.info('Cutting %d objects with close neighbors.', len(neighbored))
+            primary_star_cat = np.delete(primary_star_cat, neighbored)
+
+        return primary_star_cat
+
+    def _match_observations(self, bands, star_obs_cat, primary_star_cat):
+        """Match observations to primary stars.
+
+        Parameters
+        ----------
+        bands : `list` [`str`]
+            List of bands.
+        star_obs_cat : `np.ndarray`
+            Array of star observations.
+        primary_star_cat : `np.ndarray`
+            Array of primary stars.
+
+        Returns
+        -------
+        star_obs_cat_cut : `np.ndarray`
+            Cropped and sorted array of star observations.
+        primary_star_cat : `np.ndarray`
+            Catalog of isolated stars, with indexes to star_obs_cat_cut.
+        """
+        ra_col = self.config.ra_column
+        dec_col = self.config.dec_column
+
+        # We match observations per-band because it allows us to have sorted
+        # observations for easy retrieval of per-band matches.
+        n_obs_per_band_per_obj = np.zeros((len(bands),
+                                           len(primary_star_cat)),
+                                          dtype=np.int32)
+        band_uses = []
+        idxs = []
+        with Matcher(primary_star_cat[ra_col], primary_star_cat[dec_col]) as matcher:
+            for b, band in enumerate(bands):
+                band_use, = np.where(star_obs_cat['band'] == band)
+
+                idx = matcher.query_radius(star_obs_cat[ra_col][band_use],
+                                           star_obs_cat[dec_col][band_use],
+                                           self.config.match_radius/3600.)
+                n_obs_per_band_per_obj[b, :] = np.array([len(row) for row in idx])
+                idxs.append(idx)
+                band_uses.append(band_use)
+
+        n_obs_per_obj = np.sum(n_obs_per_band_per_obj, axis=0)
+
+        primary_star_cat['nobs'] = n_obs_per_obj
+        primary_star_cat['obs_cat_index'][1:] = np.cumsum(n_obs_per_obj)[:-1]
+
+        n_tot_obs = primary_star_cat['obs_cat_index'][-1] + primary_star_cat['nobs'][-1]
+
+        # Temporary arrays until we crop/sort the observation catalog
+        obs_index = np.zeros(n_tot_obs, dtype=np.int32)
+        obj_index = np.zeros(n_tot_obs, dtype=np.int32)
+
+        ctr = 0
+        for i in range(len(primary_star_cat)):
+            obj_index[ctr: ctr + n_obs_per_obj[i]] = i
+            for b in range(len(bands)):
+                obs_index[ctr: ctr + n_obs_per_band_per_obj[b, i]] = band_uses[b][idxs[b][i]]
+                ctr += n_obs_per_band_per_obj[b, i]
+
+        obs_cat_index_band_offset = np.cumsum(n_obs_per_band_per_obj, axis=0)
+
+        for b, band in enumerate(bands):
+            primary_star_cat[f'nobs_{band}'] = n_obs_per_band_per_obj[b, :]
+            if b == 0:
+                # The first band listed is the same as the overall star
+                primary_star_cat[f'obs_cat_index_{band}'] = primary_star_cat['obs_cat_index']
+            else:
+                # Other band indices are offset from the previous band
+                primary_star_cat[f'obs_cat_index_{band}'] = (primary_star_cat['obs_cat_index']
+                                                             + obs_cat_index_band_offset[b - 1, :])
+
+        # Reset all indices to illegal value -1
+        star_obs_cat['obj_index'] = -1
+        star_obs_cat['obj_index'][obs_index] = obj_index
+
+        star_obs_cat = star_obs_cat[obs_index]
+
+        return star_obs_cat, primary_star_cat
+
+    def _compute_unique_ids(self, skymap, tract, nstar):
+        """Compute unique star ids.
+
+        This is a simple hash of the tract and star to provide an
+        id that is unique for a given processing.
+
+        Parameters
+        ----------
+        skymap : `lsst.skymap.Skymap`
+            Skymap object.
+        tract : `int`
+            Tract id number.
+        nstar : `int`
+            Number of stars.
+
+        Returns
+        -------
+        ids : `np.ndarray`
+            Array of unique star ids.
+        """
+        # The end of the id will be big enough to hold the tract number
+        mult = 10**(int(np.log10(len(skymap))) + 1)
+
+        return (np.arange(nstar) + 1)*mult + tract

--- a/python/lsst/pipe/tasks/isolatedStarAssociation.py
+++ b/python/lsst/pipe/tasks/isolatedStarAssociation.py
@@ -172,7 +172,7 @@ class IsolatedStarAssociationConfig(pipeBase.PipelineTaskConfig,
 
 
 class IsolatedStarAssociationTask(pipeBase.PipelineTask):
-    """Match isolated stars and suchlike.
+    """Associate sources into isolated star catalogs.
     """
     ConfigClass = IsolatedStarAssociationConfig
     _DefaultName = 'isolatedStarAssociation'

--- a/python/lsst/pipe/tasks/isolatedStarAssociation.py
+++ b/python/lsst/pipe/tasks/isolatedStarAssociation.py
@@ -189,9 +189,9 @@ class IsolatedStarAssociationTask(pipeBase.PipelineTask):
 
         tract = butlerQC.quantum.dataId['tract']
 
-        source_table_refs = input_ref_dict['sourceTable_visit']
+        source_table_refs = input_ref_dict['source_table_visit']
 
-        self.log.info('Running with %d sourceTable_visit dataRefs',
+        self.log.info('Running with %d source_table_visit dataRefs',
                       len(source_table_refs))
 
         source_table_ref_dict_temp = {source_table_ref.dataId['visit']: source_table_ref for

--- a/python/lsst/pipe/tasks/isolatedStarAssociation.py
+++ b/python/lsst/pipe/tasks/isolatedStarAssociation.py
@@ -35,7 +35,7 @@ __all__ = ['IsolatedStarAssociationConnections',
 
 
 class IsolatedStarAssociationConnections(pipeBase.PipelineTaskConnections,
-                                         dimensions=('instrument', 'tract',),
+                                         dimensions=('instrument', 'tract', 'skymap',),
                                          defaultTemplates={}):
     source_table_visit = pipeBase.connectionTypes.Input(
         doc='Source table in parquet format, per visit',
@@ -48,20 +48,20 @@ class IsolatedStarAssociationConnections(pipeBase.PipelineTaskConnections,
     skymap = pipeBase.connectionTypes.Input(
         doc="Input definition of geometry/bbox and projection/wcs for warped exposures",
         name=BaseSkyMap.SKYMAP_DATASET_TYPE_NAME,
-        storageClass="SkyMap",
-        dimensions=("skymap",),
+        storageClass='SkyMap',
+        dimensions=('skymap',),
     )
     isolated_star_sources = pipeBase.connectionTypes.Output(
         doc='Catalog of individual sources for the isolated stars',
         name='isolated_star_sources',
         storageClass='DataFrame',
-        dimensions=('instrument', 'tract'),
+        dimensions=('instrument', 'tract', 'skymap'),
     )
     isolated_star_cat = pipeBase.connectionTypes.Output(
         doc='Catalog of isolated star positions',
         name='isolated_star_cat',
         storageClass='DataFrame',
-        dimensions=('instrument', 'tract'),
+        dimensions=('instrument', 'tract', 'skymap'),
     )
 
 

--- a/tests/test_isolatedStarAssociation.py
+++ b/tests/test_isolatedStarAssociation.py
@@ -1,0 +1,357 @@
+# This file is part of pipe_tasks.
+#
+# LSST Data Management System
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+# See COPYRIGHT file at the top of the source tree.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+"""Test IsolatedStarAssociationTask.
+"""
+import unittest
+import numpy as np
+import pandas as pd
+
+import lsst.utils.tests
+import lsst.daf.butler
+import lsst.skymap
+
+from lsst.pipe.tasks.isolatedStarAssociation import (IsolatedStarAssociationConfig,
+                                                     IsolatedStarAssociationTask)
+from smatch.matcher import Matcher
+
+
+class MockSourceTableReference(lsst.daf.butler.DeferredDatasetHandle):
+    """Very simple object that looks like a Gen3 data reference to
+    a sourceTable_visit.
+
+    Parameters
+    ----------
+    source_table : `pandas.DataFrame`
+        Dataframe of the source table.
+    """
+    def __init__(self, source_table):
+        self.source_table = source_table
+
+    def get(self, parameters={}, **kwargs):
+        """Retrieve the specified dataset using the API of the Gen3 Butler.
+
+        Parameters
+        ----------
+        parameters : `dict`, optional
+            Parameter dictionary.  Supported key is ``columns``.
+
+        Returns
+        -------
+        dataframe : `pandas.DataFrame`
+            dataframe, cut to the specified columns.
+        """
+        if 'columns' in parameters:
+            return self.source_table[parameters['columns']]
+        else:
+            return self.source_table.copy()
+
+
+class IsolatedStarAssociationTestCase(lsst.utils.tests.TestCase):
+    """Tests of IsolatedStarAssociationTask.
+
+    These tests bypass the middleware used for accessing data and
+    managing Task execution.
+    """
+    def setUp(self):
+        self.skymap = self._make_skymap()
+        self.tract = 9813
+        self.data_refs = self._make_simdata(self.tract)
+        self.visits = np.arange(len(self.data_refs)) + 1
+
+        self.data_ref_dict = {visit: data_ref for visit, data_ref in zip(self.visits,
+                                                                         self.data_refs)}
+
+        config = IsolatedStarAssociationConfig()
+        config.band_order = ['i', 'r']
+        config.extra_columns = ['extra_column']
+        config.source_selector['science'].doFlags = False
+        config.source_selector['science'].doIsolated = False
+
+        self.isolatedStarAssociationTask = IsolatedStarAssociationTask(config=config)
+
+    def _make_skymap(self):
+        """Make a testing skymap."""
+        skymap_config = lsst.skymap.ringsSkyMap.RingsSkyMapConfig()
+        skymap_config.numRings = 120
+        skymap_config.projection = "TAN"
+        skymap_config.tractOverlap = 1.0/60
+        skymap_config.pixelScale = 0.168
+        return lsst.skymap.ringsSkyMap.RingsSkyMap(skymap_config)
+
+    def _make_simdata(self, tract):
+        """Make simulated data tables and references."""
+        np.random.seed(12345)
+
+        n_visit_per_band = 5
+        n_star_both = 50
+        n_star_just_one = 5
+
+        tract_info = self.skymap[tract]
+        ctr = tract_info.ctr_coord
+        ctr_ra = ctr.getRa().asDegrees()
+        ctr_dec = ctr.getDec().asDegrees()
+
+        ra_both = np.linspace(ctr_ra - 1.5, ctr_ra + 1.5, n_star_both)
+        dec_both = np.linspace(ctr_dec - 1.5, ctr_dec + 1.5, n_star_both)
+
+        ra_just_r = np.linspace(ctr_ra - 0.5, ctr_ra + 0.5, n_star_just_one)
+        dec_just_r = np.linspace(ctr_dec + 0.2, ctr_dec + 0.2, n_star_just_one)
+        ra_just_i = np.linspace(ctr_ra - 0.5, ctr_ra + 0.5, n_star_just_one)
+        dec_just_i = np.linspace(ctr_dec - 0.2, ctr_dec - 0.2, n_star_just_one)
+
+        ra_neighbor = np.array([ra_both[n_star_both//2] + 1./3600.])
+        dec_neighbor = np.array([dec_both[n_star_both//2] + 1./3600.])
+
+        # Create the r-band datarefs
+        dtype = [('sourceId', 'i8'),
+                 ('ra', 'f8'),
+                 ('decl', 'f8'),
+                 ('apFlux_12_0_instFlux', 'f4'),
+                 ('apFlux_12_0_instFluxErr', 'f4'),
+                 ('apFlux_12_0_instFlux_flag', '?'),
+                 ('extendedness', 'f4'),
+                 ('visit', 'i4'),
+                 ('detector', 'i4'),
+                 ('physical_filter', 'U10'),
+                 ('band', 'U2'),
+                 ('extra_column', 'f4')]
+
+        id_counter = 0
+        visit_counter = 1
+
+        data_refs = []
+        for band in ['r', 'i']:
+            if band == 'r':
+                filtername = 'R FILTER'
+                ra_just = ra_just_r
+                dec_just = dec_just_r
+            else:
+                filtername = 'I FILTER'
+                ra_just = ra_just_i
+                dec_just = dec_just_i
+
+            star_ra = np.concatenate((ra_both, ra_neighbor, ra_just))
+            star_dec = np.concatenate((dec_both, dec_neighbor, dec_just))
+
+            nstar = len(star_ra)
+
+            for i in range(n_visit_per_band):
+                ras = np.random.normal(loc=star_ra, scale=0.2/3600.)
+                decs = np.random.normal(loc=star_dec, scale=0.2/3600.)
+
+                table = np.zeros(nstar, dtype=dtype)
+                table['sourceId'] = np.arange(nstar) + id_counter
+                table['ra'] = ras
+                table['decl'] = decs
+                table['apFlux_12_0_instFlux'] = 100.0
+                table['apFlux_12_0_instFluxErr'] = 1.0
+                table['physical_filter'] = filtername
+                table['band'] = band
+                table['extra_column'] = np.ones(nstar)
+                table['visit'] = visit_counter
+                table['detector'] = 1
+
+                if i == 0:
+                    # Make one star have low s/n
+                    table['apFlux_12_0_instFlux'][0] = 1.0
+
+                data_refs.append(MockSourceTableReference(pd.DataFrame(table)))
+
+                id_counter += nstar
+                visit_counter += 1
+
+        self.n_visit_per_band = n_visit_per_band
+        self.n_star_both = n_star_both
+        self.n_star_just_one = n_star_just_one
+        self.star_ras = np.concatenate((ra_both, ra_just_r, ra_just_i, ra_neighbor))
+        self.star_decs = np.concatenate((dec_both, dec_just_r, dec_just_i, dec_neighbor))
+
+        return data_refs
+
+    def test_compute_unique_ids(self):
+        """Test computation of unique ids."""
+        ids1 = self.isolatedStarAssociationTask._compute_unique_ids(self.skymap,
+                                                                    9813,
+                                                                    10000)
+        ids2 = self.isolatedStarAssociationTask._compute_unique_ids(self.skymap,
+                                                                    9814,
+                                                                    5000)
+        ids = np.concatenate((ids1, ids2))
+        self.assertEqual(len(np.unique(ids)), len(ids))
+
+    def test_remove_neighbors(self):
+        """Test removing close neighbors."""
+        primary_star_cat = np.zeros(3, dtype=[('ra', 'f8'),
+                                              ('decl', 'f8')])
+
+        # Put two stars < 2" apart, and across the 0/360 boundary.
+        primary_star_cat['ra'] = [0.7/3600., 360.0 - 0.7/3600., 1.0]
+        primary_star_cat['decl'] = [5.0, 5.0, 5.0]
+
+        cut_cat = self.isolatedStarAssociationTask._remove_neighbors(primary_star_cat)
+
+        self.assertEqual(len(cut_cat), 1)
+        np.testing.assert_almost_equal(1.0, cut_cat['ra'][0])
+
+    def test_match_primary_stars(self):
+        """Test matching primary stars."""
+        # Stack all the observations; we do not want any cutting here.
+        tables = []
+        for data_ref in self.data_refs:
+            df = data_ref.get()
+            tables.append(df.to_records())
+        obs_cat = np.concatenate(tables)
+
+        primary_star_cat = self.isolatedStarAssociationTask._match_primary_stars(['i', 'r'],
+                                                                                 obs_cat)
+
+        # Ensure we found the right number of stars in each p
+        test_i = (primary_star_cat['primary_band'] == 'i')
+        self.assertEqual(test_i.sum(), self.n_star_both + self.n_star_just_one + 1)
+        test_r = (primary_star_cat['primary_band'] == 'r')
+        self.assertEqual(test_r.sum(), self.n_star_just_one)
+
+        # Ensure that these stars all match to input stars within 1 arcsec.
+        with Matcher(self.star_ras, self.star_decs) as matcher:
+            idx, i1, i2, d = matcher.query_radius(primary_star_cat['ra'],
+                                                  primary_star_cat['decl'],
+                                                  1./3600.,
+                                                  return_indices=True)
+        self.assertEqual(i1.size, self.star_ras.size)
+
+    def test_get_source_table_visit_columns(self):
+        """Test making of source table visit columns."""
+        all_columns, persist_columns = self.isolatedStarAssociationTask._get_source_table_visit_columns()
+
+        # Make sure all persisted columns are in all columns.
+        for col in persist_columns:
+            self.assertTrue(col in all_columns)
+
+        # And make sure extendedness is not in persisted columns.
+        self.assertTrue('extendedness' not in persist_columns)
+
+    def test_match_obsservations(self):
+        """Test _match_observations observation to primary matching."""
+        # Stack all the observations; we do not want any cutting here.
+        tables = []
+        for data_ref in self.data_refs:
+            df = data_ref.get()
+            tables.append(df.to_records())
+        obs_cat = np.concatenate(tables)
+
+        obs_cat = np.lib.recfunctions.append_fields(obs_cat,
+                                                    ['obj_index'],
+                                                    [np.zeros(obs_cat.size, dtype=np.int32)],
+                                                    dtypes=['i4'],
+                                                    usemask=False)
+
+        primary_bands = ['i', 'r']
+
+        primary_cat = np.zeros(self.star_ras.size,
+                               dtype=self.isolatedStarAssociationTask._get_primary_dtype(primary_bands))
+        primary_cat['ra'] = self.star_ras
+        primary_cat['decl'] = self.star_decs
+
+        obs_cat_sorted, primary_star_cat = self.isolatedStarAssociationTask._match_observations(['i', 'r'],
+                                                                                                obs_cat,
+                                                                                                primary_cat)
+        # All the star observations should be matched
+        self.assertEqual(obs_cat_sorted.size, obs_cat.size)
+
+        # Full index tests are performed in test_run_isolated_star_association_task
+
+    def test_make_all_star_obs(self):
+        """Test appending all the star observations."""
+        obs_cat = self.isolatedStarAssociationTask._make_all_star_obs(self.skymap[self.tract],
+                                                                      self.data_ref_dict)
+
+        # Make sure we don't have any low s/n observations.
+        sn_min = np.min(obs_cat['apFlux_12_0_instFlux']/obs_cat['apFlux_12_0_instFluxErr'])
+        self.assertGreater(sn_min, 10.0)
+
+        # And make sure they are all within the tract outer boundary.
+        poly = self.skymap[self.tract].outer_sky_polygon
+        use = poly.contains(np.deg2rad(obs_cat['ra']), np.deg2rad(obs_cat['decl']))
+        self.assertEqual(use.sum(), len(obs_cat))
+
+    def test_run_isolated_star_association_task(self):
+        """Test running the full task."""
+
+        struct = self.isolatedStarAssociationTask.run(self.skymap,
+                                                      self.tract,
+                                                      self.data_ref_dict)
+
+        star_obs_cat = struct.star_obs_cat
+        star_cat = struct.star_cat
+
+        # Check that observations are all unique ids
+        self.assertEqual(np.unique(star_obs_cat['sourceId']).size, star_obs_cat.size)
+
+        inner_tract_ids = self.skymap.findTractIdArray(self.star_ras,
+                                                       self.star_decs,
+                                                       degrees=True)
+        inner_stars = (inner_tract_ids == self.tract)
+
+        # There should be the same number of stars in the inner tract region,
+        # taking away the 2 close neighbors.
+        self.assertEqual(star_cat.size, np.sum(inner_stars) - 2)
+
+        # Check the star indices
+        for i in range(len(star_cat)):
+            all_obs_star = star_obs_cat[star_cat['obs_cat_index'][i]:
+                                        star_cat['obs_cat_index'][i] + star_cat['nobs'][i]]
+
+            # Check that these all point to the correct object
+            np.testing.assert_array_equal(all_obs_star['obj_index'], i)
+
+            # Check these are all pointing to the same star position
+            with Matcher(np.atleast_1d(star_cat['ra'][i]),
+                         np.atleast_1d(star_cat['decl'][i])) as matcher:
+                idx = matcher.query_radius(all_obs_star['ra'],
+                                           all_obs_star['decl'],
+                                           1./3600.)
+            self.assertEqual(len(idx[0]), star_cat['nobs'][i])
+
+            # Check per band indices
+            for band in ['r', 'i']:
+                band_obs_star = star_obs_cat[star_cat[f'obs_cat_index_{band}'][i]:
+                                             star_cat[f'obs_cat_index_{band}'][i]
+                                             + star_cat[f'nobs_{band}'][i]]
+                with Matcher(np.atleast_1d(star_cat['ra'][i]),
+                             np.atleast_1d(star_cat['decl'][i])) as matcher:
+                    idx = matcher.query_radius(band_obs_star['ra'],
+                                               band_obs_star['decl'],
+                                               1./3600.)
+                self.assertEqual(len(idx[0]), star_cat[f'nobs_{band}'][i])
+
+
+class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This PR adds a new isolated star association task for input to re-estimating the psf with consistently reserved stars, and for input to fgcmcal.

Note that the `Matcher` code currently in the commit is just there for testing purposes until DM-33545 is finished and we have a new env with `spherematch`.