### PR TITLE
DM-33786-v23: Remove try block for stacking

### DIFF
--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -839,7 +839,8 @@ class AssembleCoaddTask(CoaddBaseTask, pipeBase.PipelineTask):
                                              weightList, altMaskList, stats.ctrl,
                                              nImage=nImage)
             except Exception as e:
-                self.log.fatal("Cannot compute online coadd %s", e)
+                self.log.exception("Cannot compute online coadd %s", e)
+                raise
         else:
             for subBBox in self._subBBoxIter(skyInfo.bbox, subregionSize):
                 try:
@@ -847,7 +848,8 @@ class AssembleCoaddTask(CoaddBaseTask, pipeBase.PipelineTask):
                                            weightList, altMaskList, stats.flags, stats.ctrl,
                                            nImage=nImage)
                 except Exception as e:
-                    self.log.fatal("Cannot compute coadd %s: %s", subBBox, e)
+                    self.log.exception("Cannot compute coadd %s: %s", subBBox, e)
+                    raise
 
         # If inputMap is requested, we must finalize the map after the accumulation.
         if self.config.doInputMap:


### PR DESCRIPTION
because log.fatal does not exit.
There is still a log.debug that prints each bbox in the loop
if more info on which subregion it is working on is needed.