### PR TITLE
DM-33834: Fix bug to run on scarlet models

### DIFF
--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -589,7 +589,8 @@ class DeblendCoaddSourcesTask(CmdLineTask):
 class MeasureMergedCoaddSourcesConnections(PipelineTaskConnections,
                                            dimensions=("tract", "patch", "band", "skymap"),
                                            defaultTemplates={"inputCoaddName": "deep",
-                                                             "outputCoaddName": "deep"}):
+                                                             "outputCoaddName": "deep",
+                                                             "deblendedCatalog": "deblendedFlux"}):
     inputSchema = cT.InitInput(
         doc="Input schema for measure merged task produced by a deblender or detection task",
         name="{inputCoaddName}Coadd_deblendedFlux_schema",
@@ -636,7 +637,7 @@ class MeasureMergedCoaddSourcesConnections(PipelineTaskConnections,
              "or deblendedFlux if the multiband deblender was configured to output "
              "deblended flux catalogs. If no deblending was performed this should "
              "be 'mergeDet'"),
-        name="{inputCoaddName}Coadd_deblendedFlux",
+        name="{inputCoaddName}Coadd_{deblendedCatalog}",
         storageClass="SourceCatalog",
         dimensions=("tract", "patch", "band", "skymap"),
     )


### PR DESCRIPTION
There was previously no way to run a task on the `deblendedModel` outputs from `ScarletDeblendTask`. This commit allows the user to choose whether to run measurement on the scarlet models or flux re-distributed models.