### PR TITLE
DM-33980: adding psfFlux and psfFluxErr columns to isolatedStarAssociationTask

### DIFF
--- a/python/lsst/pipe/tasks/isolatedStarAssociation.py
+++ b/python/lsst/pipe/tasks/isolatedStarAssociation.py
@@ -128,7 +128,9 @@ class IsolatedStarAssociationConfig(pipeBase.PipelineTaskConfig,
                  'apFlux_17_0_instFluxErr',
                  'apFlux_17_0_flag',
                  'localBackground_instFlux',
-                 'localBackground_flag']
+                 'localBackground_flag',
+                 'psfFlux',
+                 'psfFluxErr']
     )
     source_selector = sourceSelectorRegistry.makeField(
         doc='How to select sources.  Under normal usage this should not be changed.',


### PR DESCRIPTION
In order to use the output of` isolatedStarAssociationTask` for faro photometric repeatability metrics the `isolated_star_sources` output should contain the columns `psfFlux` and `psfFluxErr`.