### PR TITLE
tickets/DM-33977 Fixes for ConfigurableActionStructField

### DIFF
--- a/python/lsst/pipe/tasks/configurableActions/_configurableActionStructField.py
+++ b/python/lsst/pipe/tasks/configurableActions/_configurableActionStructField.py
@@ -164,6 +164,11 @@ class ConfigurableActionStruct:
                   f"Attempting to set item {attr} to value {value}"
             raise FieldValidationError(self._field, self._config, msg)
 
+        # verify that someone has not passed a string with a space or leading
+        # number or something through the dict assignment update interface
+        if not attr.isidentifier():
+            raise ValueError("Names used in ConfigurableStructs must be valid as python variable names")
+
         if attr not in (self.__dict__.keys() | type(self).__dict__.keys()):
             base_name = _joinNamePath(self._config._name, self._field.name)
             name = _joinNamePath(base_name, attr)

--- a/python/lsst/pipe/tasks/configurableActions/_configurableActionStructField.py
+++ b/python/lsst/pipe/tasks/configurableActions/_configurableActionStructField.py
@@ -247,7 +247,7 @@ class ConfigurableActionStructField(Field):
         if value is None or (self.default is not None and self.default == value):
             value = self.StructClass(instance, self, value, at=at, label=label)
         else:
-            # An actual value is being assgigned check for what it is
+            # An actual value is being assigned check for what it is
             if isinstance(value, self.StructClass):
                 # If this is a ConfigurableActionStruct, we need to make our own
                 # copy that references this current field


### PR DESCRIPTION
This ticket fixes some assignment logic in ConfigurableActionStructField wherein a local copy of a ConfigurableActionStruct was not being made, leaving a dangling reference to a config object that goes out of scope.

This ticket also makes a change to stay in line with other pex_config fields wherein it takes other python classes that duck like a ConfigurableActionStructField as an argument in assigment.

Finally this ticket adds a verification that a string used in the dict update interface is a valid python identifier.