### PR TITLE
DM-33157: Fix doxygen errors in pipe_tasks

### DIFF
--- a/doc/doxygen.conf.in
+++ b/doc/doxygen.conf.in
@@ -1,0 +1,1 @@
+EXAMPLE_PATH += examples/

--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -359,8 +359,8 @@ class CalibrateTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
     @section pipe_tasks_calibrate_Purpose  Description
 
     Given an exposure with a good PSF model and aperture correction map
-    (e.g. as provided by @ref CharacterizeImageTask), perform the following
-     operations:
+    (e.g. as provided by @ref characterizeImage::CharacterizeImageTask "CharacterizeImageTask"),
+    perform the following operations:
     - Run detection and measurement
     - Run astrometry subtask to fit an improved WCS
     - Run photoCal subtask to fit the exposure's photometric zero-point
@@ -395,9 +395,10 @@ class CalibrateTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
 
     @section pipe_tasks_calibrate_Debug  Debug variables
 
-    The @link lsst.pipe.base.cmdLineTask.CmdLineTask command line task@endlink
+    The command line task
     interface supports a flag
-    `--debug` to import `debug.py` from your `$PYTHONPATH`; see @ref baseDebug
+    `--debug` to import `debug.py` from your `$PYTHONPATH`; see
+    <a href="https://pipelines.lsst.io/modules/lsstDebug/">the lsstDebug documentation</a>
     for more about `debug.py`.
 
     CalibrateTask has a debug dictionary containing one key:

--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -356,7 +356,6 @@ class CalibrateTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
      - @ref pipe_tasks_calibrate_Metadata
      - @ref pipe_tasks_calibrate_Debug
 
-
     @section pipe_tasks_calibrate_Purpose  Description
 
     Given an exposure with a good PSF model and aperture correction map

--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -336,7 +336,7 @@ class CalibrateConfig(pipeBase.PipelineTaskConfig, pipelineConnections=Calibrate
 
 ## \addtogroup LSST_task_documentation
 ## \{
-## \page CalibrateTask
+## \page page_CalibrateTask CalibrateTask
 ## \ref CalibrateTask_ "CalibrateTask"
 ## \copybrief CalibrateTask
 ## \}

--- a/python/lsst/pipe/tasks/characterizeImage.py
+++ b/python/lsst/pipe/tasks/characterizeImage.py
@@ -288,8 +288,10 @@ class CharacterizeImageTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
 
     @section pipe_tasks_characterizeImage_Debug  Debug variables
 
-    The @link lsst.pipe.base.cmdLineTask.CmdLineTask command line task@endlink interface supports a flag
-    `--debug` to import `debug.py` from your `$PYTHONPATH`; see @ref baseDebug for more about `debug.py`.
+    The command line task interface supports a flag
+    `--debug` to import `debug.py` from your `$PYTHONPATH`; see
+    <a href="https://pipelines.lsst.io/modules/lsstDebug/">the lsstDebug documentation</a>
+    for more about `debug.py`.
 
     CharacterizeImageTask has a debug dictionary with the following keys:
     <dl>

--- a/python/lsst/pipe/tasks/characterizeImage.py
+++ b/python/lsst/pipe/tasks/characterizeImage.py
@@ -249,7 +249,8 @@ class CharacterizeImageConfig(pipeBase.PipelineTaskConfig,
 
 
 class CharacterizeImageTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
-    r"""!Measure bright sources and use this to estimate background and PSF of an exposure
+    r"""!
+    Measure bright sources and use this to estimate background and PSF of an exposure
 
     @anchor CharacterizeImageTask_
 
@@ -260,7 +261,6 @@ class CharacterizeImageTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
      - @ref pipe_tasks_characterizeImage_IO
      - @ref pipe_tasks_characterizeImage_Config
      - @ref pipe_tasks_characterizeImage_Debug
-
 
     @section pipe_tasks_characterizeImage_Purpose  Description
 

--- a/python/lsst/pipe/tasks/characterizeImage.py
+++ b/python/lsst/pipe/tasks/characterizeImage.py
@@ -242,7 +242,7 @@ class CharacterizeImageConfig(pipeBase.PipelineTaskConfig,
 
 ## \addtogroup LSST_task_documentation
 ## \{
-## \page CharacterizeImageTask
+## \page page_CharacterizeImageTask CharacterizeImageTask
 ## \ref CharacterizeImageTask_ "CharacterizeImageTask"
 ## \copybrief CharacterizeImageTask
 ## \}

--- a/python/lsst/pipe/tasks/coaddBase.py
+++ b/python/lsst/pipe/tasks/coaddBase.py
@@ -156,9 +156,10 @@ class CoaddBaseTask(pipeBase.CmdLineTask, pipeBase.PipelineTask):
         @brief Select exposures to coadd
 
         Get the corners of the bbox supplied in skyInfo using @ref geom.Box2D and convert the pixel
-        positions of the bbox corners to sky coordinates using @ref skyInfo.wcs.pixelToSky. Use the
-        @ref WcsSelectImagesTask_ "WcsSelectImagesTask" to select exposures that lie inside the patch
-        indicated by the dataRef.
+        positions of the bbox corners to sky coordinates using
+        @ref afw::geom::SkyWcs::pixelToSky "skyInfo.wcs.pixelToSky". Use the
+        @ref selectImages::WcsSelectImagesTask "WcsSelectImagesTask" to select exposures that lie
+        inside the patch indicated by the dataRef.
 
         @param[in] patchRef  data reference for sky map patch. Must include keys "tract", "patch",
                              plus the camera-specific filter key (e.g. "filter" or "band")
@@ -173,7 +174,8 @@ class CoaddBaseTask(pipeBase.CmdLineTask, pipeBase.PipelineTask):
 
     def getSkyInfo(self, patchRef):
         """!
-        @brief Use @ref getSkyinfo to return the skyMap, tract and patch information, wcs and the outer bbox
+        @brief Use @ref coaddBase::getSkyInfo "getSkyInfo" to return the skyMap,
+        tract and patch information, wcs and the outer bbox
         of the patch.
 
         @param[in] patchRef  data reference for sky map. Must include keys "tract" and "patch"

--- a/python/lsst/pipe/tasks/coaddBase.py
+++ b/python/lsst/pipe/tasks/coaddBase.py
@@ -164,6 +164,8 @@ class CoaddBaseTask(pipeBase.CmdLineTask, pipeBase.PipelineTask):
         @param[in] patchRef  data reference for sky map patch. Must include keys "tract", "patch",
                              plus the camera-specific filter key (e.g. "filter" or "band")
         @param[in] skyInfo   geometry for the patch; output from getSkyInfo
+        @param[in] selectDataList list of @ref selectImages::SelectStruct "SelectStruct"
+                             to consider for selection
         @return    a list of science exposures to coadd, as butler data references
         """
         if skyInfo is None:

--- a/python/lsst/pipe/tasks/dcrAssembleCoadd.py
+++ b/python/lsst/pipe/tasks/dcrAssembleCoadd.py
@@ -1236,7 +1236,7 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
         convergeMaskPixels = dcrModels.mask[dcrBBox].array & convergeMask > 0
         weights = np.zeros_like(dcrModels[0][dcrBBox].array)
         weights[convergeMaskPixels] = 1.
-        weights = ndimage.filters.gaussian_filter(weights, self.config.modelWeightsWidth)
+        weights = ndimage.gaussian_filter(weights, self.config.modelWeightsWidth)
         weights /= np.max(weights)
         return weights
 

--- a/python/lsst/pipe/tasks/diff_matched_tract_catalog.py
+++ b/python/lsst/pipe/tasks/diff_matched_tract_catalog.py
@@ -543,7 +543,7 @@ class DiffMatchedTractCatalogTask(pipeBase.PipelineTask):
         cat_left = cat_target.iloc[matched_row]
         has_index_left = cat_left.index.name is not None
         cat_right = cat_ref[matched_ref].reset_index()
-        cat_matched = pd.concat((cat_left.reset_index(drop=True), cat_right), 1)
+        cat_matched = pd.concat((cat_left.reset_index(drop=True), cat_right), axis=1)
         if has_index_left:
             cat_matched.index = cat_left.index
         cat_matched.columns.values[len(cat_target.columns):] = [f'refcat_{col}' for col in cat_right.columns]

--- a/python/lsst/pipe/tasks/exampleCmdLineTask.py
+++ b/python/lsst/pipe/tasks/exampleCmdLineTask.py
@@ -53,7 +53,8 @@ class ExampleCmdLineConfig(pexConfig.Config):
 
 
 class ExampleCmdLineTask(pipeBase.CmdLineTask):
-    r"""!Example command-line task that computes simple statistics on an image
+    r"""!
+    Example command-line task that computes simple statistics on an image
 
     \section pipeTasks_ExampleCmdLineTask_Contents Contents
 

--- a/python/lsst/pipe/tasks/exampleCmdLineTask.py
+++ b/python/lsst/pipe/tasks/exampleCmdLineTask.py
@@ -31,7 +31,7 @@ __all__ = ["ExampleCmdLineConfig", "ExampleCmdLineTask"]
 # This works even for task(s) that are not in lsst.pipe.tasks.
 ## \addtogroup LSST_task_documentation
 ## \{
-## \page pipeTasks_exampleTask
+## \page page_ExampleTask ExampleTask
 ## \ref ExampleCmdLineTask "ExampleCmdLineTask"
 ##      An example intended to show how to write a command-line task.
 ## \}

--- a/python/lsst/pipe/tasks/exampleCmdLineTask.py
+++ b/python/lsst/pipe/tasks/exampleCmdLineTask.py
@@ -67,14 +67,17 @@ class ExampleCmdLineTask(pipeBase.CmdLineTask):
 
     \copybrief ExampleCmdLineTask
 
-    This task was written as an example for the documents \ref pipeTasks_writeTask
-    and \ref pipeTasks_writeCmdLineTask.
+    This task was written as an example for the documents
+    <a href="https://pipelines.lsst.io/modules/lsst.pipe.base/creating-a-task.html">Creating a task</a>
+    and <a href="https://pipelines.lsst.io/modules/lsst.pipe.base/creating-a-command-line-task.html">
+    Creating a command-line task</a>.
     The task reads in a "calexp" (a calibrated science \ref lsst::afw::image::Exposure "exposure"),
     computes statistics on the image plane, and logs and returns the statistics.
     In addition, if debugging is enabled, it displays the image in current display backend.
 
     The image statistics are computed using a subtask, in order to show how to call subtasks and how to
-    \ref pipeBase_argumentParser_retargetSubtasks "retarget" (replace) them with variant subtasks.
+    <a href="https://pipelines.lsst.io/modules/lsst.pipe.base/command-line-task-retargeting-howto.html">
+    retarget</a> (replace) them with variant subtasks.
 
     The main method is \ref ExampleCmdLineTask.runDataRef "runDataRef".
 
@@ -90,7 +93,8 @@ class ExampleCmdLineTask(pipeBase.CmdLineTask):
         <dd>If True then display the exposure in current display backend
     </dl>
 
-    To enable debugging, see \ref baseDebug.
+    To enable debugging, see
+    <a href="https://pipelines.lsst.io/modules/lsstDebug/">the lsstDebug documentation</a>.
 
     \section pipeTasks_ExampleCmdLineTask_Example A complete example of using ExampleCmdLineTask
 

--- a/python/lsst/pipe/tasks/exampleStatsTasks.py
+++ b/python/lsst/pipe/tasks/exampleStatsTasks.py
@@ -31,7 +31,7 @@ __all__ = ["ExampleSigmaClippedStatsConfig", "ExampleSigmaClippedStatsTask", "Ex
 # This works even for task(s) that are not in lsst.pipe.tasks.
 ## \addtogroup LSST_task_documentation
 ## \{
-## \page pipeTasks_exampleStatsTasks
+## \page page_exampleStatsTasks ExampleStatsTasks
 ## \ref ExampleSigmaClippedStatsTask "ExampleSigmaClippedStatsTask"
 ##      A simple example subtask that computes sigma-clipped statistics of an image
 ## <br>

--- a/python/lsst/pipe/tasks/exampleStatsTasks.py
+++ b/python/lsst/pipe/tasks/exampleStatsTasks.py
@@ -62,7 +62,8 @@ class ExampleSigmaClippedStatsConfig(pexConfig.Config):
 
 
 class ExampleSigmaClippedStatsTask(pipeBase.Task):
-    r"""!Example task to compute sigma-clipped mean and standard deviation of an image
+    r"""!
+    Example task to compute sigma-clipped mean and standard deviation of an image
 
     \section pipeTasks_ExampleSigmaClippedStatsTask_Contents Contents
 
@@ -142,7 +143,8 @@ class ExampleSigmaClippedStatsTask(pipeBase.Task):
 
 
 class ExampleSimpleStatsTask(pipeBase.Task):
-    r"""!Example task to compute mean and standard deviation of an image
+    r"""!
+    Example task to compute mean and standard deviation of an image
 
     \section pipeTasks_ExampleSimpleStatsTask_Contents Contents
 

--- a/python/lsst/pipe/tasks/functors.py
+++ b/python/lsst/pipe/tasks/functors.py
@@ -589,10 +589,10 @@ def mag_aware_eval(df, expr):
     """
     try:
         expr_new = re.sub(r'mag\((\w+)\)', r'-2.5*log(\g<1>)/log(10)', expr)
-        val = df.eval(expr_new, truediv=True)
+        val = df.eval(expr_new)
     except Exception:  # Should check what actually gets raised
         expr_new = re.sub(r'mag\((\w+)\)', r'-2.5*log(\g<1>_instFlux)/log(10)', expr)
-        val = df.eval(expr_new, truediv=True)
+        val = df.eval(expr_new)
     return val
 
 

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -297,12 +297,14 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
 
     @timeMethod
     def runDataRef(self, patchRef, selectDataList=[]):
-        """!Produce <coaddName>Coadd_<warpType>Warp images by warping and optionally PSF-matching.
+        """!
+        Produce @<coaddName>Coadd_@<warpType>Warp images by warping and optionally PSF-matching.
 
         @param[in] patchRef: data reference for sky map patch. Must include keys "tract", "patch",
             plus the camera-specific filter key (e.g. "filter" or "band")
-        @return: dataRefList: a list of data references for the new <coaddName>Coadd_directWarps
-            if direct or both warp types are requested and <coaddName>Coadd_psfMatchedWarps if only psfMatched
+        @return: dataRefList: a list of data references for the new @<coaddName>Coadd_directWarps
+            if direct or both warp types are requested and @<coaddName>Coadd_psfMatchedWarps
+            if only psfMatched
             warps are requested.
 
         @warning: this task assumes that all exposures in a warp (coaddTempExp) have the same filter.

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -302,6 +302,8 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
 
         @param[in] patchRef: data reference for sky map patch. Must include keys "tract", "patch",
             plus the camera-specific filter key (e.g. "filter" or "band")
+        @param[in] selectDataList list of @ref selectImages::SelectStruct "SelectStruct"
+            to consider for selection
         @return: dataRefList: a list of data references for the new @<coaddName>Coadd_directWarps
             if direct or both warp types are requested and @<coaddName>Coadd_psfMatchedWarps
             if only psfMatched

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -127,7 +127,8 @@ class MakeCoaddTempExpConfig(CoaddBaseTask.ConfigClass):
 
 
 class MakeCoaddTempExpTask(CoaddBaseTask):
-    r"""!Warp and optionally PSF-Match calexps onto an a common projection.
+    r"""!
+    Warp and optionally PSF-Match calexps onto an a common projection.
 
     @anchor MakeCoaddTempExpTask_
 

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -146,8 +146,9 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
     Warp and optionally PSF-Match calexps onto a common projection, by
     performing the following operations:
     - Group calexps by visit/run
-    - For each visit, generate a Warp by calling method @ref makeTempExp.
-      makeTempExp loops over the visit's calexps calling @ref WarpAndPsfMatch
+    - For each visit, generate a Warp by calling method @ref run.
+      `run` loops over the visit's calexps calling
+      @ref warpAndPsfMatch::WarpAndPsfMatchTask "WarpAndPsfMatchTask"
       on each visit
 
     The result is a `directWarp` (and/or optionally a `psfMatchedWarp`).
@@ -177,12 +178,12 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
     @section pipe_tasks_makeCoaddTempExp_Config  Configuration parameters
 
     See @ref MakeCoaddTempExpConfig and parameters inherited from
-    @link lsst.pipe.tasks.coaddBase.CoaddBaseConfig CoaddBaseConfig @endlink
+    @link coaddBase::CoaddBaseConfig CoaddBaseConfig @endlink
 
     @subsection pipe_tasks_MakeCoaddTempExp_psfMatching Guide to PSF-Matching Configs
 
     To make `psfMatchedWarps`, select `config.makePsfMatched=True`. The subtask
-    @link lsst.ip.diffim.modelPsfMatch.ModelPsfMatchTask ModelPsfMatchTask @endlink
+    @link ip::diffim::modelPsfMatch::ModelPsfMatchTask ModelPsfMatchTask @endlink
     is responsible for the PSF-Matching, and its config is accessed via `config.warpAndPsfMatch.psfMatch`.
     The optimal configuration depends on aspects of dataset: the pixel scale, average PSF FWHM and
     dimensions of the PSF kernel. These configs include the requested model PSF, the matching kernel size,
@@ -194,7 +195,7 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
     with the worst seeing. The smallest it should be set to is the median FWHM. The defaults
     of the other config options offer a reasonable starting point.
     The following list presents the most common problems that arise from a misconfigured
-    @link lsst.ip.diffim.modelPsfMatch.ModelPsfMatchTask ModelPsfMatchTask @endlink
+    @link ip::diffim::modelPsfMatch::ModelPsfMatchTask ModelPsfMatchTask @endlink
     and corresponding solutions. All assume the default Alard-Lupton kernel, with configs accessed via
     ```config.warpAndPsfMatch.psfMatch.kernel['AL']```. Each item in the list is formatted as:
     Problem: Explanation. *Solution*

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -120,7 +120,7 @@ class MakeCoaddTempExpConfig(CoaddBaseTask.ConfigClass):
 
 ## \addtogroup LSST_task_documentation
 ## \{
-## \page MakeCoaddTempExpTask
+## \page page_MakeCoaddTempExpTask MakeCoaddTempExpTask
 ## \ref MakeCoaddTempExpTask_ "MakeCoaddTempExpTask"
 ## \copybrief MakeCoaddTempExpTask
 ## \}

--- a/python/lsst/pipe/tasks/measurePsf.py
+++ b/python/lsst/pipe/tasks/measurePsf.py
@@ -49,7 +49,7 @@ class MeasurePsfConfig(pexConfig.Config):
 
 ## @addtogroup LSST_task_documentation
 ## @{
-## @page MeasurePsfTask
+## @page page_MeasurePsfTask MeasurePsfTask
 ## @ref MeasurePsfTask_ "MeasurePsfTask"
 ## @copybrief MeasurePsfTask
 ## @}

--- a/python/lsst/pipe/tasks/measurePsf.py
+++ b/python/lsst/pipe/tasks/measurePsf.py
@@ -97,8 +97,10 @@ See @ref MeasurePsfConfig.
 
 @section pipe_tasks_measurePsf_Debug		Debug variables
 
-The @link lsst.pipe.base.cmdLineTask.CmdLineTask command line task@endlink interface supports a
-flag @c -d to import @b debug.py from your @c PYTHONPATH; see @ref baseDebug for more about @b debug.py files.
+The command line task interface supports a
+flag @c -d to import @b debug.py from your @c PYTHONPATH; see
+<a href="https://pipelines.lsst.io/modules/lsstDebug/">the lsstDebug documentation</a>
+for more about @b debug.py files.
 
 <DL>
   <DT> @c display
@@ -121,14 +123,13 @@ Additionally you can enable any debug outputs that your chosen star selector and
 
 @section pipe_tasks_measurePsf_Example	A complete example of using MeasurePsfTask
 
-This code is in @link measurePsfTask.py@endlink in the examples directory, and can be run as @em e.g.
+This code is in `measurePsfTask.py` in the examples directory, and can be run as @em e.g.
 @code
 examples/measurePsfTask.py --doDisplay
 @endcode
 @dontinclude measurePsfTask.py
 
-The example also runs SourceDetectionTask and SingleFrameMeasurementTask;
-see @ref meas_algorithms_measurement_Example for more explanation.
+The example also runs SourceDetectionTask and SingleFrameMeasurementTask.
 
 Import the tasks (there are some other standard imports; read the file to see them all):
 

--- a/python/lsst/pipe/tasks/mergeDetections.py
+++ b/python/lsst/pipe/tasks/mergeDetections.py
@@ -251,7 +251,7 @@ class MergeDetectionsTask(PipelineTask, CmdLineTask):
 
     @section pipe_tasks_multiBand_MergeDetectionsTask_Debug		Debug variables
 
-    The @link lsst.pipe.base.cmdLineTask.CmdLineTask command line task@endlink interface supports a flag @c -d
+    The command line task interface supports a flag @c -d
     to import @b debug.py from your @c PYTHONPATH; see @ref baseDebug for more about @b debug.py files.
 
     MergeDetectionsTask has no debug variables.

--- a/python/lsst/pipe/tasks/mergeMeasurements.py
+++ b/python/lsst/pipe/tasks/mergeMeasurements.py
@@ -119,7 +119,7 @@ class MergeMeasurementsConfig(PipelineTaskConfig, pipelineConnections=MergeMeasu
 
 ## @addtogroup LSST_task_documentation
 ## @{
-## @page MergeMeasurementsTask
+## @page page_MergeMeasurementsTask MergeMeasurementsTask
 ## @ref MergeMeasurementsTask_ "MergeMeasurementsTask"
 ## @copybrief MergeMeasurementsTask
 ## @}

--- a/python/lsst/pipe/tasks/mergeMeasurements.py
+++ b/python/lsst/pipe/tasks/mergeMeasurements.py
@@ -171,7 +171,7 @@ class MergeMeasurementsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
 
     @section pipe_tasks_multiBand_MergeMeasurementsTask_Debug		Debug variables
 
-    The @link lsst.pipe.base.cmdLineTask.CmdLineTask command line task@endlink interface supports a
+    The command line task interface supports a
     flag @c -d to import @b debug.py from your @c PYTHONPATH; see @ref baseDebug for more about @b debug.py
     files.
 

--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -139,7 +139,7 @@ class DetectCoaddSourcesConfig(PipelineTaskConfig, pipelineConnections=DetectCoa
 
 ## @addtogroup LSST_task_documentation
 ## @{
-## @page DetectCoaddSourcesTask
+## @page page_DetectCoaddSourcesTask DetectCoaddSourcesTask
 ## @ref DetectCoaddSourcesTask_ "DetectCoaddSourcesTask"
 ## @copybrief DetectCoaddSourcesTask
 ## @}
@@ -759,7 +759,7 @@ class MeasureMergedCoaddSourcesConfig(PipelineTaskConfig,
 
 ## @addtogroup LSST_task_documentation
 ## @{
-## @page MeasureMergedCoaddSourcesTask
+## @page page_MeasureMergedCoaddSourcesTask MeasureMergedCoaddSourcesTask
 ## @ref MeasureMergedCoaddSourcesTask_ "MeasureMergedCoaddSourcesTask"
 ## @copybrief MeasureMergedCoaddSourcesTask
 ## @}

--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -199,7 +199,7 @@ class DetectCoaddSourcesTask(PipelineTask, CmdLineTask):
 
     @section pipe_tasks_multiBand_DetectCoaddSourcesTask_Debug		Debug variables
 
-    The @link lsst.pipe.base.cmdLineTask.CmdLineTask command line task@endlink interface supports a
+    The command line task interface supports a
     flag @c -d to import @b debug.py from your @c PYTHONPATH; see @ref baseDebug for more about @b debug.py
     files.
 
@@ -842,7 +842,7 @@ class MeasureMergedCoaddSourcesTask(PipelineTask, CmdLineTask):
 
     @section pipe_tasks_multiBand_MeasureMergedCoaddSourcesTask_Debug		Debug variables
 
-    The @link lsst.pipe.base.cmdLineTask.CmdLineTask command line task@endlink interface supports a
+    The command line task interface supports a
     flag @c -d to import @b debug.py from your @c PYTHONPATH; see @ref baseDebug for more about @b debug.py
     files.
 

--- a/python/lsst/pipe/tasks/multiBandUtils.py
+++ b/python/lsst/pipe/tasks/multiBandUtils.py
@@ -148,6 +148,7 @@ def getInputSchema(task, butler=None, schema=None):
     """!
     @brief Obtain the input schema either directly or froma  butler reference.
 
+    @param[in]  task     the task whose input schema is desired
     @param[in]  butler   butler reference to obtain the input schema from
     @param[in]  schema   the input schema
     """
@@ -165,6 +166,7 @@ def readCatalog(task, patchRef):
     We read the input dataset provided by the 'inputDataset'
     class variable.
 
+    @param[in]  task       the task whose input catalog is desired
     @param[in]  patchRef   data reference for patch
     @return tuple consisting of the band name and the catalog
     """

--- a/python/lsst/pipe/tasks/photoCal.py
+++ b/python/lsst/pipe/tasks/photoCal.py
@@ -119,7 +119,7 @@ class PhotoCalConfig(pexConf.Config):
 
 ## @addtogroup LSST_task_documentation
 ## @{
-## @page photoCalTask
+## @page page_photoCalTask PhotoCalTask
 ## @ref PhotoCalTask_ "PhotoCalTask"
 ##      Detect positive and negative sources on an exposure and return a new SourceCatalog.
 ## @}

--- a/python/lsst/pipe/tasks/photoCal.py
+++ b/python/lsst/pipe/tasks/photoCal.py
@@ -401,6 +401,7 @@ into your debug.py file and run photoCalTask.py with the @c --debug flag.
         @c first being of type lsst.afw.table.SimpleRecord and @c second type lsst.afw.table.SourceRecord ---
         the reference object and matched object respectively).
         (will not be modified  except to set the outputField if requested.).
+        @param[in]  expId Exposure identifier; used for seeding the random number generator.
 
         @return Struct of:
          - photoCalib -- @link lsst::afw::image::PhotoCalib @endlink object containing the calibration

--- a/python/lsst/pipe/tasks/photoCal.py
+++ b/python/lsst/pipe/tasks/photoCal.py
@@ -165,8 +165,10 @@ See @ref PhotoCalConfig
 
 @section pipe_tasks_photocal_Debug		Debug variables
 
-The @link lsst.pipe.base.cmdLineTask.CmdLineTask command line task@endlink interface supports a
-flag @c -d to import @b debug.py from your @c PYTHONPATH; see @ref baseDebug for more about @b debug.py files.
+The command line task interface supports a
+flag @c -d to import @b debug.py from your @c PYTHONPATH; see
+<a href="https://pipelines.lsst.io/modules/lsstDebug/">the lsstDebug documentation</a>
+for more about @b debug.py files.
 
 The available variables in PhotoCalTask are:
 <DL>
@@ -189,7 +191,7 @@ The available variables in PhotoCalTask are:
 
 @section pipe_tasks_photocal_Example	A complete example of using PhotoCalTask
 
-This code is in @link examples/photoCalTask.py@endlink, and can be run as @em e.g.
+This code is in `examples/photoCalTask.py`, and can be run as @em e.g.
 @code
 examples/photoCalTask.py
 @endcode
@@ -287,7 +289,7 @@ into your debug.py file and run photoCalTask.py with the @c --debug flag.
     def extractMagArrays(self, matches, filterLabel, sourceKeys):
         """!Extract magnitude and magnitude error arrays from the given matches.
 
-        @param[in] matches Reference/source matches, a @link lsst::afw::table::ReferenceMatchVector@endlink
+        @param[in] matches Reference/source matches, a @link lsst::afw::table::ReferenceMatchVector @endlink
         @param[in] filterLabel Label of filter being calibrated
         @param[in] sourceKeys  Struct of source catalog keys, as returned by getSourceKeys()
 
@@ -401,7 +403,7 @@ into your debug.py file and run photoCalTask.py with the @c --debug flag.
         (will not be modified  except to set the outputField if requested.).
 
         @return Struct of:
-         - photoCalib -- @link lsst::afw::image::PhotoCalib@endlink object containing the calibration
+         - photoCalib -- @link lsst::afw::image::PhotoCalib @endlink object containing the calibration
          - arrays ------ Magnitude arrays returned be PhotoCalTask.extractMagArrays
          - matches ----- Final ReferenceMatchVector, as returned by PhotoCalTask.selectMatches.
          - zp ---------- Photometric zero point (mag)

--- a/python/lsst/pipe/tasks/processCcd.py
+++ b/python/lsst/pipe/tasks/processCcd.py
@@ -69,7 +69,7 @@ class ProcessCcdConfig(pexConfig.Config):
 
 ## \addtogroup LSST_task_documentation
 ## \{
-## \page ProcessCcdTask
+## \page page_ProcessCcdTask ProcessCcdTask
 ## \ref ProcessCcdTask_ "ProcessCcdTask"
 ## \copybrief ProcessCcdTask
 ## \}

--- a/python/lsst/pipe/tasks/processCcd.py
+++ b/python/lsst/pipe/tasks/processCcd.py
@@ -76,7 +76,8 @@ class ProcessCcdConfig(pexConfig.Config):
 
 
 class ProcessCcdTask(pipeBase.CmdLineTask):
-    r"""!Assemble raw data, fit the PSF, detect and measure, and fit WCS and zero-point
+    r"""!
+    Assemble raw data, fit the PSF, detect and measure, and fit WCS and zero-point
 
     @anchor ProcessCcdTask_
 

--- a/python/lsst/pipe/tasks/propagateVisitFlags.py
+++ b/python/lsst/pipe/tasks/propagateVisitFlags.py
@@ -43,7 +43,7 @@ class PropagateVisitFlagsConfig(Config):
 
 ## \addtogroup LSST_task_documentation
 ## \{
-## \page PropagateVisitFlagsTask
+## \page page_PropagateVisitFlagsTask PropagateVisitFlagsTask
 ## \ref PropagateVisitFlagsTask_ "PropagateVisitFlagsTask"
 ## \copybrief PropagateVisitFlagsTask
 ## \}

--- a/python/lsst/pipe/tasks/repair.py
+++ b/python/lsst/pipe/tasks/repair.py
@@ -100,7 +100,7 @@ class RepairTask(pipeBase.Task):
 
     @section pipe_tasks_repair_Debug Debug variables
 
-    The @link lsst.pipe.base.cmdLineTask.CmdLineTask command line task@endlink interface supports a
+    The command line task interface supports a
     flag @c -d to import @b debug.py from your @c PYTHONPATH; see <a
     href="https://developer.lsst.io/stack/debug.html">Debugging Tasks with lsstDebug</a> for more
     about @b debug.py files.

--- a/python/lsst/pipe/tasks/repair.py
+++ b/python/lsst/pipe/tasks/repair.py
@@ -57,7 +57,7 @@ class RepairConfig(pexConfig.Config):
 
 ## @addtogroup LSST_task_documentation
 ## @{
-## @page RepairTask
+## @page page_RepairTask RepairTask
 ## @ref RepairTask_ "RepairTask"
 ## @copybrief RepairTask
 ## @}

--- a/python/lsst/pipe/tasks/snapCombine.py
+++ b/python/lsst/pipe/tasks/snapCombine.py
@@ -127,7 +127,7 @@ class SnapCombineConfig(pexConfig.Config):
 
 ## \addtogroup LSST_task_documentation
 ## \{
-## \page SnapCombineTask
+## \page page_SnapCombineTask SnapCombineTask
 ## \ref SnapCombineTask_ "SnapCombineTask"
 ## \copybrief SnapCombineTask
 ## \}

--- a/python/lsst/pipe/tasks/snapCombine.py
+++ b/python/lsst/pipe/tasks/snapCombine.py
@@ -145,7 +145,7 @@ class SnapCombineTask(pipeBase.Task):
 
     \section pipe_tasks_snapcombine_Debug Debug variables
 
-    The \link lsst.pipe.base.cmdLineTask.CmdLineTask command line task\endlink interface supports a
+    The command line task interface supports a
     flag \c -d to import \b debug.py from your \c PYTHONPATH; see <a
     href="https://developer.lsst.io/stack/debug.html">Debugging Tasks with lsstDebug</a> for more
     about \b debug.py files.

--- a/python/lsst/pipe/tasks/transformMeasurement.py
+++ b/python/lsst/pipe/tasks/transformMeasurement.py
@@ -170,7 +170,7 @@ class RunTransformTaskBase(pipeBase.CmdLineTask):
 
     \brief Command line interface for TransformTask.
 
-    \section pipe_tasks_transform_Contents Contents
+    \section pipe_tasks_runtransform_Contents Contents
 
      - \ref pipe_tasks_runtransform_purpose
      - \ref pipe_tasks_runtransform_invoke

--- a/python/lsst/pipe/tasks/transformMeasurement.py
+++ b/python/lsst/pipe/tasks/transformMeasurement.py
@@ -46,7 +46,7 @@ class TransformConfig(pexConfig.Config):
 
 ## \addtogroup LSST_task_documentation
 ## \{
-## \page TransformTask
+## \page page_TransformTask TransformTask
 ## \ref TransformTask_ "TransformTask"
 ## \copybrief TransformTask
 ## \}
@@ -266,7 +266,7 @@ class RunTransformTaskBase(pipeBase.CmdLineTask):
 
 ## \addtogroup LSST_task_documentation
 ## \{
-## \page SrcTransformTask
+## \page page_SrcTransformTask SrcTransformTask
 ## \ref SrcTransformTask_ "SrcTransformTask"
 ## \copybrief SrcTransformTask
 ## \}
@@ -291,7 +291,7 @@ class SrcTransformTask(RunTransformTaskBase):
 
 ## \addtogroup LSST_task_documentation
 ## \{
-## \page ForcedSrcTransformTask
+## \page page_ForcedSrcTransformTask ForcedSrcTransformTask
 ## \ref ForcedSrcTransformTask_ "ForcedSrcTransformTask"
 ## \copybrief ForcedSrcTransformTask
 ## \}
@@ -312,7 +312,7 @@ class ForcedSrcTransformTask(RunTransformTaskBase):
 
 ## \addtogroup LSST_task_documentation
 ## \{
-## \page CoaddSrcTransformTask
+## \page page_CoaddSrcTransformTask CoaddSrcTransformTask
 ## \ref CoaddSrcTransformTask_ "CoaddSrcTransformTask"
 ## \copybrief CoaddSrcTransformTask
 ## \}

--- a/tests/test_finalizeCharacterization.py
+++ b/tests/test_finalizeCharacterization.py
@@ -64,6 +64,8 @@ class MockDataFrameReference(lsst.daf.butler.DeferredDatasetHandle):
 class TestFinalizeCharacterizationTask(FinalizeCharacterizationTask):
     """A derived class which skips the initialization routines.
     """
+    __test__ = False  # Stop Pytest from trying to parse as a TestCase
+
     def __init__(self, **kwargs):
         pipeBase.PipelineTask.__init__(self, **kwargs)
 

--- a/ups/pipe_tasks.cfg
+++ b/ups/pipe_tasks.cfg
@@ -8,9 +8,7 @@ dependencies = dict(
         "daf_persistence",
         "log",
         "meas_base",
-        "obs_base",
         "pex_config",
-        "utils",
         ],
     optional = [
         "coadd_utils",


### PR DESCRIPTION
This PR cleans up a very long list of Doxygen errors in `pipe_tasks`, as well as some unrelated warnings that were easy fixes. Given the ongoing (if stalled) documentation migration, I've prioritized error-free builds over correct ones, intervening for correctness only if I found an issue that badly corrupted the documentation (e.g., failure to properly close `@link` tags).

While few of the fixes overlap, some of them are non-obvious, so I recommend reviewing this PR commit-by-commit for context.