### PR TITLE
DM-34364: Use the PSF-matched template for decorrelation

### DIFF
--- a/python/lsst/pipe/tasks/imageDifference.py
+++ b/python/lsst/pipe/tasks/imageDifference.py
@@ -1029,7 +1029,7 @@ class ImageDifferenceTask(pipeBase.CmdLineTask, pipeBase.PipelineTask):
                     if self.config.useGaussianForPreConvolution:
                         preConvKernel = preConvPsf.getLocalKernel()
                     if self.config.useScoreImageDetection:
-                        scoreExposure = self.decorrelate.run(exposureOrig, subtractRes.warpedExposure,
+                        scoreExposure = self.decorrelate.run(exposureOrig, subtractRes.matchedExposure,
                                                              scoreExposure,
                                                              subtractRes.psfMatchingKernel,
                                                              spatiallyVarying=self.config.doSpatiallyVarying,
@@ -1038,7 +1038,7 @@ class ImageDifferenceTask(pipeBase.CmdLineTask, pipeBase.PipelineTask):
                                                              preConvMode=True).correctedExposure
                     # Note that the subtracted exposure is always decorrelated,
                     # even if the score image is used for detection
-                    subtractedExposure = self.decorrelate.run(exposureOrig, subtractRes.warpedExposure,
+                    subtractedExposure = self.decorrelate.run(exposureOrig, subtractRes.matchedExposure,
                                                               subtractedExposure,
                                                               subtractRes.psfMatchingKernel,
                                                               spatiallyVarying=self.config.doSpatiallyVarying,


### PR DESCRIPTION
Decorrelation is supposed to correct the correlated noise caused by convolving the template with the PSF matching kernel, so we need to actually supply the PSF-matched template to the calculation. Currently we are passing in the warped, but not PSF-matched, template.