### PR TITLE
DM-33959: Calibrate Source Tables with Global Calibrations

### DIFF
--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -398,17 +398,17 @@ class WriteRecalibratedSourceTableConfig(WriteSourceTableConfig,
 
     doReevaluatePhotoCalib = pexConfig.Field(
         dtype=bool,
-        default=False,
+        default=True,
         doc=("Add or replace local photoCalib columns from either the calexp.photoCalib or jointcal/FGCM")
     )
     doReevaluateSkyWcs = pexConfig.Field(
         dtype=bool,
-        default=False,
+        default=True,
         doc=("Add or replace local WCS columns from either the calexp.wcs or  or jointcal")
     )
     doApplyExternalPhotoCalib = pexConfig.Field(
         dtype=bool,
-        default=False,
+        default=True,
         doc=("Whether to apply external photometric calibration via an "
              "`lsst.afw.image.PhotoCalib` object. Uses the "
              "``externalPhotoCalibName`` field to determine which calibration "
@@ -416,7 +416,7 @@ class WriteRecalibratedSourceTableConfig(WriteSourceTableConfig,
     )
     doApplyExternalSkyWcs = pexConfig.Field(
         dtype=bool,
-        default=False,
+        default=True,
         doc=("Whether to apply external astrometric calibration via an "
              "`lsst.afw.geom.SkyWcs` object. Uses ``externalSkyWcsName`` "
              "field to determine which calibration to load."),


### PR DESCRIPTION
Switch configs to reEval and doApplyExternal to True

Almost every time this task will be used after DP0.2
will be to apply jointcal/FGCM calibrations to the
source tables