### PR TITLE
DM-27177: Deprecate transitional getFilterLabel API

### DIFF
--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -898,7 +898,7 @@ class AssembleCoaddTask(CoaddBaseTask, pipeBase.PipelineTask):
 
         # Set the coadd FilterLabel to the band of the first input exposure:
         # Coadds are calibrated, so the physical label is now meaningless.
-        coaddExposure.setFilterLabel(afwImage.FilterLabel(tempExpList[0].getFilterLabel().bandLabel))
+        coaddExposure.setFilter(afwImage.FilterLabel(tempExpList[0].getFilter().bandLabel))
         coaddInputs = coaddExposure.getInfo().getCoaddInputs()
         coaddInputs.ccds.reserve(numCcds)
         coaddInputs.visits.reserve(len(tempExpList))

--- a/python/lsst/pipe/tasks/coaddInputRecorder.py
+++ b/python/lsst/pipe/tasks/coaddInputRecorder.py
@@ -112,7 +112,7 @@ class CoaddTempExpInputRecorder:
             self._setExposureInfoInRecord(exposure=calExp, record=record)
             if self.task.config.saveCcdWeights:
                 record.setD(self.task.ccdWeightKey, 1.0)  # No weighting or overlap when warping
-            record.set(self.task.ccdFilterKey, calExp.getFilterLabel().physicalLabel)
+            record.set(self.task.ccdFilterKey, calExp.getFilter().physicalLabel)
 
     def finish(self, coaddTempExp, nGoodPix=None):
         """Finish creating the CoaddInputs for a CoaddTempExp.
@@ -216,7 +216,7 @@ class CoaddInputRecorderTask(pipeBase.Task):
         outputVisitRecord = coaddInputs.visits.addNew()
         outputVisitRecord.assign(inputVisitRecord)
         outputVisitRecord.setD(self.visitWeightKey, weight)
-        outputVisitRecord.set(self.visitFilterKey, coaddTempExp.getFilterLabel().physicalLabel)
+        outputVisitRecord.set(self.visitFilterKey, coaddTempExp.getFilter().physicalLabel)
         for inputCcdRecord in tempExpInputs.ccds:
             if inputCcdRecord.getL(self.ccdVisitKey) != inputVisitRecord.getId():
                 self.log.warning("CoaddInputs for coaddTempExp with id %d contains CCDs with visit=%d. "
@@ -226,5 +226,5 @@ class CoaddInputRecorderTask(pipeBase.Task):
             outputCcdRecord.assign(inputCcdRecord)
             if self.config.saveCcdWeights:
                 outputCcdRecord.setD(self.ccdWeightKey, weight)
-            outputCcdRecord.set(self.ccdFilterKey, coaddTempExp.getFilterLabel().physicalLabel)
+            outputCcdRecord.set(self.ccdFilterKey, coaddTempExp.getFilter().physicalLabel)
         return inputVisitRecord

--- a/python/lsst/pipe/tasks/dcrAssembleCoadd.py
+++ b/python/lsst/pipe/tasks/dcrAssembleCoadd.py
@@ -531,7 +531,7 @@ class DcrAssembleCoaddTask(CompareWarpAssembleCoaddTask):
             If ``lambdaMin`` is missing from the Mapper class of the obs package being used.
         """
         sigma2fwhm = 2.*np.sqrt(2.*np.log(2.))
-        filterLabel = templateCoadd.getFilterLabel()
+        filterLabel = templateCoadd.getFilter()
         tempExpName = self.getTempExpDatasetName(self.warpType)
         dcrShifts = []
         airmassDict = {}

--- a/python/lsst/pipe/tasks/hips.py
+++ b/python/lsst/pipe/tasks/hips.py
@@ -249,7 +249,7 @@ class HighResolutionHipsTask(pipeBase.PipelineTask):
                     # Make sure the mask planes, filter, and photocalib of the output
                     # exposure match the (first) input exposure.
                     exp_hpx_dict[pixel].mask.conformMaskPlanes(coadd_exp.mask.getMaskPlaneDict())
-                    exp_hpx_dict[pixel].setFilterLabel(coadd_exp.getFilterLabel())
+                    exp_hpx_dict[pixel].setFilter(coadd_exp.getFilter())
                     exp_hpx_dict[pixel].setPhotoCalib(coadd_exp.getPhotoCalib())
 
                 if warped.getBBox().getArea() == 0 or not np.any(np.isfinite(warped.image.array)):

--- a/python/lsst/pipe/tasks/insertFakes.py
+++ b/python/lsst/pipe/tasks/insertFakes.py
@@ -650,7 +650,7 @@ class InsertFakesTask(PipelineTask, CmdLineTask):
         image.setWcs(wcs)
         image.setPhotoCalib(photoCalib)
 
-        band = image.getFilterLabel().bandLabel
+        band = image.getFilter().bandLabel
         fakeCat = self._standardizeColumns(fakeCat, band)
 
         fakeCat = self.addPixCoords(fakeCat, image)
@@ -894,7 +894,7 @@ class InsertFakesTask(PipelineTask, CmdLineTask):
         gsObjects : `generator`
             A generator of tuples of `lsst.geom.SpherePoint` and `galsim.GSObject`.
         """
-        band = exposure.getFilterLabel().bandLabel
+        band = exposure.getFilter().bandLabel
         wcs = exposure.getWcs()
         photoCalib = exposure.getPhotoCalib()
 

--- a/python/lsst/pipe/tasks/makeCoaddTempExp.py
+++ b/python/lsst/pipe/tasks/makeCoaddTempExp.py
@@ -467,7 +467,7 @@ class MakeCoaddTempExpTask(CoaddBaseTask):
                     if numGoodPix[warpType] > 0 and not didSetMetadata[warpType]:
                         coaddTempExp.info.id = exposure.info.id
                         coaddTempExp.setPhotoCalib(exposure.getPhotoCalib())
-                        coaddTempExp.setFilterLabel(exposure.getFilterLabel())
+                        coaddTempExp.setFilter(exposure.getFilter())
                         coaddTempExp.getInfo().setVisitInfo(exposure.getInfo().getVisitInfo())
                         # PSF replaced with CoaddPsf after loop if and only if creating direct warp
                         coaddTempExp.setPsf(exposure.getPsf())

--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -1248,7 +1248,7 @@ class MeasureMergedCoaddSourcesTask(PipelineTask, CmdLineTask):
         results = Struct()
 
         if self.config.doMatchSources:
-            matchResult = self.match.run(sources, exposure.getInfo().getFilterLabel().bandLabel)
+            matchResult = self.match.run(sources, exposure.getInfo().getFilter().bandLabel)
             matches = afwTable.packMatches(matchResult.matches)
             matches.table.setMetadata(matchResult.matchMeta)
             results.matchResult = matches

--- a/python/lsst/pipe/tasks/photoCal.py
+++ b/python/lsst/pipe/tasks/photoCal.py
@@ -448,7 +448,7 @@ into your debug.py file and run photoCalTask.py with the @c --debug flag.
             except Exception:
                 self.fig = pyplot.figure()
 
-        filterLabel = exposure.getFilterLabel()
+        filterLabel = exposure.getFilter()
 
         # Match sources
         matchResults = self.match.run(sourceCat, filterLabel.bandLabel)

--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -193,7 +193,7 @@ class WriteObjectTableTask(CmdLineTask, pipeBase.PipelineTask):
         Tuple consisting of band name and a dict of catalogs, keyed by
         dataset name
         """
-        band = patchRef.get(self.config.coaddName + "Coadd_filterLabel", immediate=True).bandLabel
+        band = patchRef.get(self.config.coaddName + "Coadd_filter", immediate=True).bandLabel
         catalogDict = {}
         for dataset in self.inputDatasets:
             catalog = patchRef.get(self.config.coaddName + "Coadd_" + dataset, immediate=True)
@@ -1443,7 +1443,7 @@ class ConsolidateVisitSummaryTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         for i, dataRef in enumerate(dataRefs):
             if isGen3:
                 visitInfo = dataRef.get(component='visitInfo')
-                filterLabel = dataRef.get(component='filterLabel')
+                filterLabel = dataRef.get(component='filter')
                 summaryStats = dataRef.get(component='summaryStats')
                 detector = dataRef.get(component='detector')
                 wcs = dataRef.get(component='wcs')
@@ -1457,7 +1457,7 @@ class ConsolidateVisitSummaryTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                 gen2_read_bbox = lsst.geom.BoxI(lsst.geom.PointI(0, 0), lsst.geom.PointI(1, 1))
                 exp = dataRef.get(datasetType='calexp_sub', bbox=gen2_read_bbox)
                 visitInfo = exp.getInfo().getVisitInfo()
-                filterLabel = dataRef.get("calexp_filterLabel")
+                filterLabel = dataRef.get("calexp_filter")
                 summaryStats = exp.getInfo().getSummaryStats()
                 wcs = exp.getWcs()
                 photoCalib = exp.getPhotoCalib()

--- a/python/lsst/pipe/tasks/processCcdWithFakes.py
+++ b/python/lsst/pipe/tasks/processCcdWithFakes.py
@@ -736,7 +736,7 @@ class ProcessCcdWithVariableFakesTask(ProcessCcdWithFakesTask):
         if exposureIdInfo is None:
             exposureIdInfo = ExposureIdInfo()
 
-        band = exposure.getFilterLabel().bandLabel
+        band = exposure.getFilter().bandLabel
         ccdVisitMagnitudes = self.addVariablity(fakeCat, band, exposure, photoCalib, exposureIdInfo)
 
         self.insertFakes.run(fakeCat, exposure, wcs, photoCalib)

--- a/tests/assembleCoaddTestUtils.py
+++ b/tests/assembleCoaddTestUtils.py
@@ -425,7 +425,7 @@ class MockCoaddTestData:
         tempExp = rawExposure.clone()
         tempExp.setWcs(self.wcs)
 
-        tempExp.setFilterLabel(self.filterLabel)
+        tempExp.setFilter(self.filterLabel)
         tempExp.setPhotoCalib(self.photoCalib)
         tempExp.getInfo().setVisitInfo(visitInfo)
         tempExp.getInfo().setDetector(self.detector)

--- a/tests/test_coaddInputs.py
+++ b/tests/test_coaddInputs.py
@@ -108,7 +108,7 @@ class MockExposure:
         expInfo.setPhotoCalib(lsst.afw.image.makePhotoCalibFromCalibZeroPoint(1.1e12, 2.2e10))
         expInfo.setApCorrMap(self.makeApCorrMap())
         expInfo.setValidPolygon(lsst.afw.geom.Polygon(lsst.geom.Box2D(bbox).getCorners()))
-        expInfo.setFilterLabel(lsst.afw.image.FilterLabel(physical="fakeFilter", band="fake"))
+        expInfo.setFilter(lsst.afw.image.FilterLabel(physical="fakeFilter", band="fake"))
         if self.version > 1:
             expInfo.setVisitInfo(self.makeVisitInfo())
 

--- a/tests/test_hips.py
+++ b/tests/test_hips.py
@@ -92,7 +92,7 @@ class HipsTestCase(unittest.TestCase):
 
         # Check that metadata is correct
         self.assertEqual(output.hips_exposures[pixel].getPhotoCalib(), exposure.getPhotoCalib())
-        self.assertEqual(output.hips_exposures[pixel].getFilterLabel(), exposure.getFilterLabel())
+        self.assertEqual(output.hips_exposures[pixel].getFilter(), exposure.getFilter())
 
     def test_hips_double(self):
         """Test creating a HIPS image from two neighboring patches."""
@@ -192,7 +192,7 @@ class HipsTestCase(unittest.TestCase):
         exposure.image.array[:, :] = np.random.normal(scale=1.0, size=exposure.image.array.shape)
         exposure.setWcs(patch_info.wcs)
         exposure.setPhotoCalib(lsst.afw.image.PhotoCalib(calibrationMean=1.0))
-        exposure.setFilterLabel(lsst.afw.image.FilterLabel(band='i'))
+        exposure.setFilter(lsst.afw.image.FilterLabel(band='i'))
 
         return exposure
 

--- a/tests/test_photoCal.py
+++ b/tests/test_photoCal.py
@@ -71,7 +71,7 @@ class PhotoCalTest(unittest.TestCase):
         smallExposure = afwImage.ExposureF(os.path.join(testDir, "data", "v695833-e0-c000-a00.sci.fits"))
         self.exposure = afwImage.ExposureF(self.bbox)
         self.exposure.setWcs(smallExposure.getWcs())
-        self.exposure.setFilterLabel(afwImage.FilterLabel(band="i", physical="test-i"))
+        self.exposure.setFilter(afwImage.FilterLabel(band="i", physical="test-i"))
         self.exposure.setPhotoCalib(smallExposure.getPhotoCalib())
 
         coordKey = self.srcCat.getCoordKey()


### PR DESCRIPTION
This PR removes references to `getFilterLabel` and similarly-named methods, replacing them with `getFilter` (etc.) methods backed by `FilterLabel`.