### PR TITLE
DM-35083: Add support for new and old smatch grouping API.

### DIFF
--- a/python/lsst/pipe/tasks/isolatedStarAssociation.py
+++ b/python/lsst/pipe/tasks/isolatedStarAssociation.py
@@ -385,7 +385,12 @@ class IsolatedStarAssociationTask(pipeBase.PipelineTask):
             dec = star_source_cat[dec_col][use]
 
             with Matcher(ra, dec) as matcher:
-                idx = matcher.query_self(self.config.match_radius/3600., min_match=1)
+                try:
+                    # New smatch API
+                    idx = matcher.query_groups(self.config.match_radius/3600., min_match=1)
+                except AttributeError:
+                    # Old smatch API
+                    idx = matcher.query_self(self.config.match_radius/3600., min_match=1)
 
             count = len(idx)
 
@@ -457,7 +462,12 @@ class IsolatedStarAssociationTask(pipeBase.PipelineTask):
         with Matcher(primary_star_cat[ra_col], primary_star_cat[dec_col]) as matcher:
             # By setting min_match=2 objects that only match to themselves
             # will not be recorded.
-            idx = matcher.query_self(self.config.isolation_radius/3600., min_match=2)
+            try:
+                # New smatch API
+                idx = matcher.query_groups(self.config.isolation_radius/3600., min_match=2)
+            except AttributeError:
+                # Old smatch API
+                idx = matcher.query_self(self.config.isolation_radius/3600., min_match=2)
 
         try:
             neighbor_indices = np.concatenate(idx)


### PR DESCRIPTION
The smatch API for matching a catalog to itself is changing in a breaking way for the upcoming 0.10 version.  The current rubin-env is pinned so that it won't be updated without us deliberately making the update.  This PR adds support for both the old and the new API, to smooth this transition.