### PR TITLE
DM-33256: Remove Gen 2 support from verify

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,5 +1,5 @@
 Copyright 2014-2019 The Trustees of Princeton University
-Copyright 2014-2019 University of Washington
+Copyright 2014-2022 University of Washington
 Copyright 2014-2018 Association of Universities for Research in Astronomy
 Copyright 2016-2018 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
 Copyright 2014-2015, 2017 The Regents of the University of California

--- a/python/lsst/pipe/tasks/metrics.py
+++ b/python/lsst/pipe/tasks/metrics.py
@@ -30,7 +30,6 @@ import astropy.units as u
 
 from lsst.pipe.base import Struct, connectionTypes
 from lsst.verify import Measurement
-from lsst.verify.gen2tasks import register
 from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections, MetricComputationError
 
 
@@ -54,7 +53,6 @@ class NumberDeblendedSourcesMetricConfig(
     pass
 
 
-@register("numDeblendedSciSources")
 class NumberDeblendedSourcesMetricTask(MetricTask):
     """Task that computes the number of science sources that have
     been deblended.
@@ -139,7 +137,6 @@ class NumberDeblendChildSourcesMetricConfig(
     pass
 
 
-@register("numDeblendChildSciSources")
 class NumberDeblendChildSourcesMetricTask(MetricTask):
     """Task that computes the number of science sources created
     through deblending.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -29,7 +29,7 @@ from lsst.afw.table import SourceCatalog
 import lsst.utils.tests
 import lsst.pipe.base.testUtils
 from lsst.verify import Name
-from lsst.verify.gen2tasks.testUtils import MetricTaskTestCase
+from lsst.verify.tasks.testUtils import MetricTaskTestCase
 
 from lsst.pipe.tasks.metrics import \
     NumberDeblendedSourcesMetricTask, NumberDeblendChildSourcesMetricTask


### PR DESCRIPTION
This PR removes use of the `lsst.verify.gen2tasks.register` decorator, which is removed in lsst/verify#103.