### PR TITLE
DM-36198: Allow fakes propagation in postprocessing

### DIFF
--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -1456,7 +1456,7 @@ class MakeCcdVisitTableConnections(pipeBase.PipelineTaskConnections,
     )
     outputCatalog = connectionTypes.Output(
         doc="CCD and Visit metadata table",
-        name="ccdVisitTable",
+        name="{calexpType}ccdVisitTable",
         storageClass="DataFrame",
         dimensions=("instrument",)
     )
@@ -1561,7 +1561,7 @@ class MakeVisitTableConnections(pipeBase.PipelineTaskConnections,
     )
     outputCatalog = connectionTypes.Output(
         doc="Visit metadata table",
-        name="visitTable",
+        name="{calexpType}visitTable",
         storageClass="DataFrame",
         dimensions=("instrument",)
     )


### PR DESCRIPTION
This PR adds the `calexpType` template to the outputs of `MakeCcdVisitTableTask` and `MakeVisitTableTask` (they were added to inputs on 80aa66dc92c83c1e284b116ae07675d6559376d3). This makes it possible run both fakes and non-fakes versions of these tasks in the same pipeline, though the only difference in output should be a few extra columns in the fakes version.