### PR TITLE
DM-30869: Modernize MetricTask for better Gen 3 workflow

### DIFF
--- a/python/lsst/pipe/tasks/metrics.py
+++ b/python/lsst/pipe/tasks/metrics.py
@@ -76,8 +76,8 @@ class NumberDeblendedSourcesMetricTask(MetricTask):
 
         Parameters
         ----------
-        sources : `lsst.afw.table.SourceCatalog` or `None`
-            A science source catalog, which may be empty or `None`.
+        sources : `lsst.afw.table.SourceCatalog`
+            A science source catalog, which may be empty.
 
         Returns
         -------
@@ -95,10 +95,7 @@ class NumberDeblendedSourcesMetricTask(MetricTask):
             Raised if ``sources`` is missing mandatory keys for
             source catalogs.
         """
-        if sources is None:
-            self.log.info("Nothing to do: no catalogs found.")
-            meas = None
-        elif "deblend_nChild" not in sources.schema:
+        if "deblend_nChild" not in sources.schema:
             self.log.info("Nothing to do: no deblending performed.")
             meas = None
         else:
@@ -159,8 +156,8 @@ class NumberDeblendChildSourcesMetricTask(MetricTask):
 
         Parameters
         ----------
-        sources : `lsst.afw.table.SourceCatalog` or `None`
-            A science source catalog, which may be empty or `None`.
+        sources : `lsst.afw.table.SourceCatalog`
+            A science source catalog, which may be empty.
 
         Returns
         -------
@@ -178,12 +175,9 @@ class NumberDeblendChildSourcesMetricTask(MetricTask):
             Raised if ``sources`` is missing mandatory keys for
             source catalogs.
         """
-        if sources is None:
-            self.log.info("Nothing to do: no catalogs found.")
-            meas = None
         # Use deblend_parentNChild rather than detect_fromBlend because the
         # latter need not be defined in post-deblending catalogs.
-        elif "deblend_parentNChild" not in sources.schema or "deblend_nChild" not in sources.schema:
+        if "deblend_parentNChild" not in sources.schema or "deblend_nChild" not in sources.schema:
             self.log.info("Nothing to do: no deblending performed.")
             meas = None
         else:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -182,12 +182,6 @@ class TestNumDeblended(MetricTaskTestCase):
         meas = result.measurement
         self.assertIsNone(meas)
 
-    def testMissingData(self):
-        result = self.task.run(None)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
-
 
 class TestNumDeblendChild(MetricTaskTestCase):
 
@@ -246,12 +240,6 @@ class TestNumDeblendChild(MetricTaskTestCase):
     def testNoDeblending(self):
         catalog = _makeDummyCatalog(3, deblendFlags=False)
         result = self.task.run(catalog)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
-
-    def testMissingData(self):
-        result = self.task.run(None)
         lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
         meas = result.measurement
         self.assertIsNone(meas)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -177,10 +177,16 @@ class TestNumDeblended(MetricTaskTestCase):
 
     def testNoDeblending(self):
         catalog = _makeDummyCatalog(3, deblendFlags=False)
-        result = self.task.run(catalog)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
+        try:
+            result = self.task.run(catalog)
+        except lsst.pipe.base.NoWorkFound:
+            # Correct behavior
+            pass
+        else:
+            # Alternative correct behavior
+            lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
+            meas = result.measurement
+            self.assertIsNone(meas)
 
 
 class TestNumDeblendChild(MetricTaskTestCase):
@@ -239,10 +245,16 @@ class TestNumDeblendChild(MetricTaskTestCase):
 
     def testNoDeblending(self):
         catalog = _makeDummyCatalog(3, deblendFlags=False)
-        result = self.task.run(catalog)
-        lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
-        meas = result.measurement
-        self.assertIsNone(meas)
+        try:
+            result = self.task.run(catalog)
+        except lsst.pipe.base.NoWorkFound:
+            # Correct behavior
+            pass
+        else:
+            # Alternative correct behavior
+            lsst.pipe.base.testUtils.assertValidOutput(self.task, result)
+            meas = result.measurement
+            self.assertIsNone(meas)
 
 
 # Hack around unittest's hacky test setup system


### PR DESCRIPTION
This PR removes all code for handling `None` inputs from concrete `MetricTasks` and raises `NoWorkFound` where appropriate.