### PR TITLE
DM-36440: Add EpochPropertyMap to track observing epoch in coadds.

### DIFF
--- a/python/lsst/pipe/tasks/healSparseMapping.py
+++ b/python/lsst/pipe/tasks/healSparseMapping.py
@@ -435,7 +435,8 @@ class HealSparsePropertyMapConfig(pipeBase.PipelineTaskConfig,
                  "dcr_dra",
                  "dcr_ddec",
                  "dcr_e1",
-                 "dcr_e2"],
+                 "dcr_e2",
+                 "epoch"],
         doc="Property map computation objects",
     )
 
@@ -451,6 +452,9 @@ class HealSparsePropertyMapConfig(pipeBase.PipelineTaskConfig,
         self.property_maps["dcr_ddec"].do_weighted_mean = True
         self.property_maps["dcr_e1"].do_weighted_mean = True
         self.property_maps["dcr_e2"].do_weighted_mean = True
+        self.property_maps["epoch"].do_mean = True
+        self.property_maps["epoch"].do_min = True
+        self.property_maps["epoch"].do_max = True
 
 
 class HealSparsePropertyMapTask(pipeBase.PipelineTask):
@@ -847,7 +851,8 @@ class ConsolidateHealSparsePropertyMapConfig(pipeBase.PipelineTaskConfig,
                  "dcr_dra",
                  "dcr_ddec",
                  "dcr_e1",
-                 "dcr_e2"],
+                 "dcr_e2",
+                 "epoch"],
         doc="Property map computation objects",
     )
     nside_coverage = pexConfig.Field(
@@ -869,6 +874,9 @@ class ConsolidateHealSparsePropertyMapConfig(pipeBase.PipelineTaskConfig,
         self.property_maps["dcr_ddec"].do_weighted_mean = True
         self.property_maps["dcr_e1"].do_weighted_mean = True
         self.property_maps["dcr_e2"].do_weighted_mean = True
+        self.property_maps["epoch"].do_mean = True
+        self.property_maps["epoch"].do_min = True
+        self.property_maps["epoch"].do_max = True
 
 
 class ConsolidateHealSparsePropertyMapTask(pipeBase.PipelineTask):

--- a/python/lsst/pipe/tasks/healSparseMapping.py
+++ b/python/lsst/pipe/tasks/healSparseMapping.py
@@ -554,8 +554,14 @@ class HealSparsePropertyMapTask(pipeBase.PipelineTask):
             patch_radec = self._vertices_to_radec(poly_vertices)
             patch_poly = hsp.Polygon(ra=patch_radec[:, 0], dec=patch_radec[:, 1],
                                      value=np.arange(input_map.wide_mask_maxbits))
-            patch_poly_map = patch_poly.get_map_like(input_map)
-            input_map = hsp.and_intersection([input_map, patch_poly_map])
+            with warnings.catch_warnings():
+                # Healsparse will emit a warning if nside coverage is greater than
+                # 128.  In the case of generating patch input maps, and not global
+                # maps, high nside coverage works fine, so we can suppress this
+                # warning.
+                warnings.simplefilter("ignore")
+                patch_poly_map = patch_poly.get_map_like(input_map)
+                input_map = hsp.and_intersection([input_map, patch_poly_map])
 
             if not tract_maps_initialized:
                 # We use the first input map nside information to initialize

--- a/python/lsst/pipe/tasks/healSparseMappingProperties.py
+++ b/python/lsst/pipe/tasks/healSparseMappingProperties.py
@@ -25,7 +25,7 @@ __all__ = ["BasePropertyMapConfig", "PropertyMapRegistry", "register_property_ma
            "NExposurePropertyMap", "PsfMaglimPropertyMapConfig",
            "PsfMaglimPropertyMap", "SkyBackgroundPropertyMap", "SkyNoisePropertyMap",
            "DcrDraPropertyMap", "DcrDdecPropertyMap", "DcrE1PropertyMap",
-           "DcrE2PropertyMap", "compute_approx_psf_size_and_shape"]
+           "DcrE2PropertyMap", "EpochPropertyMap", "compute_approx_psf_size_and_shape"]
 
 import numpy as np
 import healsparse as hsp
@@ -496,3 +496,11 @@ class DcrE2PropertyMap(BasePropertyMap):
     def _compute(self, row, ra, dec, scalings, psf_array=None):
         par_angle = row.getVisitInfo().getBoresightParAngle().asRadians()
         return (np.tan(np.deg2rad(row["zenithDistance"]))**2.)*np.sin(2.*par_angle)
+
+
+@register_property_map("epoch")
+class EpochPropertyMap(BasePropertyMap):
+    """Observation epoch (mjd) property map."""
+    def _compute(self, row, ra, dec, scalings, psf_array=None):
+        date = row.getVisitInfo().getDate()
+        return date.get(date.MJD)


### PR DESCRIPTION
This also fixes the high coverage nside warnings from healsparse which were not fully suppressed.