### PR TITLE
DM-2850: Remove getSchemaCatalogs methods

### DIFF
--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -680,14 +680,6 @@ class CalibrateTask(pipeBase.PipelineTask):
             outputBackground=background,
         )
 
-    def getSchemaCatalogs(self):
-        """Return a dict of empty catalogs for each catalog dataset produced
-        by this task.
-        """
-        sourceCat = afwTable.SourceCatalog(self.schema)
-        sourceCat.getTable().setMetadata(self.algMetadata)
-        return {"src": sourceCat}
-
     def setMetadata(self, exposure, photoRes=None):
         """Set task and exposure metadata.
 

--- a/python/lsst/pipe/tasks/characterizeImage.py
+++ b/python/lsst/pipe/tasks/characterizeImage.py
@@ -31,7 +31,7 @@ import lsst.pipe.base as pipeBase
 import lsst.daf.base as dafBase
 import lsst.pipe.base.connectionTypes as cT
 from lsst.afw.math import BackgroundList
-from lsst.afw.table import SourceTable, SourceCatalog
+from lsst.afw.table import SourceTable
 from lsst.meas.algorithms import SubtractBackgroundTask, SourceDetectionTask, MeasureApCorrTask
 from lsst.meas.algorithms.installGaussianPsf import InstallGaussianPsfTask
 from lsst.meas.astrom import RefMatchTask, displayAstrometry
@@ -531,13 +531,6 @@ class CharacterizeImageTask(pipeBase.PipelineTask):
             background=background,
             psfCellSet=measPsfRes.cellSet,
         )
-
-    def getSchemaCatalogs(self):
-        """Return a dict of empty catalogs for each catalog dataset produced by this task.
-        """
-        sourceCat = SourceCatalog(self.schema)
-        sourceCat.getTable().setMetadata(self.algMetadata)
-        return {"icSrc": sourceCat}
 
     def display(self, itemName, exposure, sourceCat=None):
         """Display exposure and sources on next frame (for debugging).

--- a/python/lsst/pipe/tasks/mergeDetections.py
+++ b/python/lsst/pipe/tasks/mergeDetections.py
@@ -363,19 +363,6 @@ class MergeDetectionsTask(PipelineTask):
                     culledPeaks += 1
         self.log.info("Culled %d of %d peaks", culledPeaks, totalPeaks)
 
-    def getSchemaCatalogs(self):
-        """Return a dict of empty catalogs for each catalog dataset produced by this task.
-
-        Returns
-        ----------
-        dictionary : `dict`
-            Dictionary of empty catalogs.
-        """
-        mergeDet = afwTable.SourceCatalog(self.schema)
-        peak = afwDetect.PeakCatalog(self.merged.getPeakSchema())
-        return {self.config.coaddName + "Coadd_mergeDet": mergeDet,
-                self.config.coaddName + "Coadd_peak": peak}
-
     def getSkySourceFootprints(self, mergedList, skyInfo, seed):
         """Return a list of Footprints of sky objects which don't overlap with anything in mergedList.
 

--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -43,7 +43,7 @@ from lsst.obs.base import ExposureIdInfo
 # NOTE: these imports are a convenience so multiband users only have to import this file.
 from .mergeDetections import MergeDetectionsConfig, MergeDetectionsTask  # noqa: F401
 from .mergeMeasurements import MergeMeasurementsConfig, MergeMeasurementsTask  # noqa: F401
-from .multiBandUtils import CullPeaksConfig, _makeGetSchemaCatalogs  # noqa: F401
+from .multiBandUtils import CullPeaksConfig  # noqa: F401
 from .deblendCoaddSourcesPipeline import DeblendCoaddSourcesSingleConfig  # noqa: F401
 from .deblendCoaddSourcesPipeline import DeblendCoaddSourcesSingleTask  # noqa: F401
 from .deblendCoaddSourcesPipeline import DeblendCoaddSourcesMultiConfig  # noqa: F401
@@ -164,7 +164,6 @@ class DetectCoaddSourcesTask(PipelineTask):
 
     _DefaultName = "detectCoaddSources"
     ConfigClass = DetectCoaddSourcesConfig
-    getSchemaCatalogs = _makeGetSchemaCatalogs("det")
 
     def __init__(self, schema=None, **kwargs):
         # N.B. Super is used here to handle the multiple inheritance of PipelineTasks, the init tree
@@ -530,7 +529,6 @@ class MeasureMergedCoaddSourcesTask(PipelineTask):
 
     _DefaultName = "measureCoaddSources"
     ConfigClass = MeasureMergedCoaddSourcesConfig
-    getSchemaCatalogs = _makeGetSchemaCatalogs("meas")
 
     def __init__(self, butler=None, schema=None, peakSchema=None, refObjLoader=None, initInputs=None,
                  **kwargs):

--- a/python/lsst/pipe/tasks/multiBandUtils.py
+++ b/python/lsst/pipe/tasks/multiBandUtils.py
@@ -21,27 +21,7 @@
 
 __all__ = ["CullPeaksConfig"]
 
-import lsst.afw.table as afwTable
-
 from lsst.pex.config import Config, RangeField
-
-
-def _makeGetSchemaCatalogs(datasetSuffix):
-    """Construct a getSchemaCatalogs instance method
-
-    These are identical for most of the classes here, so we'll consolidate
-    the code.
-
-    datasetSuffix:  Suffix of dataset name, e.g., "src" for "deepCoadd_src"
-    """
-
-    def getSchemaCatalogs(self):
-        """Return a dict of empty catalogs for each catalog dataset produced by this task."""
-        src = afwTable.SourceCatalog(self.schema)
-        if hasattr(self, "algMetadata"):
-            src.getTable().setMetadata(self.algMetadata)
-        return {self.config.coaddName + "Coadd_" + datasetSuffix: src}
-    return getSchemaCatalogs
 
 
 class CullPeaksConfig(Config):


### PR DESCRIPTION
They aren't used in gen3