### PR TITLE
DM-37011-v24: Remove second Parameters section

### DIFF
--- a/python/lsst/pipe/tasks/loadReferenceCatalog.py
+++ b/python/lsst/pipe/tasks/loadReferenceCatalog.py
@@ -201,8 +201,8 @@ class LoadReferenceCatalogTask(pipeBase.Task):
             Epoch to which to correct proper motion and parallax
             (if available), or `None` to not apply such corrections.
 
-        Parameters
-        ----------
+        Returns
+        -------
         refCat : `numpy.ndarray`
             Reference catalog.
         """


### PR DESCRIPTION
pipelines.lsst.io will not build with two
Parameters sections