### PR TITLE
DM-37865: Remove unused parameters from deferred dataset handle get calls

### DIFF
--- a/python/lsst/pipe/tasks/coaddBase.py
+++ b/python/lsst/pipe/tasks/coaddBase.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__all__ = ["CoaddBaseTask", "getSkyInfo", "makeSkyInfo"]
+__all__ = ["CoaddBaseTask", "makeSkyInfo"]
 
 import lsst.pex.config as pexConfig
 import lsst.afw.image as afwImage
@@ -140,33 +140,6 @@ class CoaddBaseTask(pipeBase.PipelineTask):
         self.makeSubtask("select")
         self.makeSubtask("inputRecorder")
 
-    def getSkyInfo(self, patchRef):
-        """Use getSkyinfo to return the skyMap, tract and patch information, wcs and the outer bbox
-        of the patch.
-
-        Parameters
-        ----------
-        patchRef : `Unknown`
-            Data reference for sky map. Must include keys "tract" and "patch".
-
-        Returns
-        -------
-        getSkyInfo : `lsst.pipe.base.Struct`
-            Sky Info as a struct with attributes:
-
-            ``skyMap``
-                sky map (`lsst.skyMap.SkyMap`).
-            ``tractInfo``
-                Information for chosen tract of sky map (`lsst.skymap.TractInfo`).
-            ``patchInfo``
-                Information about chosen patch of tract (`lsst.skymap.PatchInfo`).
-            ``wcs``
-                WCS of tract (`lsst.afw.image.SkyWcs`).
-            ``bbox``
-                Outer bbox of patch, as an geom Box2I (`lsst.afw.geom.Box2I`).
-        """
-        return getSkyInfo(coaddName=self.config.coaddName, patchRef=patchRef)
-
     def getTempExpDatasetName(self, warpType="direct"):
         """Return warp name for given warpType and task config
 
@@ -185,36 +158,6 @@ class CoaddBaseTask(pipeBase.PipelineTask):
         """Convenience method to provide the bitmask from the mask plane names
         """
         return afwImage.Mask.getPlaneBitMask(self.config.badMaskPlanes)
-
-
-def getSkyInfo(coaddName, patchRef):
-    """Return the SkyMap, tract and patch information, wcs, and outer bbox of the patch to be coadded.
-
-    Parameters
-    ----------
-    coaddName : `str`
-        Coadd name; typically one of deep or goodSeeing.
-    patchRef : `Unknown`
-        Data reference for sky map. Must include keys "tract" and "patch".
-
-    Returns
-    -------
-    makeSkyInfo : `lsst.pipe.base.Struct`
-        pipe_base Struct with attributes:
-
-        ``skyMap``
-            Sky map (`lsst.skyMap.SkyMap`).
-        ``tractInfo``
-            Information for chosen tract of sky map (`lsst.skyMap.TractInfo`).
-        ``patchInfo``
-            Information about chosen patch of tract (`lsst.skyMap.PatchInfo`).
-        ``wcs``
-            WCS of tract (`lsst.afw.image.SkyWcs`).
-        ``bbox``
-            Outer bbox of patch, as an geom Box2I (`lsst.afw.geom.Box2I`).
-    """
-    skyMap = patchRef.get(coaddName + "Coadd_skyMap")
-    return makeSkyInfo(skyMap, patchRef.dataId["tract"], patchRef.dataId["patch"])
 
 
 def makeSkyInfo(skyMap, tractId, patchId):

--- a/python/lsst/pipe/tasks/drpAssociationPipe.py
+++ b/python/lsst/pipe/tasks/drpAssociationPipe.py
@@ -166,9 +166,7 @@ class DrpAssociationPipeTask(pipeBase.PipelineTask):
 
         diaSourceHistory = []
         for catRef in diaSourceTables:
-            cat = catRef.get(
-                datasetType=self.config.connections.diaSourceTables,
-                immediate=True)
+            cat = catRef.get()
 
             isInTractPatch = self._trimToPatch(cat,
                                                innerPatchBox,

--- a/python/lsst/pipe/tasks/extended_psf.py
+++ b/python/lsst/pipe/tasks/extended_psf.py
@@ -354,7 +354,7 @@ class StackBrightStarsTask(pipeBase.Task):
         self.log.info('Building extended PSF from stamps extracted from %d detector images%s',
                       len(bss_ref_list), region_message)
         # read in example set of full stamps
-        example_bss = bss_ref_list[0].get(datasetType="brightStarStamps", immediate=True)
+        example_bss = bss_ref_list[0].get()
         example_stamp = example_bss[0].stamp_im
         # create model image
         ext_psf = afwImage.MaskedImageF(example_stamp.getBBox())
@@ -372,7 +372,7 @@ class StackBrightStarsTask(pipeBase.Task):
         for jbbox, bbox in enumerate(sub_bboxes):
             all_stars = None
             for bss_ref in bss_ref_list:
-                read_stars = bss_ref.get(datasetType="brightStarStamps", parameters={'bbox': bbox})
+                read_stars = bss_ref.get(parameters={'bbox': bbox})
                 if self.config.do_mag_cut:
                     read_stars = read_stars.selectByMag(magMax=self.config.mag_limit)
                 if all_stars:

--- a/python/lsst/pipe/tasks/makeWarp.py
+++ b/python/lsst/pipe/tasks/makeWarp.py
@@ -439,8 +439,8 @@ class MakeWarpTask(CoaddBaseTask):
             List of data references for calexps that (may)
             overlap the patch of interest.
         skyInfo : `lsst.pipe.base.Struct`
-            Struct from CoaddBaseTask.getSkyInfo() with geometric
-            information about the patch.
+            Struct from `~lsst.pipe.base.coaddBase.makeSkyInfo()` with
+            geometric information about the patch.
         visitId : `int`
             Integer identifier for visit, for the table that will
             produce the CoaddPsf.
@@ -738,8 +738,8 @@ class MakeWarpTask(CoaddBaseTask):
         Parameters
         ----------
         skyInfo : `lsst.pipe.base.Struct`
-            Struct from CoaddBaseTask.getSkyInfo() with geometric
-            information about the patch.
+            Struct from `~lsst.pipe.base.coaddBase.makeSkyInfo()` with
+            geometric information about the patch.
 
         Returns
         -------

--- a/python/lsst/pipe/tasks/matchBackgrounds.py
+++ b/python/lsst/pipe/tasks/matchBackgrounds.py
@@ -236,7 +236,7 @@ class MatchBackgroundsTask(pipeBase.Task):
         if refInd is not None and refInd not in refIndSet:
             raise RuntimeError("Internal error: selected reference %s not found in expRefList")
 
-        refExposure = refExpDataRef.get(expDatasetType, immediate=True)
+        refExposure = refExpDataRef.get()
         if refImageScaler is not None:
             refMI = refExposure.getMaskedImage()
             refImageScaler.scaleMaskedImage(refMI)
@@ -258,7 +258,7 @@ class MatchBackgroundsTask(pipeBase.Task):
             else:
                 self.log.info("Matching background of %s to %s", toMatchRef.dataId, refExpDataRef.dataId)
                 try:
-                    toMatchExposure = toMatchRef.get(expDatasetType, immediate=True)
+                    toMatchExposure = toMatchRef.get()
                     if imageScaler is not None:
                         toMatchMI = toMatchExposure.getMaskedImage()
                         imageScaler.scaleMaskedImage(toMatchMI)
@@ -326,7 +326,7 @@ class MatchBackgroundsTask(pipeBase.Task):
                                (len(expRefList), len(imageScalerList)))
 
         for expRef, imageScaler in zip(expRefList, imageScalerList):
-            exposure = expRef.get(expDatasetType, immediate=True)
+            exposure = expRef.get()
             maskedImage = exposure.getMaskedImage()
             if imageScaler is not None:
                 try:

--- a/python/lsst/pipe/tasks/matchFakes.py
+++ b/python/lsst/pipe/tasks/matchFakes.py
@@ -212,12 +212,10 @@ class MatchFakesTask(PipelineTask):
             quantum.
         """
         if len(fakeCats) == 1:
-            return fakeCats[0].get(
-                datasetType=self.config.connections.fakeCats)
+            return fakeCats[0].get()
         outputCat = []
         for fakeCatRef in fakeCats:
-            cat = fakeCatRef.get(
-                datasetType=self.config.connections.fakeCats)
+            cat = fakeCatRef.get()
             tractId = fakeCatRef.dataId["tract"]
             # Make sure all data is within the inner part of the tract.
             outputCat.append(cat[

--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -539,7 +539,7 @@ class MeasureMergedCoaddSourcesTask(PipelineTask):
             schema = initInputs['inputSchema'].schema
         if schema is None:
             assert butler is not None, "Neither butler nor schema is defined"
-            schema = butler.get(self.config.coaddName + self.inputCatalog + "_schema", immediate=True).schema
+            schema = butler.get(self.config.coaddName + self.inputCatalog + "_schema").schema
         self.schemaMapper = afwTable.SchemaMapper(schema)
         self.schemaMapper.addMinimalSchema(schema)
         self.schema = self.schemaMapper.getOutputSchema()

--- a/python/lsst/pipe/tasks/processCcdWithFakes.py
+++ b/python/lsst/pipe/tasks/processCcdWithFakes.py
@@ -337,16 +337,14 @@ class ProcessCcdWithFakesTask(PipelineTask):
             externalSkyWcsCatalog = None
             for externalSkyWcsCatalogRef in externalSkyWcsCatalogList:
                 if externalSkyWcsCatalogRef.dataId["tract"] == tractId:
-                    externalSkyWcsCatalog = externalSkyWcsCatalogRef.get(
-                        datasetType=self.config.connections.externalSkyWcsTractCatalog)
+                    externalSkyWcsCatalog = externalSkyWcsCatalogRef.get()
                     break
             if externalSkyWcsCatalog is None:
                 usedTract = externalSkyWcsCatalogList[-1].dataId["tract"]
                 self.log.warn(
                     f"Warning, external SkyWcs for tract {tractId} not found. Using tract {usedTract} "
                     "instead.")
-                externalSkyWcsCatalog = externalSkyWcsCatalogList[-1].get(
-                    datasetType=self.config.connections.externalSkyWcsTractCatalog)
+                externalSkyWcsCatalog = externalSkyWcsCatalogList[-1].get()
             row = externalSkyWcsCatalog.find(detectorId)
             if row is None:
                 self.log.info("No %s external tract sky WCS for exposure %s so cannot insert fake "
@@ -373,16 +371,14 @@ class ProcessCcdWithFakesTask(PipelineTask):
             externalPhotoCalibCatalog = None
             for externalPhotoCalibCatalogRef in externalPhotoCalibCatalogList:
                 if externalPhotoCalibCatalogRef.dataId["tract"] == tractId:
-                    externalPhotoCalibCatalog = externalPhotoCalibCatalogRef.get(
-                        datasetType=self.config.connections.externalPhotoCalibTractCatalog)
+                    externalPhotoCalibCatalog = externalPhotoCalibCatalogRef.get()
                     break
             if externalPhotoCalibCatalog is None:
                 usedTract = externalPhotoCalibCatalogList[-1].dataId["tract"]
                 self.log.warn(
                     f"Warning, external PhotoCalib for tract {tractId} not found. Using tract {usedTract} "
                     "instead.")
-                externalPhotoCalibCatalog = externalPhotoCalibCatalogList[-1].get(
-                    datasetType=self.config.connections.externalPhotoCalibTractCatalog)
+                externalPhotoCalibCatalog = externalPhotoCalibCatalogList[-1].get()
             row = externalPhotoCalibCatalog.find(detectorId)
             if row is None:
                 self.log.info("No %s external tract photoCalib for exposure %s so cannot insert fake "
@@ -484,12 +480,10 @@ class ProcessCcdWithFakesTask(PipelineTask):
             quantum.
         """
         if len(fakeCats) == 1:
-            return fakeCats[0].get(
-                datasetType=self.config.connections.fakeCats)
+            return fakeCats[0].get()
         outputCat = []
         for fakeCatRef in fakeCats:
-            cat = fakeCatRef.get(
-                datasetType=self.config.connections.fakeCats)
+            cat = fakeCatRef.get()
             tractId = fakeCatRef.dataId["tract"]
             # Make sure all data is within the inner part of the tract.
             outputCat.append(cat[

--- a/python/lsst/pipe/tasks/propagateVisitFlags.py
+++ b/python/lsst/pipe/tasks/propagateVisitFlags.py
@@ -223,7 +223,7 @@ class PropagateVisitFlagsTask(Task):
                 v = ccdRecord.get(visitKey)
                 c = ccdRecord.get(ccdKey)
                 dataId = {"visit": int(v), self.config.ccdName: int(c)}
-                ccdSources = butler.get("src", dataId=dataId, immediate=True)
+                ccdSources = butler.get("src", dataId=dataId)
                 processCcd(ccdSources, ccdRecord.getWcs())
 
         # Apply threshold

--- a/tests/assembleCoaddTestUtils.py
+++ b/tests/assembleCoaddTestUtils.py
@@ -71,7 +71,7 @@ class MockWarpReference(lsst.daf.butler.DeferredDatasetHandle):
         self.patch = patch
         self.visit = visit
 
-    def get(self, bbox=None, component=None, parameters=None, **kwargs):
+    def get(self, bbox=None, component=None, parameters=None):
         """Retrieve the specified dataset using the API of the Gen 3 Butler.
 
         Parameters
@@ -83,9 +83,6 @@ class MockWarpReference(lsst.daf.butler.DeferredDatasetHandle):
         parameters : `dict`, optional
             If supplied, use the parameters to modify the exposure,
             typically by taking a subset.
-        **kwargs
-            Additional keyword arguments such as `immediate=True` that would
-            control internal butler behavior.
 
         Returns
         -------

--- a/tests/surveyPropertyMapsTestUtils.py
+++ b/tests/surveyPropertyMapsTestUtils.py
@@ -195,14 +195,8 @@ class MockVisitSummaryReference(lsst.daf.butler.DeferredDatasetHandle):
         self.visit_summary = visit_summary
         self.visit = visit
 
-    def get(self, **kwargs):
+    def get(self):
         """Retrieve the specified dataset using the API of the Gen3 Butler.
-
-        Parameters
-        ----------
-        **kwargs :
-            Additional keyword arguments such as `immediate=True` that would
-            control internal butler behavior.
 
         Returns
         -------
@@ -232,7 +226,7 @@ class MockCoaddReference(lsst.daf.butler.DeferredDatasetHandle):
         self.tract = tract
         self.patch = patch
 
-    def get(self, component=None, **kwargs):
+    def get(self, component=None):
         """Retrieve the specified dataset using the API of the Gen 3 Butler.
 
         Parameters
@@ -240,9 +234,6 @@ class MockCoaddReference(lsst.daf.butler.DeferredDatasetHandle):
         component : `str`, optional
             If supplied, return the named metadata of the exposure.  Allowed
             components are "photoCalib" or "coaddInputs".
-        **kwargs
-            Additional keyword arguments such as `immediate=True` that would
-            control internal butler behavior.
 
         Returns
         -------
@@ -276,15 +267,9 @@ class MockInputMapReference(lsst.daf.butler.DeferredDatasetHandle):
         self.tract = tract
         self.patch = patch
 
-    def get(self, **kwargs):
+    def get(self):
         """
         Retrieve the specified dataset using the API of the Gen 3 Butler.
-
-        Parameters
-        ----------
-        **kwargs
-            Additional keyword arguments such as `immediate=True` that would
-            control internal butler behavior.
 
         Returns
         -------


### PR DESCRIPTION
`datasetType` and `immediate` parameters were for gen2 but will imminently not be allowed in gen3 (they are currently ignored).