### PR TITLE
DM-38062: Fix dataId property in deferred dataset handle usage

### DIFF
--- a/python/lsst/pipe/tasks/drpAssociationPipe.py
+++ b/python/lsst/pipe/tasks/drpAssociationPipe.py
@@ -135,7 +135,7 @@ class DrpAssociationPipeTask(pipeBase.PipelineTask):
 
         Parameters
         ----------
-        diaSourceTables : `list` of `lst.daf.butler.DeferredDatasetHandle`
+        diaSourceTables : `list` of `lsst.daf.butler.DeferredDatasetHandle`
             Set of DiaSource catalogs potentially covering this patch/tract.
         skyMap : `lsst.skymap.BaseSkyMap`
             SkyMap defining the patch/tract

--- a/python/lsst/pipe/tasks/matchFakes.py
+++ b/python/lsst/pipe/tasks/matchFakes.py
@@ -200,7 +200,7 @@ class MatchFakesTask(PipelineTask):
 
         Parameters
         ----------
-        fakeCats : `list` of `lst.daf.butler.DeferredDatasetHandle`
+        fakeCats : `list` of `lsst.daf.butler.DeferredDatasetHandle`
             Set of fake cats to concatenate.
         skyMap : `lsst.skymap.SkyMap`
             SkyMap defining the geometry of the tracts and patches.

--- a/python/lsst/pipe/tasks/processCcdWithFakes.py
+++ b/python/lsst/pipe/tasks/processCcdWithFakes.py
@@ -468,7 +468,7 @@ class ProcessCcdWithFakesTask(PipelineTask):
 
         Parameters
         ----------
-        fakeCats : `list` of `lst.daf.butler.DeferredDatasetHandle`
+        fakeCats : `list` of `lsst.daf.butler.DeferredDatasetHandle`
             Set of fake cats to concatenate.
         skyMap : `lsst.skymap.SkyMap`
             SkyMap defining the geometry of the tracts and patches.

--- a/tests/test_hips.py
+++ b/tests/test_hips.py
@@ -59,6 +59,7 @@ class MockCoaddImageHandle(lsst.daf.butler.DeferredDatasetHandle):
         """
         return self.exposure
 
+    @property
     def dataId(self):
         return {'visit': 0, 'detector': 0}
 


### PR DESCRIPTION
@erykoff The actual driver for this fix is that the tests fail with debug logging because the mocked deferred dataset handle didn't define the dataId as a property.

Fixing DeferredDatasetHandle usage is now in #758.