### PR TITLE
DM-38091: Use InMemoryDatasetHandle

### DIFF
--- a/python/lsst/pipe/tasks/assembleCoadd.py
+++ b/python/lsst/pipe/tasks/assembleCoadd.py
@@ -653,9 +653,17 @@ class AssembleCoaddTask(CoaddBaseTask, pipeBase.PipelineTask):
                 Input list of image scalers (`list`) (unmodified).
             ``weightList``
                 Input list of weights (`list`) (unmodified).
+
+        Raises
+        ------
+        lsst.pipe.base.NoWorkFound
+            Raised if no data references are provided.
         """
         tempExpName = self.getTempExpDatasetName(self.warpType)
         self.log.info("Assembling %s %s", len(tempExpRefList), tempExpName)
+        if not tempExpRefList:
+            raise pipeBase.NoWorkFound("No exposures provided for co-addition.")
+
         stats = self.prepareStats(mask=mask)
 
         if altMaskList is None:

--- a/python/lsst/pipe/tasks/functors.py
+++ b/python/lsst/pipe/tasks/functors.py
@@ -44,6 +44,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 
 from lsst.utils import doImport
+from lsst.utils.introspection import get_full_type_name
 from lsst.daf.butler import DeferredDatasetHandle
 import lsst.geom as geom
 import lsst.sphgeom as sphgeom
@@ -339,6 +340,8 @@ class Functor(object):
         elif isinstance(data, DeferredDatasetHandle):
             # Load in-memory dataframe with appropriate columns the gen3 way
             df = data.get(parameters={"columns": columns})
+        else:
+            raise RuntimeError(f"Unexpected type provided for data. Got {get_full_type_name(data)}.")
 
         # Drop unnecessary column levels
         if is_multiLevel:
@@ -355,8 +358,8 @@ class Functor(object):
         return vals.dropna()
 
     def __call__(self, data, dropna=False):
+        df = self._get_data(data)
         try:
-            df = self._get_data(data)
             vals = self._func(df)
         except Exception as e:
             self.log.error("Exception in %s call: %s: %s", self.name, type(e).__name__, e)

--- a/python/lsst/pipe/tasks/functors.py
+++ b/python/lsst/pipe/tasks/functors.py
@@ -293,6 +293,7 @@ class Functor(object):
                 return self._colsFromDict(columnDict, columnIndex=columnIndex)
             else:
                 return columnDict
+        raise RuntimeError(f"Unexpected data type. Got {get_full_type_name}.")
 
     def _func(self, df, dropna=True):
         raise NotImplementedError('Must define calculation on dataframe')

--- a/tests/assembleCoaddTestUtils.py
+++ b/tests/assembleCoaddTestUtils.py
@@ -46,7 +46,7 @@ from astro_metadata_translator import makeObservationInfo
 __all__ = ["MockWarpReference", "makeMockSkyInfo", "MockCoaddTestData"]
 
 
-class MockWarpReference(lsst.daf.butler.DeferredDatasetHandle):
+class MockWarpReference(pipeBase.InMemoryDatasetHandle):
     """Very simple object that looks like a Gen 3 data reference to a warped
     exposure.
 
@@ -54,30 +54,12 @@ class MockWarpReference(lsst.daf.butler.DeferredDatasetHandle):
     ----------
     exposure : `lsst.afw.image.Exposure`
         The exposure to be retrieved by the data reference.
-    coaddName : `str`
-        The type of coadd being produced. Typically 'deep'.
-    patch : `int`
-        Unique identifier for a subdivision of a tract.
-    tract : `int`
-        Unique identifier for a tract of a skyMap
-    visit : `int`
-        Unique identifier for an observation,
-        potentially consisting of multiple ccds.
     """
-    def __init__(self, exposure, coaddName='deep', patch=42, tract=0, visit=100):
-        self.coaddName = coaddName
-        self.exposure = exposure
-        self.tract = tract
-        self.patch = patch
-        self.visit = visit
-
-    def get(self, bbox=None, component=None, parameters=None):
+    def get(self, *, component=None, parameters=None):
         """Retrieve the specified dataset using the API of the Gen 3 Butler.
 
         Parameters
         ----------
-        bbox : `lsst.geom.box.Box2I`, optional
-            If supplied, retrieve only a subregion of the exposure.
         component : `str`, optional
             If supplied, return the named metadata of the exposure.
         parameters : `dict`, optional
@@ -91,35 +73,17 @@ class MockWarpReference(lsst.daf.butler.DeferredDatasetHandle):
             Either the exposure or its metadata, depending on the datasetType.
         """
         if component == 'psf':
-            return self.exposure.getPsf()
+            return self.inMemoryDataset.getPsf()
         elif component == 'visitInfo':
-            return self.exposure.getInfo().getVisitInfo()
+            return self.inMemoryDataset.getInfo().getVisitInfo()
+        bbox = None
         if parameters is not None:
-            if "bbox" in parameters:
-                bbox = parameters["bbox"]
-        exp = self.exposure.clone()
+            bbox = parameters.get("bbox")
+        exp = self.inMemoryDataset.clone()
         if bbox is not None:
             return exp[bbox]
         else:
             return exp
-
-    @property
-    def dataId(self):
-        """Generate a valid data identifier.
-
-        Returns
-        -------
-        dataId : `lsst.daf.butler.DataCoordinate`
-            Data identifier dict for the patch.
-        """
-        return lsst.daf.butler.DataCoordinate.standardize(
-            tract=self.tract,
-            patch=self.patch,
-            visit=self.visit,
-            instrument="DummyCam",
-            skymap="Skymap",
-            universe=lsst.daf.butler.DimensionUniverse(),
-        )
 
 
 def makeMockSkyInfo(bbox, wcs, patch):
@@ -479,7 +443,11 @@ class MockCoaddTestData:
                 exposure = matchedExposures[expId]
             else:
                 raise ValueError("warpType must be one of 'direct' or 'psfMatched'")
-            dataRef = MockWarpReference(exposure, coaddName=coaddName,
-                                        tract=tract, patch=patch, visit=expId)
+            dataId = lsst.daf.butler.DataCoordinate.standardize(
+                tract=tract, patch=patch, visit=expId,
+                instrument="DummyCam", skymap="Skymap",
+                universe=lsst.daf.butler.DimensionUniverse(),
+            )
+            dataRef = MockWarpReference(exposure, dataId=dataId)
             dataRefList.append(dataRef)
         return dataRefList

--- a/tests/assembleCoaddTestUtils.py
+++ b/tests/assembleCoaddTestUtils.py
@@ -33,7 +33,6 @@ import numpy as np
 from lsst.afw.cameraGeom.testUtils import DetectorWrapper
 import lsst.afw.geom as afwGeom
 import lsst.afw.image as afwImage
-import lsst.daf.butler
 import lsst.geom as geom
 from lsst.geom import arcseconds, degrees
 from lsst.meas.algorithms.testUtils import plantSources
@@ -436,11 +435,7 @@ class MockCoaddTestData:
                 exposure = matchedExposures[expId]
             else:
                 raise ValueError("warpType must be one of 'direct' or 'psfMatched'")
-            dataId = lsst.daf.butler.DataCoordinate.standardize(
-                tract=tract, patch=patch, visit=expId,
-                instrument="DummyCam", skymap="Skymap",
-                universe=lsst.daf.butler.DimensionUniverse(),
-            )
-            dataRef = MockWarpReference(exposure, dataId=dataId, storageClass="ExposureF")
+            dataRef = MockWarpReference(exposure, storageClass="ExposureF",
+                                        tract=tract, patch=patch, visit=expId, coaddName=coaddName)
             dataRefList.append(dataRef)
         return dataRefList

--- a/tests/assembleCoaddTestUtils.py
+++ b/tests/assembleCoaddTestUtils.py
@@ -70,20 +70,13 @@ class MockWarpReference(pipeBase.InMemoryDatasetHandle):
         -------
         `lsst.afw.image.Exposure` or `lsst.afw.image.VisitInfo`
         or `lsst.meas.algorithms.SingleGaussianPsf`
-            Either the exposure or its metadata, depending on the datasetType.
+            Either the exposure or its metadata, depending on the component
+            requested.
         """
-        if component == 'psf':
-            return self.inMemoryDataset.getPsf()
-        elif component == 'visitInfo':
-            return self.inMemoryDataset.getInfo().getVisitInfo()
-        bbox = None
-        if parameters is not None:
-            bbox = parameters.get("bbox")
-        exp = self.inMemoryDataset.clone()
-        if bbox is not None:
-            return exp[bbox]
-        else:
-            return exp
+        exp = super().get(component=component, parameters=parameters)
+        if isinstance(exp, afwImage.ExposureF):
+            exp = exp.clone()
+        return exp
 
 
 def makeMockSkyInfo(bbox, wcs, patch):
@@ -448,6 +441,6 @@ class MockCoaddTestData:
                 instrument="DummyCam", skymap="Skymap",
                 universe=lsst.daf.butler.DimensionUniverse(),
             )
-            dataRef = MockWarpReference(exposure, dataId=dataId)
+            dataRef = MockWarpReference(exposure, dataId=dataId, storageClass="ExposureF")
             dataRefList.append(dataRef)
         return dataRefList

--- a/tests/surveyPropertyMapsTestUtils.py
+++ b/tests/surveyPropertyMapsTestUtils.py
@@ -22,7 +22,6 @@
 """Utilities for HealSparsePropertyMapTask and others."""
 import numpy as np
 
-import lsst.pipe.base
 import lsst.geom as geom
 from lsst.daf.base import DateTime
 from lsst.afw.coord import Observatory
@@ -33,8 +32,7 @@ import lsst.afw.geom as afwGeom
 from lsst.afw.detection import GaussianPsf
 
 
-__all__ = ['makeMockVisitSummary', 'MockVisitSummaryReference', 'MockCoaddReference',
-           'MockInputMapReference']
+__all__ = ['makeMockVisitSummary']
 
 
 def makeMockVisitSummary(visit,
@@ -178,84 +176,3 @@ def makeMockVisitSummary(visit,
         row['psfArea'] = shape.getArea()
 
     return visit_summary
-
-
-class MockVisitSummaryReference(lsst.pipe.base.InMemoryDatasetHandle):
-    """Very simple object that looks like a Gen3 data reference to
-    a visit summary.
-
-    Parameters
-    ----------
-    visit_summary : `lsst.afw.table.ExposureCatalog`
-        Visit summary catalog. Can be accessed through ``inMemoryDataset``
-        property.
-    visit : `int`
-        Visit number. Is converted to a dataId.
-    """
-    def __init__(self, visit_summary, visit):
-        super().__init__(visit_summary, dataId={"visit": visit})
-
-
-class MockCoaddReference(lsst.pipe.base.InMemoryDatasetHandle):
-    """Very simple object that looks like a Gen3 data reference to
-    a coadd.
-
-    Parameters
-    ----------
-    exposure : `lsst.afw.image.Exposure`
-        The exposure to be retrieved by the data reference. Can be accessed
-        through ``inMemoryDataset`` property.
-    patch : `int`
-        Unique identifier for a subdivision of a tract. Is converted to a
-        dataId
-    tract : `int`
-        Unique identifier for a tract of a skyMap. Is converted to a dataId.
-    """
-    def __init__(self, exposure, patch=0, tract=0):
-        self.exposure = exposure
-        super().__init__(exposure, dataId={"tract": tract, "patch": patch}, storageClass="ExposureF")
-
-    def get(self, *, component=None):
-        """Retrieve the specified dataset using the API of the Gen 3 Butler.
-
-        Parameters
-        ----------
-        component : `str`, optional
-            If supplied, return the named metadata of the exposure.  Allowed
-            components are "photoCalib" or "coaddInputs".
-
-        Returns
-        -------
-        `lsst.afw.image.Exposure` ('component=None') or
-        `lsst.afw.image.PhotoCalib` ('component="photoCalib") or
-        `lsst.afw.image.CoaddInputs` ('component="coaddInputs")
-
-        Notes
-        -----
-        This implementation returns a clone of the in-memory dataset to
-        allow for it to be modified after retrieval.
-        """
-        if component == "photoCalib":
-            return self.inMemoryDataset.getPhotoCalib()
-        elif component == "coaddInputs":
-            return self.inMemoryDataset.getInfo().getCoaddInputs()
-
-        return self.exposure.clone()
-
-
-class MockInputMapReference(lsst.pipe.base.InMemoryDatasetHandle):
-    """Very simple object that looks like a Gen3 data reference to
-    an input map.
-
-    Parameters
-    ----------
-    input_map : `healsparse.HealSparseMap`
-        Bitwise input map. Can be accessed through ``inMemoryDataset``
-        property.
-    patch : `int`
-        Patch number. Is converted to a dataId.
-    tract : `int`
-        Tract number. Is converted to a dataId.
-    """
-    def __init__(self, input_map, patch=0, tract=0):
-        super().__init__(input_map, dataId={"tract": tract, "patch": patch})

--- a/tests/test_finalizeCharacterization.py
+++ b/tests/test_finalizeCharacterization.py
@@ -26,21 +26,17 @@ import numpy as np
 import pandas as pd
 
 import lsst.utils.tests
-import lsst.daf.butler
 import lsst.pipe.base as pipeBase
 
 from lsst.pipe.tasks.finalizeCharacterization import (FinalizeCharacterizationConfig,
                                                       FinalizeCharacterizationTask)
 
 
-class MockDataFrameReference(lsst.daf.butler.DeferredDatasetHandle):
+class MockDataFrameReference(pipeBase.InMemoryDatasetHandle):
     """Very simple object that looks like a Gen3 data reference to
     a dataframe.
     """
-    def __init__(self, df):
-        self.df = df
-
-    def get(self, parameters={}, **kwargs):
+    def get(self, *, parameters={}):
         """Retrieve the specified dataset using the API of the Gen3 Butler.
 
         Parameters
@@ -56,9 +52,9 @@ class MockDataFrameReference(lsst.daf.butler.DeferredDatasetHandle):
         if 'columns' in parameters:
             _columns = parameters['columns']
 
-            return self.df[_columns]
+            return self.inMemoryDataset[_columns]
         else:
-            return self.df.copy()
+            return self.inMemoryDataset.copy()
 
 
 class TestFinalizeCharacterizationTask(FinalizeCharacterizationTask):

--- a/tests/test_finalizeCharacterization.py
+++ b/tests/test_finalizeCharacterization.py
@@ -32,31 +32,6 @@ from lsst.pipe.tasks.finalizeCharacterization import (FinalizeCharacterizationCo
                                                       FinalizeCharacterizationTask)
 
 
-class MockDataFrameReference(pipeBase.InMemoryDatasetHandle):
-    """Very simple object that looks like a Gen3 data reference to
-    a dataframe.
-    """
-    def get(self, *, parameters={}):
-        """Retrieve the specified dataset using the API of the Gen3 Butler.
-
-        Parameters
-        ----------
-        parameters : `dict`, optional
-            Parameter dictionary.  Supported key is ``columns``.
-
-        Returns
-        -------
-        dataframe : `pandas.DataFrame`
-            dataframe, cut to the specified columns.
-        """
-        if 'columns' in parameters:
-            _columns = parameters['columns']
-
-            return self.inMemoryDataset[_columns]
-        else:
-            return self.inMemoryDataset.copy()
-
-
 class TestFinalizeCharacterizationTask(FinalizeCharacterizationTask):
     """A derived class which skips the initialization routines.
     """
@@ -172,8 +147,10 @@ class FinalizeCharacterizationTestCase(lsst.utils.tests.TestCase):
 
             source_cat = np.concatenate(source_cats)
 
-            isolated_star_cat_dict[tract] = MockDataFrameReference(pd.DataFrame(cat))
-            isolated_star_source_dict[tract] = MockDataFrameReference(pd.DataFrame(source_cat))
+            isolated_star_cat_dict[tract] = pipeBase.InMemoryDatasetHandle(pd.DataFrame(cat),
+                                                                           storageClass="DataFrame")
+            isolated_star_source_dict[tract] = pipeBase.InMemoryDatasetHandle(pd.DataFrame(source_cat),
+                                                                              storageClass="DataFrame")
 
         return isolated_star_cat_dict, isolated_star_source_dict
 

--- a/tests/test_hips.py
+++ b/tests/test_hips.py
@@ -25,7 +25,7 @@ import numpy as np
 import hpgeom as hpg
 
 import lsst.utils.tests
-import lsst.daf.butler
+import lsst.pipe.base
 import lsst.afw.image
 import lsst.skymap
 import lsst.geom
@@ -37,7 +37,7 @@ from lsst.pipe.tasks.hips import (
 )
 
 
-class MockCoaddImageHandle(lsst.daf.butler.DeferredDatasetHandle):
+class MockCoaddImageHandle(lsst.pipe.base.InMemoryDatasetHandle):
     """Simple object that looks like a Gen3 deferred dataset handle
     to an exposure.
 
@@ -46,22 +46,8 @@ class MockCoaddImageHandle(lsst.daf.butler.DeferredDatasetHandle):
     exposure : `lsst.afw.image.ExposureF`
         Exposure to hold.
     """
-    def __init__(self, exposure):
-        self.exposure = exposure
-
-    def get(self, **kwargs):
-        """Retrieve the dataset using the API of the Gen3 Butler.
-
-        Returns
-        -------
-        exposure : `lsst.afw.image.ExposureF`
-            Exposure held in mock handle.
-        """
-        return self.exposure
-
-    @property
-    def dataId(self):
-        return {'visit': 0, 'detector': 0}
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, dataId={"visit": 0, "detector": 0}, **kwargs)
 
 
 class HipsTestCase(unittest.TestCase):

--- a/tests/test_hips.py
+++ b/tests/test_hips.py
@@ -37,19 +37,6 @@ from lsst.pipe.tasks.hips import (
 )
 
 
-class MockCoaddImageHandle(lsst.pipe.base.InMemoryDatasetHandle):
-    """Simple object that looks like a Gen3 deferred dataset handle
-    to an exposure.
-
-    Parameters
-    ----------
-    exposure : `lsst.afw.image.ExposureF`
-        Exposure to hold.
-    """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, dataId={"visit": 0, "detector": 0}, **kwargs)
-
-
 class HipsTestCase(unittest.TestCase):
     def test_hips_single(self):
         """Test creating a single HIPS image."""
@@ -65,7 +52,7 @@ class HipsTestCase(unittest.TestCase):
         patch_info = tract_info[patch]
 
         exposure = self._make_noise_exposure(patch_info)
-        handles = [MockCoaddImageHandle(exposure)]
+        handles = [lsst.pipe.base.InMemoryDatasetHandle(exposure)]
 
         center = patch_info.wcs.pixelToSky(patch_info.inner_bbox.getCenter())
         pixel = self._get_pixel(2**config.hips_order, center)
@@ -98,7 +85,7 @@ class HipsTestCase(unittest.TestCase):
         for patch in patches:
             patch_info = tract_info[patch]
             exposure = self._make_noise_exposure(patch_info)
-            handles.append(MockCoaddImageHandle(exposure))
+            handles.append(lsst.pipe.base.InMemoryDatasetHandle(exposure))
             centers.append(patch_info.wcs.pixelToSky(patch_info.inner_bbox.getCenter()))
 
         center = lsst.geom.SpherePoint(
@@ -137,7 +124,7 @@ class HipsTestCase(unittest.TestCase):
         patch_info = tract_info[patch]
 
         exposure = self._make_noise_exposure(patch_info)
-        handles = [MockCoaddImageHandle(exposure)]
+        handles = [lsst.pipe.base.InMemoryDatasetHandle(exposure)]
 
         pixel = 0
 

--- a/tests/test_isolatedStarAssociation.py
+++ b/tests/test_isolatedStarAssociation.py
@@ -26,7 +26,7 @@ import numpy as np
 import pandas as pd
 
 import lsst.utils.tests
-import lsst.daf.butler
+import lsst.pipe.base
 import lsst.skymap
 
 from lsst.pipe.tasks.isolatedStarAssociation import (IsolatedStarAssociationConfig,
@@ -34,7 +34,7 @@ from lsst.pipe.tasks.isolatedStarAssociation import (IsolatedStarAssociationConf
 from smatch.matcher import Matcher
 
 
-class MockSourceTableReference(lsst.daf.butler.DeferredDatasetHandle):
+class MockSourceTableReference(lsst.pipe.base.InMemoryDatasetHandle):
     """Very simple object that looks like a Gen3 data reference to
     a sourceTable_visit.
 
@@ -43,10 +43,7 @@ class MockSourceTableReference(lsst.daf.butler.DeferredDatasetHandle):
     source_table : `pandas.DataFrame`
         Dataframe of the source table.
     """
-    def __init__(self, source_table):
-        self.source_table = source_table
-
-    def get(self, parameters={}, **kwargs):
+    def get(self, *, parameters={}):
         """Retrieve the specified dataset using the API of the Gen3 Butler.
 
         Parameters
@@ -65,9 +62,9 @@ class MockSourceTableReference(lsst.daf.butler.DeferredDatasetHandle):
                 # Treat the index separately
                 _columns.remove('sourceId')
 
-            return self.source_table[_columns]
+            return self.inMemoryDataset[_columns]
         else:
-            return self.source_table.copy()
+            return self.inMemoryDataset.copy()
 
 
 class IsolatedStarAssociationTestCase(lsst.utils.tests.TestCase):

--- a/tests/test_isolatedStarAssociation.py
+++ b/tests/test_isolatedStarAssociation.py
@@ -34,39 +34,6 @@ from lsst.pipe.tasks.isolatedStarAssociation import (IsolatedStarAssociationConf
 from smatch.matcher import Matcher
 
 
-class MockSourceTableReference(lsst.pipe.base.InMemoryDatasetHandle):
-    """Very simple object that looks like a Gen3 data reference to
-    a sourceTable_visit.
-
-    Parameters
-    ----------
-    source_table : `pandas.DataFrame`
-        Dataframe of the source table.
-    """
-    def get(self, *, parameters={}):
-        """Retrieve the specified dataset using the API of the Gen3 Butler.
-
-        Parameters
-        ----------
-        parameters : `dict`, optional
-            Parameter dictionary.  Supported key is ``columns``.
-
-        Returns
-        -------
-        dataframe : `pandas.DataFrame`
-            dataframe, cut to the specified columns.
-        """
-        if 'columns' in parameters:
-            _columns = parameters['columns']
-            if 'sourceId' in parameters['columns']:
-                # Treat the index separately
-                _columns.remove('sourceId')
-
-            return self.inMemoryDataset[_columns]
-        else:
-            return self.inMemoryDataset.copy()
-
-
 class IsolatedStarAssociationTestCase(lsst.utils.tests.TestCase):
     """Tests of IsolatedStarAssociationTask.
 
@@ -120,7 +87,7 @@ class IsolatedStarAssociationTestCase(lsst.utils.tests.TestCase):
 
         Returns
         -------
-        data_refs : `list` [`MockSourceTableReference`]
+        data_refs : `list` [`InMemoryDatasetHandle`]
             List of mock references.
         """
         np.random.seed(12345)
@@ -218,7 +185,7 @@ class IsolatedStarAssociationTestCase(lsst.utils.tests.TestCase):
 
                 df = pd.DataFrame(table)
                 df.set_index('sourceId', inplace=True)
-                data_refs.append(MockSourceTableReference(df))
+                data_refs.append(lsst.pipe.base.InMemoryDatasetHandle(df, storageClass="DataFrame"))
 
                 id_counter += nstar
                 visit_counter += 1

--- a/tests/test_makeSurveyPropertyMaps.py
+++ b/tests/test_makeSurveyPropertyMaps.py
@@ -36,14 +36,12 @@ import lsst.afw.image as afwImage
 from lsst.skymap.discreteSkyMap import DiscreteSkyMap
 import lsst.geom as geom
 
+from lsst.pipe.base import InMemoryDatasetHandle
 from lsst.pipe.tasks.healSparseMapping import HealSparsePropertyMapTask
 from lsst.pipe.tasks.healSparseMappingProperties import (register_property_map,
                                                          BasePropertyMap)
 
-from surveyPropertyMapsTestUtils import (makeMockVisitSummary,
-                                         MockVisitSummaryReference,
-                                         MockCoaddReference,
-                                         MockInputMapReference)
+from surveyPropertyMapsTestUtils import makeMockVisitSummary
 
 
 # Test creation of an arbitrary new property map by registering it here
@@ -93,7 +91,7 @@ class HealSparsePropertyMapTaskTestCase(lsst.utils.tests.TestCase):
                                                 ra_center=ra_center,
                                                 dec_center=dec_center)
                            for visit in visits]
-        visit_summary_refs = [MockVisitSummaryReference(visit_summary, visit)
+        visit_summary_refs = [InMemoryDatasetHandle(visit_summary, visit=visit)
                               for visit_summary, visit in zip(visit_summaries, visits)]
         self.visit_summary_dict = {visit: ref.get()
                                    for ref, visit in zip(visit_summary_refs, visits)}
@@ -123,7 +121,7 @@ class HealSparsePropertyMapTaskTestCase(lsst.utils.tests.TestCase):
         input_map.set_bits_pix(poly_pixels, [0])
         input_map.set_bits_pix(poly_pixels, [1])
 
-        input_map_ref = MockInputMapReference(input_map, patch=patch, tract=tract)
+        input_map_ref = InMemoryDatasetHandle(input_map, patch=patch, tract=tract)
         self.input_map_dict = {patch: input_map_ref}
 
         coadd = afwImage.ExposureF(sky_map[tract][patch].getOuterBBox(),
@@ -156,7 +154,7 @@ class HealSparsePropertyMapTaskTestCase(lsst.utils.tests.TestCase):
         inputs.ccds = ccds
         coadd.getInfo().setCoaddInputs(inputs)
 
-        coadd_ref = MockCoaddReference(coadd, patch=patch, tract=tract)
+        coadd_ref = InMemoryDatasetHandle(coadd, patch=patch, tract=tract, storageClass="ExposureF")
         self.coadd_dict = {patch: coadd_ref}
 
         self.tract = tract
@@ -220,7 +218,7 @@ class HealSparsePropertyMapTaskTestCase(lsst.utils.tests.TestCase):
         # Replace the input map with an empty one.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            self.input_map_dict[0] = MockInputMapReference(hsp.HealSparseMap.make_empty_like(
+            self.input_map_dict[0] = InMemoryDatasetHandle(hsp.HealSparseMap.make_empty_like(
                 self.input_map_dict[0].inMemoryDataset
             ), **self.input_map_dict[0].dataId)
 

--- a/tests/test_makeSurveyPropertyMaps.py
+++ b/tests/test_makeSurveyPropertyMaps.py
@@ -220,9 +220,9 @@ class HealSparsePropertyMapTaskTestCase(lsst.utils.tests.TestCase):
         # Replace the input map with an empty one.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            self.input_map_dict[0].input_map = hsp.HealSparseMap.make_empty_like(
-                self.input_map_dict[0].input_map
-            )
+            self.input_map_dict[0] = MockInputMapReference(hsp.HealSparseMap.make_empty_like(
+                self.input_map_dict[0].inMemoryDataset
+            ), **self.input_map_dict[0].dataId)
 
         config = HealSparsePropertyMapTask.ConfigClass()
 


### PR DESCRIPTION
Many of the get() implementations here might Just Work using the default ExposureF delegate although the cloning going on makes me worried that the returned item is modified and so it won't work because we don't clone in the default delegate. We might also need to think about a way for an InMemoryDatasetHandle to specify a default dataId constructor and also whether additional kwargs can be stored and then retrieved later on.

Requires lsst/pipe_base#318