### PR TITLE
DM-39726: Use warnings instead of numpy.warnings

### DIFF
--- a/python/lsst/pipe/tasks/dataFrameActions/_actions.py
+++ b/python/lsst/pipe/tasks/dataFrameActions/_actions.py
@@ -6,6 +6,7 @@ __all__ = ("SingleColumnAction", "MultiColumnAction", "CoordColumn", "MagColumnD
 
 from typing import Iterable
 
+import warnings
 import numpy as np
 import pandas as pd
 from astropy import units
@@ -51,9 +52,9 @@ class MagColumnDN(SingleColumnAction):
         if not (fluxMag0 := kwargs.get('fluxMag0')):
             fluxMag0 = 1/np.power(10, -0.4*self.coadd_zeropoint)
 
-        with np.warnings.catch_warnings():
-            np.warnings.filterwarnings('ignore', r'invalid value encountered')
-            np.warnings.filterwarnings('ignore', r'divide by zero')
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', r'invalid value encountered')
+            warnings.filterwarnings('ignore', r'divide by zero')
             return -2.5 * np.log10(df[self.column] / fluxMag0)
 
 
@@ -61,9 +62,9 @@ class MagColumnNanoJansky(SingleColumnAction):
 
     def __call__(self, df: pd.DataFrame, **kwargs):
 
-        with np.warnings.catch_warnings():
-            np.warnings.filterwarnings('ignore', r'invalid value encountered')
-            np.warnings.filterwarnings('ignore', r'divide by zero')
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', r'invalid value encountered')
+            warnings.filterwarnings('ignore', r'divide by zero')
             return -2.5 * np.log10((df[self.column] * 1e-9) / 3631.0)
 
 

--- a/python/lsst/pipe/tasks/functors.py
+++ b/python/lsst/pipe/tasks/functors.py
@@ -37,6 +37,7 @@ import re
 from itertools import product
 import logging
 import os.path
+import warnings
 
 import pandas as pd
 import numpy as np
@@ -787,9 +788,9 @@ class Mag(Functor):
         return [self.col]
 
     def _func(self, df):
-        with np.warnings.catch_warnings():
-            np.warnings.filterwarnings('ignore', r'invalid value encountered')
-            np.warnings.filterwarnings('ignore', r'divide by zero')
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', r'invalid value encountered')
+            warnings.filterwarnings('ignore', r'divide by zero')
             return -2.5*np.log10(df[self.col] / self.fluxMag0)
 
     @property
@@ -821,9 +822,9 @@ class MagErr(Mag):
         return [self.col, self.col + 'Err']
 
     def _func(self, df):
-        with np.warnings.catch_warnings():
-            np.warnings.filterwarnings('ignore', r'invalid value encountered')
-            np.warnings.filterwarnings('ignore', r'divide by zero')
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', r'invalid value encountered')
+            warnings.filterwarnings('ignore', r'divide by zero')
             fluxCol, fluxErrCol = self.columns
             x = df[fluxErrCol] / df[fluxCol]
             y = self.fluxMag0Err / self.fluxMag0
@@ -850,9 +851,9 @@ class MagDiff(Functor):
         return [self.col1, self.col2]
 
     def _func(self, df):
-        with np.warnings.catch_warnings():
-            np.warnings.filterwarnings('ignore', r'invalid value encountered')
-            np.warnings.filterwarnings('ignore', r'divide by zero')
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', r'invalid value encountered')
+            warnings.filterwarnings('ignore', r'divide by zero')
             return -2.5*np.log10(df[self.col1]/df[self.col2])
 
     @property
@@ -1375,9 +1376,9 @@ class Photometry(Functor):
         return self.AB_FLUX_SCALE * dn / fluxMag0
 
     def dn2mag(self, dn, fluxMag0):
-        with np.warnings.catch_warnings():
-            np.warnings.filterwarnings('ignore', r'invalid value encountered')
-            np.warnings.filterwarnings('ignore', r'divide by zero')
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', r'invalid value encountered')
+            warnings.filterwarnings('ignore', r'divide by zero')
             return -2.5 * np.log10(dn/fluxMag0)
 
     def dn2fluxErr(self, dn, dnErr, fluxMag0, fluxMag0Err):

--- a/python/lsst/pipe/tasks/skyCorrection.py
+++ b/python/lsst/pipe/tasks/skyCorrection.py
@@ -21,6 +21,8 @@
 
 __all__ = ["SkyCorrectionTask", "SkyCorrectionConfig"]
 
+import warnings
+
 import lsst.afw.image as afwImage
 import lsst.afw.math as afwMath
 import lsst.pipe.base.connectionTypes as cT
@@ -468,8 +470,8 @@ class SkyCorrectionTask(PipelineTask):
             "Focal plane background model constructed using %.2f x %.2f mm (%d x %d pixel) superpixels; "
             "FP BG median = %.1f counts, FP BG IQR = %.1f counts"
         )
-        with np.warnings.catch_warnings():
-            np.warnings.filterwarnings("ignore", r"invalid value encountered")
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", r"invalid value encountered")
             stats = np.nanpercentile(bgModelBase.getStatsImage().array, [50, 75, 25])
         self.log.info(
             msg,
@@ -506,8 +508,8 @@ class SkyCorrectionTask(PipelineTask):
             Detector level realization of the full focal plane bg model.
         """
         image = calExp.getMaskedImage()
-        with np.warnings.catch_warnings():
-            np.warnings.filterwarnings("ignore", r"invalid value encountered")
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", r"invalid value encountered")
             calBkgElement = bgModel.toCcdBackground(calExp.getDetector(), image.getBBox())
         image -= calBkgElement.getImage()
         return calExp, calBkgElement


### PR DESCRIPTION
The aliasing for numpy.warnings no longer works.