### PR TITLE
DM-39763: Slightly relax precision of tests for rubinenv 7.

### DIFF
--- a/tests/test_diff_matched_tract_catalog.py
+++ b/tests/test_diff_matched_tract_catalog.py
@@ -163,7 +163,7 @@ class DiffMatchedTractCatalogTaskTestCase(lsst.utils.tests.TestCase):
             np.savetxt(filename_diff_matched, row)
 
         self.assertEqual(len(row), len(self.diff_matched))
-        self.assertFloatsAlmostEqual(row, self.diff_matched)
+        self.assertFloatsAlmostEqual(row, self.diff_matched, rtol=1e-15)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
This is necessary on intel, centos7, with rubinenv 7.