### PR TITLE
DM-35579: Remove pipelines forwarding stubs.

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -1,4 +1,0 @@
-description: >
-  This pipeline is a backwards-compatibility stub.
-imports:
-  location: $DRP_PIPE_DIR/ingredients/DRP.yaml

--- a/pipelines/VisualizeVisit.yaml
+++ b/pipelines/VisualizeVisit.yaml
@@ -1,4 +1,0 @@
-description: >
-  This pipeline is a backwards-compatibility stub.
-imports:
-  location: $DRP_PIPE_DIR/pipelines/VisualizeVisit.yaml


### PR DESCRIPTION
Pipelines should go in *_pipe packages.