### PR TITLE
DM-40301: Add 35- and 50-pix inst fluxes to source tables

### DIFF
--- a/schemas/Source.yaml
+++ b/schemas/Source.yaml
@@ -340,6 +340,12 @@ flags:
    - base_CircularApertureFlux_17_0_flag
    - base_CircularApertureFlux_17_0_instFlux
    - base_CircularApertureFlux_17_0_instFluxErr
+   - base_CircularApertureFlux_35_0_flag
+   - base_CircularApertureFlux_35_0_instFlux
+   - base_CircularApertureFlux_35_0_instFluxErr
+   - base_CircularApertureFlux_50_0_flag
+   - base_CircularApertureFlux_50_0_instFlux
+   - base_CircularApertureFlux_50_0_instFluxErr
    - base_ClassificationExtendedness_flag
    - base_FootprintArea_value
    - base_Jacobian_flag


### PR DESCRIPTION
Because FGCM takes direct instrumental fluxes, and to enable running FGCM on LATISS.