### PR TITLE
DM-40451: Update multiband measurement task for deblending with partial coverage

### DIFF
--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -566,6 +566,7 @@ class MeasureMergedCoaddSourcesTask(PipelineTask):
                 catalog=sources,
                 band=inputRefs.exposure.dataId["band"],
                 psfModel=inputs['exposure'].getPsf(),
+                maskImage=inputs['exposure'].mask,
                 redistributeImage=redistributeImage,
                 removeScarletData=True,
             )

--- a/schemas/Object.yaml
+++ b/schemas/Object.yaml
@@ -625,6 +625,10 @@ funcs:
         dataset: ref
     ebv:
         functor: Ebv
+    dataCoverage:
+        functor: Column
+        args: deblend_dataCoverage
+        dataset: meas
     # DM-22247: Add Star/Galaxy sep columns
     #     - Morphological Star Galaxy Classifier (Names? float 0-1)]
     #     - Morphological + Color (SED-based) Star Galaxy Classifier (Names? float 0-1)]
@@ -641,6 +645,7 @@ refFlags:
     - merge_peak_sky
     - deblend_nChild
     - deblend_skipped
+    - deblend_incompleteData
     - slot_Shape_flag
     - slot_Shape_xx
     - slot_Shape_xy

--- a/tests/test_isPrimaryFlag.py
+++ b/tests/test_isPrimaryFlag.py
@@ -255,6 +255,7 @@ class IsPrimaryTestCase(lsst.utils.tests.TestCase):
             catalog=catalog,
             band="test",
             psfModel=coadds["test"].getPsf(),
+            maskImage=coadds["test"].mask,
             redistributeImage=None,
         )
         # measure


### PR DESCRIPTION
Now that meas_extensions_scarlet will deblend footprints that only have partial coverage (eg. in one or more band there is missing data that prevents building a PSF), new columns were added to the catalog to mark sources that were not deblended in a given band.