### PR TITLE
DM-40668: Update computation of psfStarScaledDeltaSizeScatter

### DIFF
--- a/python/lsst/pipe/tasks/calibrateImage.py
+++ b/python/lsst/pipe/tasks/calibrateImage.py
@@ -319,7 +319,9 @@ class CalibrateImageConfig(pipeBase.PipelineTaskConfig, pipelineConnections=Cali
         self.photometry.match.sourceSelection.retarget(sourceSelector.NullSourceSelectorTask)
 
         # All sources should be good for PSF summary statistics.
+        # TODO: These should both be changed to calib_psf_used with DM-41640.
         self.compute_summary_stats.starSelection = "calib_photometry_used"
+        self.compute_summary_stats.starSelector.flags.good = ["calib_photometry_used"]
 
 
 class CalibrateImageTask(pipeBase.PipelineTask):

--- a/python/lsst/pipe/tasks/computeExposureSummaryStats.py
+++ b/python/lsst/pipe/tasks/computeExposureSummaryStats.py
@@ -263,12 +263,15 @@ class ComputeExposureSummaryStatsTask(pipeBase.Task):
         psfYY = psf_cat[self.config.psfShape + '_yy']
         psfXY = psf_cat[self.config.psfShape + '_xy']
 
-        starSize = (starXX*starYY - starXY**2.)**0.25
+        # Use the trace radius for the star size.
+        starSize = np.sqrt(starXX/2. + starYY/2.)
+
         starE1 = (starXX - starYY)/(starXX + starYY)
         starE2 = 2*starXY/(starXX + starYY)
         starSizeMedian = np.median(starSize)
 
-        psfSize = (psfXX*psfYY - psfXY**2)**0.25
+        # Use the trace radius for the psf size.
+        psfSize = np.sqrt(psfXX/2. + psfYY/2.)
         psfE1 = (psfXX - psfYY)/(psfXX + psfYY)
         psfE2 = 2*psfXY/(psfXX + psfYY)
 

--- a/python/lsst/pipe/tasks/computeExposureSummaryStats.py
+++ b/python/lsst/pipe/tasks/computeExposureSummaryStats.py
@@ -282,7 +282,7 @@ class ComputeExposureSummaryStatsTask(pipeBase.Task):
 
         psfStarDeltaSizeMedian = np.median(starSize - psfSize)
         psfStarDeltaSizeScatter = sigmaMad(starSize - psfSize, scale='normal')
-        psfStarScaledDeltaSizeScatter = psfStarDeltaSizeScatter/starSizeMedian**2.
+        psfStarScaledDeltaSizeScatter = psfStarDeltaSizeScatter/starSizeMedian
 
         summary.nPsfStar = int(nPsfStar)
         summary.psfStarDeltaE1Median = float(psfStarDeltaE1Median)

--- a/python/lsst/pipe/tasks/selectImages.py
+++ b/python/lsst/pipe/tasks/selectImages.py
@@ -258,7 +258,7 @@ class PsfWcsSelectImagesConfig(pipeBase.PipelineTaskConfig,
     maxScaledSizeScatter = pexConfig.Field(
         doc="Maximum scatter in the size residuals, scaled by the median size",
         dtype=float,
-        default=0.009,
+        default=0.019,
         optional=True,
     )
     maxPsfTraceRadiusDelta = pexConfig.Field(


### PR DESCRIPTION
This PR updates a few things for `psfStarScaledDeltaSizeScatter`:

a) Object sizes are now computed with the trace radius rather than the determinant radius (less noisy)
b) An explicit selector can be used to control the signal to noise of the size statistics.
c) The scaling factor is changed from size squared to size.
d) The default cut applied for coadds has been updated to 0.019 appropriate for this new definition, as determined from the reprocessing of HSC PDR2.