### PR TITLE
DM-32769: Implement streak detection and masking in single frame processing

### DIFF
--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -311,6 +311,10 @@ class CalibrateConfig(pipeBase.PipelineTaskConfig, pipelineConnections=Calibrate
         # The photoRefCat connection is the name to use for the colorterms.
         self.photoCal.photoCatName = self.connections.photoRefCat
 
+        # Keep track of which footprints contain streaks
+        self.measurement.plugins['base_PixelFlags'].masksFpAnywhere = ['STREAK']
+        self.measurement.plugins['base_PixelFlags'].masksFpCenter = ['STREAK']
+
 
 class CalibrateTask(pipeBase.PipelineTask):
     """Calibrate an exposure: measure sources and perform astrometric and

--- a/python/lsst/pipe/tasks/finalizeCharacterization.py
+++ b/python/lsst/pipe/tasks/finalizeCharacterization.py
@@ -215,6 +215,11 @@ class FinalizeCharacterizationConfig(pipeBase.PipelineTaskConfig,
         self.measurement.slots.shape = 'ext_shapeHSM_HsmSourceMoments'
         self.measurement.slots.psfShape = 'ext_shapeHSM_HsmPsfMoments'
         self.measurement.plugins['ext_shapeHSM_HsmShapeRegauss'].deblendNChild = ""
+
+        # Keep track of which footprints contain streaks
+        self.measurement.plugins['base_PixelFlags'].masksFpAnywhere = ['STREAK']
+        self.measurement.plugins['base_PixelFlags'].masksFpCenter = ['STREAK']
+
         # Turn off slot setting for measurement for centroid and shape
         # (for which we use the input src catalog measurements)
         self.measurement.slots.centroid = None

--- a/python/lsst/pipe/tasks/multiBand.py
+++ b/python/lsst/pipe/tasks/multiBand.py
@@ -448,9 +448,9 @@ class MeasureMergedCoaddSourcesConfig(PipelineTaskConfig,
                                            'base_LocalPhotoCalib',
                                            'base_LocalWcs']
         self.measurement.plugins['base_PixelFlags'].masksFpAnywhere = ['CLIPPED', 'SENSOR_EDGE',
-                                                                       'INEXACT_PSF']
+                                                                       'INEXACT_PSF', 'STREAK']
         self.measurement.plugins['base_PixelFlags'].masksFpCenter = ['CLIPPED', 'SENSOR_EDGE',
-                                                                     'INEXACT_PSF']
+                                                                     'INEXACT_PSF', 'STREAK']
 
 
 class MeasureMergedCoaddSourcesTask(PipelineTask):

--- a/schemas/ForcedSource.yaml
+++ b/schemas/ForcedSource.yaml
@@ -1,4 +1,4 @@
-# This file defines the mapping between the columns in a forced source table 
+# This file defines the mapping between the columns in a forced source table
 # and their respective DPDD-style column names, as used by
 # `lsst.pipe.tasks.postprocess.TransformForcedSourceTableTask`.
 # See the DPDD for more information about the output: https://lse-163.lsst.io
@@ -91,6 +91,8 @@ calexpFlags:
     - base_PixelFlags_flag_saturatedCenter
     - base_PixelFlags_flag_crCenter
     - base_PixelFlags_flag_suspectCenter
+    - base_PixelFlags_flag_streak
+    - base_PixelFlags_flag_streakCenter
 flag_rename_rules:
     - ['base_PixelFlags_flag', 'pixelFlags']
     - ['base_Local', 'local']

--- a/schemas/Object.yaml
+++ b/schemas/Object.yaml
@@ -659,6 +659,8 @@ flags:
     - base_PixelFlags_flag_sensor_edgeCenter
     - base_PixelFlags_flag_suspect
     - base_PixelFlags_flag_suspectCenter
+    - base_PixelFlags_flag_streak
+    - base_PixelFlags_flag_streakCenter
     - base_ClassificationExtendedness_flag
     - calib_astrometry_used
     - calib_photometry_reserved

--- a/schemas/Source.yaml
+++ b/schemas/Source.yaml
@@ -44,13 +44,13 @@ funcs:
    # compatibility. To be removed after September 2023.
     decl:
         functor: DecColumn
-    
+
     raErr:
         functor: RAErrColumn
     decErr:
         functor: DecErrColumn
     ra_dec_Cov:
-        functor: RADecCovColumn    
+        functor: RADecCovColumn
     # One calibrated Calib flux is important:
     calibFlux:
         functor: LocalNanojansky
@@ -369,6 +369,8 @@ flags:
    - base_PixelFlags_flag_saturatedCenter
    - base_PixelFlags_flag_suspect
    - base_PixelFlags_flag_suspectCenter
+   - base_PixelFlags_flag_streak
+   - base_PixelFlags_flag_streakCenter
    - base_PsfFlux_apCorr
    - base_PsfFlux_apCorrErr
    - base_PsfFlux_area


### PR DESCRIPTION
This PR adds maskStreaksTask (with no bells or whistles) as a default step to single frame processing.

It supports both main "modes" of single frame: the original `isr -> characterizeImage -> calibrate` AS WELL AS the newfangled `isr -> calibrateImage`.

The result is that linear DETECTED features are also masked as STREAK.