### PR TITLE
DM-41008-v24: Do not include bands with no data in merge measurements

### DIFF
--- a/python/lsst/pipe/tasks/mergeMeasurements.py
+++ b/python/lsst/pipe/tasks/mergeMeasurements.py
@@ -330,8 +330,13 @@ class MergeMeasurementsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                     if hasPseudoFilter:
                         break
 
-                isBad = any(inputRecord.get(flag) for flag in self.badFlags)
-                if isBad or inputRecord.get(self.fluxFlagKey) or inputRecord.get(self.instFluxErrKey) == 0:
+                isBad = (
+                    any(inputRecord.get(flag) for flag in self.badFlags)
+                    or inputRecord["deblend_dataCoverage"] == 0
+                    or inputRecord.get(self.fluxFlagKey)
+                    or inputRecord.get(self.instFluxErrKey) == 0
+                )
+                if isBad:
                     sn = 0.
                 else:
                     sn = inputRecord.get(self.instFluxKey)/inputRecord.get(self.instFluxErrKey)


### PR DESCRIPTION
Needs to be merged after DM-40451-v24.