### PR TITLE
DM-41345: Let TestDataset handle coordinates

### DIFF
--- a/tests/test_calibrateImage.py
+++ b/tests/test_calibrateImage.py
@@ -76,7 +76,6 @@ class CalibrateImageTaskTests(lsst.utils.tests.TestCase):
 
         schema = dataset.makeMinimalSchema()
         self.truth_exposure, self.truth_cat = dataset.realize(noise=noise, schema=schema)
-        lsst.afw.table.updateSourceCoords(self.truth_exposure.wcs, self.truth_cat)
         # To make it look like a version=1 (nJy fluxes) refcat
         self.truth_cat = self.truth_exposure.photoCalib.calibrateCatalog(self.truth_cat)
         self.ref_loader = testUtils.MockReferenceObjectLoaderFromMemory([self.truth_cat])

--- a/tests/test_calibrateImage.py
+++ b/tests/test_calibrateImage.py
@@ -75,7 +75,6 @@ class CalibrateImageTaskTests(lsst.utils.tests.TestCase):
         dataset.addSource(instFlux=500*noise*psf_scale, centroid=center, shape=shape)
 
         schema = dataset.makeMinimalSchema()
-        afwTable.CoordKey.addErrorFields(schema)
         self.truth_exposure, self.truth_cat = dataset.realize(noise=noise, schema=schema)
         lsst.afw.table.updateSourceCoords(self.truth_exposure.wcs, self.truth_cat)
         # To make it look like a version=1 (nJy fluxes) refcat


### PR DESCRIPTION
The expectation is that TestDataset returns a catalog that looks like a measurement catalog, that means that it has coordErr fields and that the coord/coordErr fields are filled in from the pixel positions using the provided WCS.