### PR TITLE
DM-41503: Allow BestSeeingSelectVisitsTask to select all visits below some fwhm cut

### DIFF
--- a/python/lsst/pipe/tasks/selectImages.py
+++ b/python/lsst/pipe/tasks/selectImages.py
@@ -524,7 +524,7 @@ class BestSeeingSelectVisitsTask(pipeBase.PipelineTask):
             output = sortedVisits
         else:
             output = sortedVisits[:self.config.nVisitsMax]
-        self.log.info("%d images selected with FWHM range of %d--%d arcseconds",
+        self.log.info("%d images selected with FWHM range of %f--%f arcseconds",
                       len(output), fwhmSizes[visits.index(output[0])], fwhmSizes[visits.index(output[-1])])
 
         # In order to store as a StructuredDataDict, convert list to dict

--- a/python/lsst/pipe/tasks/selectImages.py
+++ b/python/lsst/pipe/tasks/selectImages.py
@@ -407,7 +407,7 @@ class BestSeeingSelectVisitsConfig(pipeBase.PipelineTaskConfig,
                                    pipelineConnections=BestSeeingSelectVisitsConnections):
     nVisitsMax = pexConfig.RangeField(
         dtype=int,
-        doc="Maximum number of visits to select",
+        doc="Maximum number of visits to select; use -1 to select all.",
         default=12,
         min=-1,
     )

--- a/python/lsst/pipe/tasks/selectImages.py
+++ b/python/lsst/pipe/tasks/selectImages.py
@@ -409,7 +409,7 @@ class BestSeeingSelectVisitsConfig(pipeBase.PipelineTaskConfig,
         dtype=int,
         doc="Maximum number of visits to select",
         default=12,
-        min=0
+        min=-1,
     )
     maxPsfFwhm = pexConfig.Field(
         dtype=float,
@@ -520,7 +520,10 @@ class BestSeeingSelectVisitsTask(pipeBase.PipelineTask):
             visits.append(visit)
 
         sortedVisits = [ind for (_, ind) in sorted(zip(fwhmSizes, visits))]
-        output = sortedVisits[:self.config.nVisitsMax]
+        if self.config.nVisitsMax < 0:
+            output = sortedVisits
+        else:
+            output = sortedVisits[:self.config.nVisitsMax]
         self.log.info("%d images selected with FWHM range of %d--%d arcseconds",
                       len(output), fwhmSizes[visits.index(output[0])], fwhmSizes[visits.index(output[-1])])
 


### PR DESCRIPTION
This PR also fixes the logging of the seeing range used for selection.