### PR TITLE
DM-41846: Use the test ID as the unique component of the test run collection

### DIFF
--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -109,7 +109,7 @@ class CalibrateTaskTestCaseWithButler(lsst.utils.tests.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.butler = butlerTests.makeTestCollection(self.repo)
+        self.butler = butlerTests.makeTestCollection(self.repo, uniqueId=self.id())
 
         self.dataId = {"instrument": "notACam", "visit": 101, "detector": 42}
         # CalibrateTask absolutely requires an ExpandedDataCoordinate


### PR DESCRIPTION
This is a reasonable thing to do in general, but is important when using pytest-randomly because when using that plugin without the --randomly-dont-reset-seed flag, the seed is forced to the global value before every test is run. This leads to makeTestCollection returning the same random integer for every test and the runs clash in the shared repo.