### PR TITLE
DM-42663: Use moments based classifier in isolatedStarAssociationTask.

### DIFF
--- a/python/lsst/pipe/tasks/isolatedStarAssociation.py
+++ b/python/lsst/pipe/tasks/isolatedStarAssociation.py
@@ -173,8 +173,7 @@ class IsolatedStarAssociationConfig(pipeBase.PipelineTaskConfig,
         source_selector.isolated.parentName = 'parentSourceId'
         source_selector.isolated.nChildName = 'deblend_nChild'
 
-        source_selector.unresolved.maximum = 0.5
-        source_selector.unresolved.name = 'extendedness'
+        source_selector.unresolved.name = 'sizeExtendedness'
 
         source_selector.requireFiniteRaDec.raColName = self.ra_column
         source_selector.requireFiniteRaDec.decColName = self.dec_column

--- a/tests/test_calibrateImage.py
+++ b/tests/test_calibrateImage.py
@@ -116,8 +116,8 @@ class CalibrateImageTaskTests(lsst.utils.tests.TestCase):
         # find_stars needs an id generator.
         self.id_generator = lsst.meas.base.IdGenerator()
 
-        # Something about this test dataset prefers the older fluxRatio here.
-        self.config.star_catalog_calculation.plugins['base_ClassificationExtendedness'].fluxRatio = 0.925
+        # Something about this test dataset prefers a larger threshold here.
+        self.config.star_selector["science"].unresolved.maximum = 0.2
 
     def _check_run(self, calibrate, result):
         """Test the result of CalibrateImage.run().


### PR DESCRIPTION
The selection/threshold is updated in meas_algorithms, but we also need to update the transformed column name for the isolated star association task.