### PR TITLE
DM-43247: Raise if no psf_stars match to selected stars

### DIFF
--- a/python/lsst/pipe/tasks/calibrateImage.py
+++ b/python/lsst/pipe/tasks/calibrateImage.py
@@ -725,6 +725,12 @@ class CalibrateImageTask(pipeBase.PipelineTask):
         if n_unique != n_matches:
             self.log.warning("%d psf_stars matched only %d stars; ",
                              n_matches, n_unique)
+        if n_matches == 0:
+            msg = (f"0 psf_stars out of {len(psf_stars)} matched {len(stars)} calib stars."
+                   " Downstream processes probably won't have useful stars in this case."
+                   " Is `star_source_selector` too strict?")
+            # TODO DM-39842: Turn this into an AlgorithmicError.
+            raise RuntimeError(msg)
 
         # The indices of the IDs, so we can update the flag fields as arrays.
         idx_psf_stars = np.searchsorted(psf_stars["id"], ids[0])

--- a/tests/test_calibrateImage.py
+++ b/tests/test_calibrateImage.py
@@ -354,6 +354,17 @@ class CalibrateImageTaskTests(lsst.utils.tests.TestCase):
         # Too few sources to reserve any in these tests.
         self.assertEqual(stars["calib_psf_reserved"].sum(), 0)
 
+    def test_match_psf_stars_no_matches(self):
+        """Check that _match_psf_stars handles the case of no cross-matches.
+        """
+        calibrate = CalibrateImageTask(config=self.config)
+        # Make two catalogs that cannot have matches.
+        stars = self.truth_cat[2:].copy(deep=True)
+        psf_stars = self.truth_cat[:2].copy(deep=True)
+
+        with self.assertRaisesRegex(RuntimeError, "0 psf_stars out of 2 matched"):
+            calibrate._match_psf_stars(psf_stars, stars)
+
 
 class CalibrateImageTaskRunQuantumTests(lsst.utils.tests.TestCase):
     """Tests of ``CalibrateImageTask.runQuantum``, which need a test butler,


### PR DESCRIPTION
We may eventually want to turn this into a warning, but for now we need to know when this happens, as we try to understand how to tune star selection.