### PR TITLE
DM-43231: Create Analysis Tool to send visitSummary info to sasquatch

### DIFF
--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -47,12 +47,19 @@ from .computeExposureSummaryStats import ComputeExposureSummaryStatsTask
 
 
 class _EmptyTargetTask(pipeBase.PipelineTask):
+    """
+    This is a placeholder target for CreateSummaryMetrics and must be retargeted at runtime.
+    CreateSummaryMetrics should target an analysis tool task, but that would, at the time
+    of writing, result in a circular import.
+
+    As a result, this class should not be used for anything else.
+    """
     ConfigClass = pipeBase.PipelineTaskConfig
 
     def __init__(self, **kwargs) -> None:
         raise NotImplementedError(
-            "doCreateSummaryMetrics is set to True, in which case"
-            "CreateSummaryMetrics must be retargeted."
+            "doCreateSummaryMetrics is set to True, in which case "
+            "createSummaryMetrics must be retargeted."
         )
 
 

--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -50,7 +50,10 @@ class _EmptyTargetTask(pipeBase.PipelineTask):
     ConfigClass = pipeBase.PipelineTaskConfig
 
     def __init__(self, **kwargs) -> None:
-        raise NotImplementedError("CreateSummaryMetrics must be retargeted")
+        raise NotImplementedError(
+            "doCreateSummaryMetrics is set to True, in which case"
+            "CreateSummaryMetrics must be retargeted."
+        )
 
 
 class CalibrateConnections(pipeBase.PipelineTaskConnections, dimensions=("instrument", "visit", "detector"),
@@ -312,7 +315,7 @@ class CalibrateConfig(pipeBase.PipelineTaskConfig, pipelineConnections=Calibrate
     doCreateSummaryMetrics = pexConfig.Field(
         dtype=bool,
         default=False,
-        doc="Run the subtask to create summary metrics, and then write those metrics?"
+        doc="Run the subtask to create summary metrics, and then write those metrics."
     )
     createSummaryMetrics = pexConfig.ConfigurableField(
         target=_EmptyTargetTask,


### PR DESCRIPTION
Added the ability to create and write metrics from the calexp summary stats. The task to calculate the metrics must be retargeted at runtime to avoid circular imports in calibrate. This is the reason for the private _EmptyTargetTask. This gets retargeted to CalexpSummaryTask in analysis tools, which is what creates the MetricMeasurementBundle that gets written to sasquatch.