### PR TITLE
DM-43545: Ensure that images without psfs/aperture corrections are not used in warps.

### DIFF
--- a/python/lsst/pipe/tasks/makeWarp.py
+++ b/python/lsst/pipe/tasks/makeWarp.py
@@ -145,8 +145,6 @@ class MakeWarpConfig(pipeBase.PipelineTaskConfig, CoaddBaseTask.ConfigClass,
         doc=(
             "If True, use the PSF model and aperture corrections from the 'visitSummary' connection. "
             "If False, use the PSF model and aperture corrections from the 'exposure' connection. "
-            # TODO: remove this next sentence on DM-39854.
-            "The finalizedPsfApCorrCatalog connection (if enabled) takes precedence over either."
         ),
         dtype=bool,
         default=True,
@@ -165,13 +163,6 @@ class MakeWarpConfig(pipeBase.PipelineTaskConfig, CoaddBaseTask.ConfigClass,
         dtype=bool,
         default=False,
         doc="Apply sky correction?",
-    )
-    doApplyFinalizedPsf = pexConfig.Field(
-        doc="Whether to apply finalized psf models and aperture correction map.",
-        dtype=bool,
-        default=False,
-        # TODO: remove on DM-39854.
-        deprecated="Deprecated in favor of useVisitSummaryPsf.  Will be removed after v26.",
     )
     idGenerator = DetectorVisitIdGeneratorConfig.make_field()
 
@@ -256,27 +247,6 @@ class MakeWarpTask(CoaddBaseTask):
             wcsList.append(row.getWcs())
         inputs["bboxList"] = bboxList
         inputs["wcsList"] = wcsList
-
-        if self.config.doApplyExternalSkyWcs:
-            if self.config.useGlobalExternalSkyWcs:
-                externalSkyWcsCatalog = inputs.pop("externalSkyWcsGlobalCatalog")
-            else:
-                externalSkyWcsCatalog = inputs.pop("externalSkyWcsTractCatalog")
-        else:
-            externalSkyWcsCatalog = None
-
-        if self.config.doApplyExternalPhotoCalib:
-            if self.config.useGlobalExternalPhotoCalib:
-                externalPhotoCalibCatalog = inputs.pop("externalPhotoCalibGlobalCatalog")
-            else:
-                externalPhotoCalibCatalog = inputs.pop("externalPhotoCalibTractCatalog")
-        else:
-            externalPhotoCalibCatalog = None
-
-        if self.config.doApplyFinalizedPsf:
-            finalizedPsfApCorrCatalog = inputs.pop("finalizedPsfApCorrCatalog")
-        else:
-            finalizedPsfApCorrCatalog = None
 
         # Do an initial selection on inputs with complete wcs/photoCalib info.
         # Qualifying calexps will be read in the following call.

--- a/python/lsst/pipe/tasks/makeWarp.py
+++ b/python/lsst/pipe/tasks/makeWarp.py
@@ -234,6 +234,7 @@ class MakeWarpTask(CoaddBaseTask):
             for dataId in dataIdList
         ]
 
+        # Check early that the visitSummary contains everything we need.
         visitSummary = inputs["visitSummary"]
         bboxList = []
         wcsList = []
@@ -250,12 +251,7 @@ class MakeWarpTask(CoaddBaseTask):
 
         # Do an initial selection on inputs with complete wcs/photoCalib info.
         # Qualifying calexps will be read in the following call.
-        completeIndices = self._prepareCalibratedExposures(
-            **inputs,
-            externalSkyWcsCatalog=externalSkyWcsCatalog,
-            externalPhotoCalibCatalog=externalPhotoCalibCatalog,
-            finalizedPsfApCorrCatalog=finalizedPsfApCorrCatalog,
-        )
+        completeIndices = self._prepareCalibratedExposures(**inputs)
         inputs = self.filterInputs(indices=completeIndices, inputs=inputs)
 
         # Do another selection based on the configured selection task
@@ -411,46 +407,27 @@ class MakeWarpTask(CoaddBaseTask):
                 inputs[key] = [inputs[key][ind] for ind in indices]
         return inputs
 
-    def _prepareCalibratedExposures(self, calExpList=[], wcsList=None, backgroundList=None, skyCorrList=None,
-                                    externalSkyWcsCatalog=None, externalPhotoCalibCatalog=None,
-                                    finalizedPsfApCorrCatalog=None, visitSummary=None, **kwargs):
+    def _prepareCalibratedExposures(self, *, visitSummary, calExpList=[], wcsList=None,
+                                    backgroundList=None, skyCorrList=None, **kwargs):
         """Calibrate and add backgrounds to input calExpList in place.
 
         Parameters
         ----------
+        visitSummary : `lsst.afw.table.ExposureCatalog`
+            Exposure catalog with potentially all calibrations.  Attributes set
+            to `None` are ignored.
         calExpList : `list` [`lsst.afw.image.Exposure` or
                      `lsst.daf.butler.DeferredDatasetHandle`]
             Sequence of calexps to be modified in place.
         wcsList : `list` [`lsst.afw.geom.SkyWcs`]
-            The WCSs of the calexps in ``calExpList``.  When
-            ``externalSkyCatalog`` is `None`, these are used to determine if
-            the calexp should be included in the warp, namely checking that it
-            is not `None`.  If ``externalSkyCatalog`` is not `None`, this list
-            will be dynamically updated with the external sky WCS.
+            The WCSs of the calexps in ``calExpList``. These will be used to
+            determine if the calexp should be used in the warp. The list is
+            dynamically updated with the WCSs from the visitSummary.
         backgroundList : `list` [`lsst.afw.math.backgroundList`], optional
             Sequence of backgrounds to be added back in if bgSubtracted=False.
         skyCorrList : `list` [`lsst.afw.math.backgroundList`], optional
             Sequence of background corrections to be subtracted if
             doApplySkyCorr=True.
-        externalSkyWcsCatalog : `lsst.afw.table.ExposureCatalog`, optional
-            Exposure catalog with external skyWcs to be applied
-            if config.doApplyExternalSkyWcs=True.  Catalog uses the detector id
-            for the catalog id, sorted on id for fast lookup.
-            Deprecated and will be removed after v26.
-        externalPhotoCalibCatalog : `lsst.afw.table.ExposureCatalog`, optional
-            Exposure catalog with external photoCalib to be applied
-            if config.doApplyExternalPhotoCalib=True.  Catalog uses the
-            detector id for the catalog id, sorted on id for fast lookup.
-            Deprecated and will be removed after v26.
-        finalizedPsfApCorrCatalog : `lsst.afw.table.ExposureCatalog`, optional
-            Exposure catalog with finalized psf models and aperture correction
-            maps to be applied if config.doApplyFinalizedPsf=True.  Catalog
-            uses the detector id for the catalog id, sorted on id for fast
-            lookup.
-            Deprecated and will be removed after v26.
-        visitSummary : `lsst.afw.table.ExposureCatalog`, optional
-            Exposure catalog with potentially all calibrations.  Attributes set
-            to `None` are ignored.
         **kwargs
             Additional keyword arguments.
 
@@ -467,15 +444,9 @@ class MakeWarpTask(CoaddBaseTask):
         includeCalibVar = self.config.includeCalibVar
 
         indices = []
-        for index, (calexp, wcs, background, skyCorr) in enumerate(zip(calExpList,
-                                                                       wcsList,
-                                                                       backgroundList,
-                                                                       skyCorrList)):
-            if externalSkyWcsCatalog is None and wcs is None:
-                self.log.warning("Detector id %d for visit %d has None for skyWcs and will not be "
-                                 "used in the warp", calexp.dataId["detector"], calexp.dataId["visit"])
-                continue
-
+        for index, (calexp, background, skyCorr) in enumerate(zip(calExpList,
+                                                                  backgroundList,
+                                                                  skyCorrList)):
             if isinstance(calexp, DeferredDatasetHandle):
                 calexp = calexp.get()
 
@@ -485,96 +456,57 @@ class MakeWarpTask(CoaddBaseTask):
             detectorId = calexp.info.getDetector().getId()
 
             # Load all calibrations from visitSummary.
-            if visitSummary is not None:
-                row = visitSummary.find(detectorId)
-                if row is None:
-                    raise RuntimeError(
-                        f"Unexpectedly incomplete visitSummary: detector={detectorId} is missing."
-                    )
-                if (photoCalib := row.getPhotoCalib()) is not None:
-                    calexp.setPhotoCalib(photoCalib)
-                if (skyWcs := row.getWcs()) is not None:
-                    calexp.setWcs(skyWcs)
-                    wcsList[index] = skyWcs
-                if self.config.useVisitSummaryPsf:
-                    if (psf := row.getPsf()) is not None:
-                        calexp.setPsf(psf)
-                    if (apCorrMap := row.getApCorrMap()) is not None:
-                        calexp.info.setApCorrMap(apCorrMap)
-                # TODO: on DM-39854 the logic in the 'elif' blocks below could
-                # be moved into 'else' blocks above (or otherwise simplified
-                # substantially) after the 'external' arguments are removed.
-
-            # Find the external photoCalib.
-            if externalPhotoCalibCatalog is not None:
-                row = externalPhotoCalibCatalog.find(detectorId)
-                if row is None:
-                    self.log.warning("Detector id %s not found in externalPhotoCalibCatalog "
-                                     "and will not be used in the warp.", detectorId)
-                    continue
-                photoCalib = row.getPhotoCalib()
-                if photoCalib is None:
-                    self.log.warning("Detector id %s has None for photoCalib in externalPhotoCalibCatalog "
-                                     "and will not be used in the warp.", detectorId)
-                    continue
+            row = visitSummary.find(detectorId)
+            if row is None:
+                raise RuntimeError(
+                    f"Unexpectedly incomplete visitSummary: detector={detectorId} is missing."
+                )
+            if (photoCalib := row.getPhotoCalib()) is not None:
                 calexp.setPhotoCalib(photoCalib)
-            elif photoCalib is None:
-                self.log.warning("Detector id %s has None for photoCalib in the visit summary "
-                                 "and will not be used in the warp.", detectorId)
+            else:
+                self.log.warning(
+                    "Detector id %d for visit %d has None for photoCalib in the visitSummary and will "
+                    "not be used in the warp", detectorId, row["visit"],
+                )
                 continue
-
-            # Find and apply external skyWcs.
-            if externalSkyWcsCatalog is not None:
-                row = externalSkyWcsCatalog.find(detectorId)
-                if row is None:
-                    self.log.warning("Detector id %s not found in externalSkyWcsCatalog "
-                                     "and will not be used in the warp.", detectorId)
-                    continue
-                skyWcs = row.getWcs()
-                wcsList[index] = skyWcs
-                if skyWcs is None:
-                    self.log.warning("Detector id %s has None for skyWcs in externalSkyWcsCatalog "
-                                     "and will not be used in the warp.", detectorId)
-                    continue
+            if (skyWcs := row.getWcs()) is not None:
                 calexp.setWcs(skyWcs)
-            elif skyWcs is None:
-                self.log.warning("Detector id %s has None for skyWcs in the visit summary "
-                                 "and will not be used in the warp.", detectorId)
+                wcsList[index] = skyWcs
+            else:
+                self.log.warning(
+                    "Detector id %d for visit %d has None for wcs in the visitSummary and will "
+                    "not be used in the warp", detectorId, row["visit"],
+                )
                 continue
-
-            # Find and apply finalized psf and aperture correction.
-            if finalizedPsfApCorrCatalog is not None:
-                row = finalizedPsfApCorrCatalog.find(detectorId)
-                if row is None:
-                    self.log.warning("Detector id %s not found in finalizedPsfApCorrCatalog "
-                                     "and will not be used in the warp.", detectorId)
+            if self.config.useVisitSummaryPsf:
+                if (psf := row.getPsf()) is not None:
+                    calexp.setPsf(psf)
+                else:
+                    self.log.warning(
+                        "Detector id %d for visit %d has None for psf in the visitSummary and will "
+                        "not be used in the warp", detectorId, row["visit"],
+                    )
                     continue
-                psf = row.getPsf()
-                if psf is None:
-                    self.log.warning("Detector id %s has None for psf in finalizedPsfApCorrCatalog "
-                                     "and will not be used in the warp.", detectorId)
+                if (apCorrMap := row.getApCorrMap()) is not None:
+                    calexp.info.setApCorrMap(apCorrMap)
+                else:
+                    self.log.warning(
+                        "Detector id %d for visit %d has None for apCorrMap in the visitSummary and will "
+                        "not be used in the warp", detectorId, row["visit"],
+                    )
                     continue
-                calexp.setPsf(psf)
-                apCorrMap = row.getApCorrMap()
-                if apCorrMap is None:
-                    self.log.warning("Detector id %s has None for ApCorrMap in finalizedPsfApCorrCatalog "
-                                     "and will not be used in the warp.", detectorId)
-                    continue
-                calexp.info.setApCorrMap(apCorrMap)
-            elif self.config.useVisitSummaryPsf:
-                if psf is None:
-                    self.log.warning("Detector id %s has None for PSF in the visit summary "
-                                     "and will not be used in the warp.", detectorId)
-                if apCorrMap is None:
-                    self.log.warning("Detector id %s has None for ApCorrMap in the visit summary "
-                                     "and will not be used in the warp.", detectorId)
             else:
                 if calexp.getPsf() is None:
-                    self.log.warning("Detector id %s has None for PSF in the calexp "
-                                     "and will not be used in the warp.", detectorId)
+                    self.log.warning(
+                        "Detector id %d for visit %d has None for psf for the calexp and will "
+                        "not be used in the warp", detectorId, row["visit"],
+                    )
+                    continue
                 if calexp.info.getApCorrMap() is None:
-                    self.log.warning("Detector id %s has None for ApCorrMap in the calexp "
-                                     "and will not be used in the warp.", detectorId)
+                    self.log.warning(
+                        "Detector id %d for visit %d has None for apCorrMap in the calexp and will "
+                        "not be used in the warp", detectorId, row["visit"],
+                    )
                     continue
 
             # Calibrate the image.


### PR DESCRIPTION
This also partly covers the deprecation cleanup from DM-39854, at least as far as makeWarp.py is concerned.