### PR TITLE
DM-43020: Implement region and time extraction for preload

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,5 +1,5 @@
 Copyright 2014-2019 The Trustees of Princeton University
-Copyright 2014-2022 University of Washington
+Copyright 2014-2022, 2024 University of Washington
 Copyright 2014-2018 Association of Universities for Research in Astronomy
 Copyright 2016-2018 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
 Copyright 2014-2015, 2017 The Regents of the University of California

--- a/doc/lsst.pipe.tasks/index.rst
+++ b/doc/lsst.pipe.tasks/index.rst
@@ -132,6 +132,9 @@ Python API reference
 .. automodapi:: lsst.pipe.tasks.functors
    :no-inheritance-diagram:
 
+.. automodapi:: lsst.pipe.tasks.getRegionTimeFromVisit
+   :no-inheritance-diagram:
+
 .. automodapi:: lsst.pipe.tasks.healSparseMapping
    :no-inheritance-diagram:
 

--- a/python/lsst/pipe/tasks/getRegionTimeFromVisit.py
+++ b/python/lsst/pipe/tasks/getRegionTimeFromVisit.py
@@ -1,0 +1,86 @@
+# This file is part of pipe_tasks.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+__all__ = ["GetRegionTimeFromVisitTask", "GetRegionTimeFromVisitConfig"]
+
+
+import lsst.pipe.base as pipeBase
+from lsst.pipe.base.utils import RegionTimeInfo
+from lsst.utils.timer import timeMethod
+
+
+class GetRegionTimeFromVisitConnections(pipeBase.PipelineTaskConnections,
+                                        dimensions={"instrument", "group", "detector"},
+                                        defaultTemplates={"coaddName": "goodSeeing", "fakesType": ""}):
+
+    dummy_visit = pipeBase.connectionTypes.Input(
+        doc="Placeholder connection to provide visit-detector records and "
+            "constrain data IDs to images we're processing. Use of a catalog "
+            "dataset lets us also control how late in the pipeline the task "
+            "is run.",
+        name="{fakesType}{coaddName}Diff_diaSrcTable",
+        storageClass="DataFrame",
+        dimensions={"instrument", "visit", "detector"},
+    )
+    dummy_exposure = pipeBase.connectionTypes.Output(
+        doc="Placeholder connection to guarantee visit-exposure-group mapping. "
+            "This output is never produced and need not be registered.",
+        name="getRegionTimeFromVisit_dummy",  # Unique in case it gets registered anyway.
+        storageClass="int",
+        dimensions={"instrument", "exposure"},
+        multiple=True,
+    )
+    output = pipeBase.connectionTypes.Output(
+        doc="The region and time associated with this group's visit.",
+        name="regionTimeInfo",
+        storageClass="RegionTimeInfo",
+        dimensions={"instrument", "group", "detector"},
+    )
+
+
+class GetRegionTimeFromVisitConfig(pipeBase.PipelineTaskConfig,
+                                   pipelineConnections=GetRegionTimeFromVisitConnections):
+    pass
+
+
+class GetRegionTimeFromVisitTask(pipeBase.PipelineTask):
+    """A converter that reads metadata from visit-dimension records and writes
+    it to a Butler dataset.
+    """
+    _DefaultName = "getRegionTimeFromVisit"
+    ConfigClass = GetRegionTimeFromVisitConfig
+
+    @timeMethod
+    def runQuantum(self, butlerQC, inputRefs, outputRefs):
+        """Convert the passed dataset refs to persistable metadata.
+        """
+        # Input datasetRefs guaranteed to be expanded.
+        times = inputRefs.dummy_visit.dataId.records["visit"].timespan
+        region = inputRefs.dummy_visit.dataId.records["visit_detector_region"].region
+        outputs = pipeBase.Struct(
+            output=RegionTimeInfo(region=region, timespan=times),
+            dummy_exposure=None,
+        )
+        butlerQC.put(outputs, outputRefs)
+
+    # All work is done in runQuantum
+    run = None

--- a/tests/test_getRegionTimeFromVisit.py
+++ b/tests/test_getRegionTimeFromVisit.py
@@ -1,0 +1,142 @@
+# This file is part of pipe_tasks.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+import tempfile
+
+import astropy.time
+import pandas as pd
+
+import lsst.utils.tests
+from lsst.sphgeom import ConvexPolygon, UnitVector3d
+import lsst.daf.butler
+import lsst.daf.butler.tests as butlerTests
+import lsst.pipe.base.testUtils as pipeTests
+
+from lsst.pipe.tasks.getRegionTimeFromVisit import GetRegionTimeFromVisitTask
+
+
+class GetRegionTimeFromVisitTests(lsst.utils.tests.TestCase):
+    def setUp(self):
+        instrument = "NotACam"
+        detector = 42
+        group = "groupy"
+        exposure = 1011
+        filter = "k2024"
+        # Coordinates taken from LATISS exposure 2024040800445
+        day_obs = 20240408
+        ra = 122.47171635551595
+        dec = -36.20378247543336
+        rot = 359.99623587800414
+        self.region = ConvexPolygon(
+            [UnitVector3d(-0.43197476135299717, 0.6808244361827491, -0.5915030791555212),
+             UnitVector3d(-0.4337643437542999, 0.6796857349601265, -0.5915029972697637),
+             UnitVector3d(-0.4344262837761736, 0.6807261608742085, -0.5898183600617098),
+             UnitVector3d(-0.43263670132940496, 0.6818648620502468, -0.5898184420345037),
+             ])
+        self.times = lsst.daf.butler.Timespan(astropy.time.Time("2024-04-09T03:50:00", scale="tai"),
+                                              astropy.time.Time("2024-04-09T03:50:30", scale="tai"))
+
+        repo_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.addCleanup(tempfile.TemporaryDirectory.cleanup, repo_dir)
+        self.repo = butlerTests.makeTestRepo(repo_dir.name)
+
+        butlerTests.addDataIdValue(self.repo, "instrument", instrument)
+        butlerTests.addDataIdValue(self.repo, "day_obs", day_obs)
+        butlerTests.addDataIdValue(self.repo, "physical_filter", filter)
+        butlerTests.addDataIdValue(self.repo, "detector", detector)
+        butlerTests.addDataIdValue(self.repo, "group", group)
+        # addDataIdValue can't handle metadata, or tables that don't have an ID column
+        self.repo.registry.insertDimensionData("exposure", {"id": exposure,
+                                                            "instrument": instrument,
+                                                            "group": group,
+                                                            "day_obs": day_obs,
+                                                            "physical_filter": filter,
+                                                            "tracking_ra": ra,
+                                                            "tracking_dec": dec,
+                                                            "sky_angle": rot,
+                                                            "timespan": self.times,
+                                                            })
+        self.repo.registry.insertDimensionData("visit", {"id": exposure,
+                                                         "instrument": instrument,
+                                                         "day_obs": day_obs,
+                                                         "physical_filter": filter,
+                                                         "timespan": self.times,
+                                                         })
+        self.repo.registry.insertDimensionData("visit_definition", {"instrument": instrument,
+                                                                    "exposure": exposure,
+                                                                    "visit": exposure,
+                                                                    })
+        self.repo.registry.insertDimensionData("visit_detector_region", {"instrument": instrument,
+                                                                         "visit": exposure,
+                                                                         "detector": detector,
+                                                                         "region": self.region,
+                                                                         })
+
+        butlerTests.addDatasetType(self.repo, "regionTimeInfo", {"instrument", "group", "detector"},
+                                   "RegionTimeInfo")
+        butlerTests.addDatasetType(self.repo, "goodSeeingDiff_diaSrcTable",
+                                   {"instrument", "visit", "detector"}, "DataFrame")
+        # pipeTests.makeQuantum needs outputs registered even if graph generation does not.
+        butlerTests.addDatasetType(self.repo, "getRegionTimeFromVisit_dummy",
+                                   {"instrument", "exposure"}, "int")
+
+        self.group_id = self.repo.registry.expandDataId(
+            {"instrument": instrument, "group": group, "detector": detector})
+        self.exposure_id = self.repo.registry.expandDataId(
+            {"instrument": instrument, "exposure": exposure})
+        self.visit_id = self.repo.registry.expandDataId(
+            {"instrument": instrument, "visit": exposure, "detector": detector})
+
+    def test_runQuantum(self):
+        butler = butlerTests.makeTestCollection(self.repo, uniqueId=self.id())
+        butler.put(pd.DataFrame(), "goodSeeingDiff_diaSrcTable", self.visit_id)
+
+        task = GetRegionTimeFromVisitTask()
+        quantum = pipeTests.makeQuantum(
+            task, butler, self.group_id,
+            {"output": self.group_id,
+             "dummy_visit": self.visit_id,
+             "dummy_exposure": [self.exposure_id],
+             })
+
+        pipeTests.runTestQuantum(task, butler, quantum, mockRun=False)
+
+        # Not exactly round-tripping, because these objects came from the dimension records.
+        info = butler.get("regionTimeInfo", self.group_id)
+        self.assertEqual(info.region, self.region)
+        self.assertEqual(info.timespan, self.times)
+
+    def test_connections(self):
+        pipeTests.lintConnections(GetRegionTimeFromVisitTask.ConfigClass.ConnectionsClass)
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+class MemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This PR adds an adapter task between AP "batch" processing (which has all the visit metadata in the visit dimension records) and Prompt Processing (which needs to get it from non-Butler sources). It's a prerequisite for several "preload" tasks in different packages.

This PR must be merged after lsst/daf_butler#999 and lsst/pipe_base#415, which provide necessary infrastructure.