### PR TITLE
DM-43973: Remove ClassificationSizeExtendedness from plugin

### DIFF
--- a/python/lsst/pipe/tasks/calibrateImage.py
+++ b/python/lsst/pipe/tasks/calibrateImage.py
@@ -285,7 +285,6 @@ class CalibrateImageConfig(pipeBase.PipelineTaskConfig, pipelineConnections=Cali
                                                "base_CircularApertureFlux",
                                                "base_GaussianFlux",
                                                "base_PsfFlux",
-                                               "base_ClassificationSizeExtendedness",
                                                ]
         self.psf_source_measurement.slots.shape = "ext_shapeHSM_HsmSourceMoments"
         # Only measure apertures we need for PSF measurement.


### PR DESCRIPTION
list to be run before having a PSF model.