### PR TITLE
DM-44246: Use full set of src footprints for noise replacement in FinalizeCharacterizationTask.

### DIFF
--- a/python/lsst/pipe/tasks/calibrateImage.py
+++ b/python/lsst/pipe/tasks/calibrateImage.py
@@ -265,6 +265,11 @@ class CalibrateImageConfig(pipeBase.PipelineTaskConfig, pipelineConnections=Cali
         self.install_simple_psf.fwhm = 4
 
         # S/N>=50 sources for PSF determination, but detection to S/N=5.
+        # The thresholdValue sets the minimum flux in a pixel to be included in the
+        # footprint, while peaks are only detected when they are above
+        # thresholdValue * includeThresholdMultiplier. The low thresholdValue
+        # ensures that the footprints are large enough for the noise replacer
+        # to mask out faint undetected neighbors that are not to be measured.
         self.psf_detection.thresholdValue = 5.0
         self.psf_detection.includeThresholdMultiplier = 10.0
         # TODO investigation: Probably want False here, but that may require

--- a/python/lsst/pipe/tasks/characterizeImage.py
+++ b/python/lsst/pipe/tasks/characterizeImage.py
@@ -226,8 +226,12 @@ class CharacterizeImageConfig(pipeBase.PipelineTaskConfig,
 
     def setDefaults(self):
         super().setDefaults()
-        # just detect bright stars; includeThresholdMultipler=10 seems large,
-        # but these are the values we have been using
+        # Just detect bright stars.
+        # The thresholdValue sets the minimum flux in a pixel to be included in the
+        # footprint, while peaks are only detected when they are above
+        # thresholdValue * includeThresholdMultiplier. The low thresholdValue
+        # ensures that the footprints are large enough for the noise replacer
+        # to mask out faint undetected neighbors that are not to be measured.
         self.detection.thresholdValue = 5.0
         self.detection.includeThresholdMultiplier = 10.0
         # do not deblend, as it makes a mess

--- a/python/lsst/pipe/tasks/finalizeCharacterization.py
+++ b/python/lsst/pipe/tasks/finalizeCharacterization.py
@@ -610,6 +610,9 @@ class FinalizeCharacterizationTask(pipeBase.PipelineTask):
         measured_src : `lsst.afw.table.SourceCatalog`
             Updated source catalog with measurements, flags and aperture corrections.
         """
+        # Extract footprints from the input src catalog for noise replacement.
+        footprints = SingleFrameMeasurementTask.getFootprintsFromCatalog(src)
+
         # Apply source selector (s/n, flags, etc.)
         good_src = self.source_selector.selectSources(src)
         if sum(good_src.selected) == 0:
@@ -699,8 +702,9 @@ class FinalizeCharacterizationTask(pipeBase.PipelineTask):
         measured_src['calib_psf_used'] = measured_used
 
         # Next, we do the measurement on all the psf candidate, used, and reserved stars.
+        # We use the full footprint list from the input src catalog for noise replacement.
         try:
-            self.measurement.run(measCat=measured_src, exposure=exposure)
+            self.measurement.run(measCat=measured_src, exposure=exposure, footprints=footprints)
         except Exception as e:
             self.log.warning('Failed to make measurements for visit %d, detector %d: %s',
                              visit, detector, e)


### PR DESCRIPTION
This also adds additional comments about why `includeThresholdMultiplier` is an important config.