### PR TITLE
DM-44796: Replace deprecated getInnerSkyPolygon() with getOuterSkyPolygon()

### DIFF
--- a/tests/test_cliCmd.py
+++ b/tests/test_cliCmd.py
@@ -83,7 +83,7 @@ class RegisterSkymapConfigTest(unittest.TestCase):
                 # assert that the first argument to the call to makeSkyMap was a butler
                 self.assertIsInstance(mock.call_args[0][0], Butler)
                 # assert that the second argument matches the expected config
-                self.assertEqual(mock.call_args[0][1], expectedConfig)
+                self.assertTrue(mock.call_args[0][1].compare(expectedConfig))
 
     def testConfigOverride(self):
         """Verify expected arguments are passed to makeSkyMap with config
@@ -102,7 +102,7 @@ class RegisterSkymapConfigTest(unittest.TestCase):
                 # assert that the first argument to the makeSkyMap call was a butler
                 self.assertIsInstance(mock.call_args[0][0], Butler)
                 # assert that the second argument matches the expected config
-                self.assertEqual(mock.call_args[0][1], expectedConfig)
+                self.assertTrue(mock.call_args[0][1].compare(expectedConfig))
 
     def testNonExistantConfigFile(self):
         """Verify an expected error when a given config override file does not

--- a/tests/test_matchFakes.py
+++ b/tests/test_matchFakes.py
@@ -52,7 +52,7 @@ class TestMatchFakes(lsst.utils.tests.TestCase):
 
         self.simpleMap = skyMap.DiscreteSkyMap(simpleMapConfig)
         self.tractId = 0
-        bCircle = self.simpleMap.generateTract(self.tractId).getInnerSkyPolygon().getBoundingCircle()
+        bCircle = self.simpleMap.generateTract(self.tractId).getOuterSkyPolygon().getBoundingCircle()
         bCenter = sphgeom.LonLat(bCircle.getCenter())
         bRadius = bCircle.getOpeningAngle().asRadians()
         targetSources = 10000


### PR DESCRIPTION
Note that (a) for rings and discrete skymap these return almost the same polygon (which was incorrect necessitating the deprecation); (b) using the outer polygon may have been the original intention in the fakes task; (c) the fakes tasks are being replaced with the new source injection tasks.