### PR TITLE
DM-45002: Update calibrate to always run the normalized calibration.

### DIFF
--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -623,19 +623,16 @@ class CalibrateTask(pipeBase.PipelineTask):
             exposureId=idGenerator.catalog_id,
         )
         if self.config.doNormalizedCalibration:
-            if exposure.getInfo().getApCorrMap() is None:
-                self.log.warning("Image does not have valid aperture correction map for %r; "
-                                 "skipping normalized calibration flux", idGenerator)
-            else:
-                self.normalizedCalibrationFlux.run(
-                    exposure=exposure,
-                    catalog=sourceCat,
-                )
+            self.normalizedCalibrationFlux.run(
+                exposure=exposure,
+                catalog=sourceCat,
+                exposure_id=idGenerator.catalog_id,
+            )
         if self.config.doApCorr:
             apCorrMap = exposure.getInfo().getApCorrMap()
             if apCorrMap is None:
                 self.log.warning("Image does not have valid aperture correction map for %r; "
-                                 "skipping aperture correction", idGenerator)
+                                 "skipping aperture correction", idGenerator.catalog_id)
             else:
                 self.applyApCorr.run(
                     catalog=sourceCat,

--- a/python/lsst/pipe/tasks/calibrate.py
+++ b/python/lsst/pipe/tasks/calibrate.py
@@ -626,7 +626,6 @@ class CalibrateTask(pipeBase.PipelineTask):
             self.normalizedCalibrationFlux.run(
                 exposure=exposure,
                 catalog=sourceCat,
-                exposure_id=idGenerator.catalog_id,
             )
         if self.config.doApCorr:
             apCorrMap = exposure.getInfo().getApCorrMap()


### PR DESCRIPTION
The calibrate task now always runs normalized calibration, which can now handle empty aperture correction maps.