### PR TITLE
DM-45234: Some minor test cleanups

### DIFF
--- a/tests/test_calexpCutout.py
+++ b/tests/test_calexpCutout.py
@@ -37,8 +37,8 @@ from lsst.pipe.tasks.calexpCutout import CalexpCutoutTask
 
 random.seed(208241138)
 
-packageDir = lsst.utils.getPackageDir('pipe_tasks')
-datadir = os.path.join(packageDir, 'tests', "data")
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+datadir = os.path.join(TESTDIR, "data")
 
 
 def make_data(bbox, wcs, border=100, ngood=13, nbad=7, nedge=3):

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -32,11 +32,12 @@ import lsst.afw.image
 import lsst.afw.math
 import lsst.afw.table
 import lsst.daf.butler.tests as butlerTests
-from lsst.utils import getPackageDir
 from lsst.pipe.base import testUtils
 from lsst.pipe.tasks.calibrate import CalibrateTask, CalibrateConfig
 from lsst.pipe.tasks.characterizeImage import CharacterizeImageTask, CharacterizeImageConfig
 import lsst.meas.extensions.piff.piffPsfDeterminer
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class CalibrateTaskTestCaseWithButler(lsst.utils.tests.TestCase):
@@ -196,7 +197,7 @@ class CalibrateTaskTestCaseWithButler(lsst.utils.tests.TestCase):
                          {"exposure", "idGenerator", "background", "icSourceCat"})
 
     def testNoAperCorrMap(self):
-        expPath = os.path.join(getPackageDir("pipe_tasks"), "tests", "data", "v695833-e0-c000-a00.sci.fits")
+        expPath = os.path.join(TESTDIR, "data", "v695833-e0-c000-a00.sci.fits")
         exposure = lsst.afw.image.ExposureF(expPath)
 
         charImConfig = CharacterizeImageConfig()

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -196,6 +196,9 @@ class CalibrateTaskTestCaseWithButler(lsst.utils.tests.TestCase):
         self.assertEqual(run.call_args[1].keys(),
                          {"exposure", "idGenerator", "background", "icSourceCat"})
 
+
+class CalibrateTaskTestCaseNoButler(lsst.utils.tests.TestCase):
+
     def testNoAperCorrMap(self):
         expPath = os.path.join(TESTDIR, "data", "v695833-e0-c000-a00.sci.fits")
         exposure = lsst.afw.image.ExposureF(expPath)

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -216,7 +216,7 @@ class CalibrateTaskTestCaseNoButler(lsst.utils.tests.TestCase):
         calibConfig.doComputeSummaryStats = False
 
         # Force the aperture correction map to None (DM-39626)
-        exposure.info.setApCorrMap(None)
+        charImResults.exposure.info.setApCorrMap(None)
         calibTask = CalibrateTask(config=calibConfig)
         with self.assertLogs(level=logging.WARNING) as cm:
             _ = calibTask.run(charImResults.exposure)

--- a/tests/test_isPrimaryFlag.py
+++ b/tests/test_isPrimaryFlag.py
@@ -22,7 +22,6 @@
 import os
 import unittest
 import numpy as np
-import logging
 
 from lsst.geom import Point2I, Box2I, Extent2I
 from lsst.skymap import TractInfo
@@ -164,9 +163,6 @@ class IsPrimaryTestCase(lsst.utils.tests.TestCase):
         charImConfig.measureApCorr.sourceSelector["science"].doSignalToNoise = False
         charImTask = CharacterizeImageTask(config=charImConfig)
         self.charImResults = charImTask.run(self.exposure)
-
-        # set log level so that warnings do not display
-        logging.getLogger("lsst.calibrate").setLevel(logging.ERROR)
 
     def tearDown(self):
         del self.exposure

--- a/tests/test_isPrimaryFlag.py
+++ b/tests/test_isPrimaryFlag.py
@@ -28,7 +28,6 @@ from lsst.skymap import TractInfo
 from lsst.skymap.patchInfo import PatchInfo
 import lsst.afw.image as afwImage
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.pipe.tasks.characterizeImage import CharacterizeImageTask, CharacterizeImageConfig
 from lsst.pipe.tasks.calibrate import CalibrateTask, CalibrateConfig
 from lsst.meas.algorithms import SourceDetectionTask, SkyObjectsTask, SetPrimaryFlagsTask
@@ -36,6 +35,8 @@ import lsst.meas.extensions.scarlet as mes
 from lsst.meas.extensions.scarlet.scarletDeblendTask import ScarletDeblendTask
 from lsst.meas.base import SingleFrameMeasurementTask
 from lsst.afw.table import SourceCatalog
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class NullTract(TractInfo):
@@ -155,7 +156,7 @@ class IsPrimaryTestCase(lsst.utils.tests.TestCase):
 
     def setUp(self):
         # Load sample input from disk
-        expPath = os.path.join(getPackageDir("pipe_tasks"), "tests", "data", "v695833-e0-c000-a00.sci.fits")
+        expPath = os.path.join(TESTDIR, "data", "v695833-e0-c000-a00.sci.fits")
         self.exposure = afwImage.ExposureF(expPath)
 
         # Characterize the image (create PSF, etc.)

--- a/tests/test_photoCal.py
+++ b/tests/test_photoCal.py
@@ -31,13 +31,13 @@ import lsst.geom as geom
 import lsst.afw.table as afwTable
 import lsst.afw.image as afwImage
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.pipe.tasks.photoCal import PhotoCalTask, PhotoCalConfig
 from lsst.pipe.tasks.colorterms import Colorterm, ColortermDict, ColortermLibrary
 from lsst.utils.logging import TRACE
 from lsst.meas.algorithms.testUtils import MockReferenceObjectLoaderFromFiles
 
-RefCatDir = os.path.join(getPackageDir("pipe_tasks"), "tests", "data", "sdssrefcat")
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+RefCatDir = os.path.join(TESTDIR, "data", "sdssrefcat")
 
 testColorterms = ColortermLibrary(data={
     "test*": ColortermDict(data={

--- a/tests/test_psfCandidateSelection.py
+++ b/tests/test_psfCandidateSelection.py
@@ -21,7 +21,6 @@
 #
 import os
 import unittest
-import logging
 
 import lsst.afw.image as afwImage
 import lsst.utils.tests
@@ -36,8 +35,6 @@ class PsfFlagTestCase(lsst.utils.tests.TestCase):
         # Load sample input from disk
         expPath = os.path.join(getPackageDir("pipe_tasks"), "tests", "data", "v695833-e0-c000-a00.sci.fits")
         self.exposure = afwImage.ExposureF(expPath)
-        # set log level so that warnings do not display
-        logging.getLogger("lsst.characterizeImage").setLevel(logging.ERROR)
 
     def tearDown(self):
         del self.exposure

--- a/tests/test_psfCandidateSelection.py
+++ b/tests/test_psfCandidateSelection.py
@@ -25,15 +25,16 @@ import unittest
 import lsst.afw.image as afwImage
 import lsst.utils.tests
 import lsst.meas.extensions.piff.piffPsfDeterminer
-from lsst.utils import getPackageDir
 from lsst.pipe.tasks.characterizeImage import CharacterizeImageTask, CharacterizeImageConfig
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class PsfFlagTestCase(lsst.utils.tests.TestCase):
 
     def setUp(self):
         # Load sample input from disk
-        expPath = os.path.join(getPackageDir("pipe_tasks"), "tests", "data", "v695833-e0-c000-a00.sci.fits")
+        expPath = os.path.join(TESTDIR, "data", "v695833-e0-c000-a00.sci.fits")
         self.exposure = afwImage.ExposureF(expPath)
 
     def tearDown(self):

--- a/tests/test_skySources.py
+++ b/tests/test_skySources.py
@@ -21,7 +21,6 @@
 
 import os
 import unittest
-import logging
 
 import lsst.afw.image as afwImage
 import lsst.meas.extensions.piff.piffPsfDeterminer
@@ -37,8 +36,6 @@ class SkySourcesTestCase(lsst.utils.tests.TestCase):
         # Load sample input from disk
         expPath = os.path.join(getPackageDir("pipe_tasks"), "tests", "data", "v695833-e0-c000-a00.sci.fits")
         self.exposure = afwImage.ExposureF(expPath)
-        # set log level so that warnings do not display
-        logging.getLogger("lsst.calibrate").setLevel(logging.ERROR)
 
     def tearDown(self):
         del self.exposure

--- a/tests/test_skySources.py
+++ b/tests/test_skySources.py
@@ -25,16 +25,17 @@ import unittest
 import lsst.afw.image as afwImage
 import lsst.meas.extensions.piff.piffPsfDeterminer
 import lsst.utils.tests
-from lsst.utils import getPackageDir
 from lsst.pipe.tasks.characterizeImage import CharacterizeImageTask, CharacterizeImageConfig
 from lsst.pipe.tasks.calibrate import CalibrateTask, CalibrateConfig
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
 class SkySourcesTestCase(lsst.utils.tests.TestCase):
 
     def setUp(self):
         # Load sample input from disk
-        expPath = os.path.join(getPackageDir("pipe_tasks"), "tests", "data", "v695833-e0-c000-a00.sci.fits")
+        expPath = os.path.join(TESTDIR, "data", "v695833-e0-c000-a00.sci.fits")
         self.exposure = afwImage.ExposureF(expPath)
 
     def tearDown(self):


### PR DESCRIPTION
* Disable changes to global log levels (changing test order can break tests)
* Do not use getPackageDir when there is no need to.
* Minor edit to test_calibrate.py