### PR TITLE
DM-45573: Compute magnitude limit for exposure summary stats

### DIFF
--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -1229,7 +1229,8 @@ class MakeCcdVisitTableTask(pipeBase.PipelineTask):
                              "psfApFluxDelta", "psfApCorrSigmaScaledDelta",
                              "maxDistToNearestPsf",
                              "effTime", "effTimePsfSigmaScale",
-                             "effTimeSkyBgScale", "effTimeZeroPointScale"]
+                             "effTimeSkyBgScale", "effTimeZeroPointScale",
+                             "magLim"]
             ccdEntry = summaryTable[selectColumns].to_pandas().set_index("id")
             # 'visit' is the human readable visit number.
             # 'visitId' is the key to the visitId table. They are the same.


### PR DESCRIPTION
Simple computation of the magnitude limit at fixed SNR (e.g., SNR=5) from the psfSigma, skyBg, zeroPoint, and readNoise. See DM-45573, STMN-002, and LSE-40 for details.