### PR TITLE
DM-45577: Add option to drop PSF fit table connection

### DIFF
--- a/python/lsst/pipe/tasks/fit_coadd_multiband.py
+++ b/python/lsst/pipe/tasks/fit_coadd_multiband.py
@@ -20,8 +20,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 __all__ = [
-    "CoaddMultibandFitConfig", "CoaddMultibandFitSubConfig", "CoaddMultibandFitSubTask",
-    "CoaddMultibandFitTask",
+    "CoaddMultibandFitConfig", "CoaddMultibandFitConnections", "CoaddMultibandFitSubConfig",
+    "CoaddMultibandFitSubTask", "CoaddMultibandFitTask",
 ]
 
 from .fit_multiband import CatalogExposure, CatalogExposureConfig

--- a/python/lsst/pipe/tasks/fit_coadd_multiband.py
+++ b/python/lsst/pipe/tasks/fit_coadd_multiband.py
@@ -42,6 +42,7 @@ from typing import Iterable
 CoaddMultibandFitBaseTemplates = {
     "name_coadd": "deep",
     "name_method": "multiprofit",
+    "name_table": "objects",
 }
 
 
@@ -173,7 +174,7 @@ class CoaddMultibandFitInputConnections(
 class CoaddMultibandFitConnections(CoaddMultibandFitInputConnections):
     cat_output = cT.Output(
         doc="Output source model fit parameter catalog",
-        name="{name_coadd}Coadd_objects_{name_method}",
+        name="{name_coadd}Coadd_{name_table}_{name_method}",
         storageClass="ArrowTable",
         dimensions=("tract", "patch", "skymap"),
     )
@@ -335,7 +336,7 @@ class CoaddMultibandFitTask(CoaddMultibandFitBase, pipeBase.PipelineTask):
     """
 
     ConfigClass = CoaddMultibandFitConfig
-    _DefaultName = "CoaddMultibandFit"
+    _DefaultName = "coaddMultibandFit"
 
     def __init__(self, initInputs, **kwargs):
         super().__init__(initInputs=initInputs, **kwargs)

--- a/python/lsst/pipe/tasks/fit_coadd_psf.py
+++ b/python/lsst/pipe/tasks/fit_coadd_psf.py
@@ -20,8 +20,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 __all__ = [
-    "CatalogExposurePsf", "CoaddPsfFitConfig", "CoaddPsfFitSubConfig", "CoaddPsfFitSubTask",
-    "CoaddPsfFitTask",
+    "CatalogExposurePsf", "CoaddPsfFitConfig", "CoaddPsfFitConnections",
+    "CoaddPsfFitSubConfig", "CoaddPsfFitSubTask", "CoaddPsfFitTask",
 ]
 
 from .fit_multiband import CatalogExposure, CatalogExposureConfig


### PR DESCRIPTION
If using shapelet PSF parameters, these are in the deepCoadd_meas catalog and so there's no need to try to load a multiprofit PSF fit table that might not even exist.