### PR TITLE
DM-46699: Dummy output of GetRegionTimeFromVisitTask confuses provenance tools

### DIFF
--- a/python/lsst/pipe/tasks/getRegionTimeFromVisit.py
+++ b/python/lsst/pipe/tasks/getRegionTimeFromVisit.py
@@ -44,9 +44,9 @@ class GetRegionTimeFromVisitConnections(pipeBase.PipelineTaskConnections,
     dummy_exposure = pipeBase.connectionTypes.Output(
         doc="Placeholder connection to guarantee visit-exposure-group mapping. "
             "This output is never produced and need not be registered.",
-        name="getRegionTimeFromVisit_dummy",  # Unique in case it gets registered anyway.
+        name="getRegionTimeFromVisit_dummy2",  # Unique because it gets registered anyway.
         storageClass="int",
-        dimensions={"instrument", "exposure"},
+        dimensions={"instrument", "exposure", "detector"},
         multiple=True,
     )
     output = pipeBase.connectionTypes.Output(

--- a/tests/test_getRegionTimeFromVisit.py
+++ b/tests/test_getRegionTimeFromVisit.py
@@ -96,13 +96,13 @@ class GetRegionTimeFromVisitTests(lsst.utils.tests.TestCase):
         butlerTests.addDatasetType(self.repo, "goodSeeingDiff_diaSrcTable",
                                    {"instrument", "visit", "detector"}, "DataFrame")
         # pipeTests.makeQuantum needs outputs registered even if graph generation does not.
-        butlerTests.addDatasetType(self.repo, "getRegionTimeFromVisit_dummy",
-                                   {"instrument", "exposure"}, "int")
+        butlerTests.addDatasetType(self.repo, "getRegionTimeFromVisit_dummy2",
+                                   {"instrument", "exposure", "detector"}, "int")
 
         self.group_id = self.repo.registry.expandDataId(
             {"instrument": instrument, "group": group, "detector": detector})
         self.exposure_id = self.repo.registry.expandDataId(
-            {"instrument": instrument, "exposure": exposure})
+            {"instrument": instrument, "exposure": exposure, "detector": detector})
         self.visit_id = self.repo.registry.expandDataId(
             {"instrument": instrument, "visit": exposure, "detector": detector})
 


### PR DESCRIPTION
This PR fixes a bug where `GetRegionTimeFromVisitTask` would cause analysis of quantum graphs to crash.