### PR TITLE
DM-46642: Rename outputs of isolatedStarAssociation

### DIFF
--- a/python/lsst/pipe/tasks/finalizeCharacterization.py
+++ b/python/lsst/pipe/tasks/finalizeCharacterization.py
@@ -70,7 +70,7 @@ class FinalizeCharacterizationConnections(pipeBase.PipelineTaskConnections,
     isolated_star_cats = pipeBase.connectionTypes.Input(
         doc=('Catalog of isolated stars with average positions, number of associated '
              'sources, and indexes to the isolated_star_sources catalogs.'),
-        name='isolated_star_cat',
+        name='isolated_star_presource_associations',
         storageClass='DataFrame',
         dimensions=('instrument', 'tract', 'skymap'),
         deferLoad=True,
@@ -79,7 +79,7 @@ class FinalizeCharacterizationConnections(pipeBase.PipelineTaskConnections,
     isolated_star_sources = pipeBase.connectionTypes.Input(
         doc=('Catalog of isolated star sources with sourceIds, and indexes to the '
              'isolated_star_cats catalogs.'),
-        name='isolated_star_sources',
+        name='isolated_star_presources',
         storageClass='DataFrame',
         dimensions=('instrument', 'tract', 'skymap'),
         deferLoad=True,

--- a/python/lsst/pipe/tasks/isolatedStarAssociation.py
+++ b/python/lsst/pipe/tasks/isolatedStarAssociation.py
@@ -42,7 +42,7 @@ class IsolatedStarAssociationConnections(pipeBase.PipelineTaskConnections,
                                          defaultTemplates={}):
     source_table_visit = pipeBase.connectionTypes.Input(
         doc='Source table in parquet format, per visit',
-        name='sourceTable_visit',
+        name='preSourceTable_visit',
         storageClass='DataFrame',
         dimensions=('instrument', 'visit'),
         deferLoad=True,
@@ -56,13 +56,13 @@ class IsolatedStarAssociationConnections(pipeBase.PipelineTaskConnections,
     )
     isolated_star_sources = pipeBase.connectionTypes.Output(
         doc='Catalog of individual sources for the isolated stars',
-        name='isolated_star_sources',
+        name='isolated_star_presources',
         storageClass='DataFrame',
         dimensions=('instrument', 'tract', 'skymap'),
     )
     isolated_star_cat = pipeBase.connectionTypes.Output(
         doc='Catalog of isolated star positions',
-        name='isolated_star_cat',
+        name='isolated_star_presource_associations',
         storageClass='DataFrame',
         dimensions=('instrument', 'tract', 'skymap'),
     )


### PR DESCRIPTION
In preparation for the great calibration refactor. PreSources will always be generated in single frame processing and have fewer rows than Sources based on a second round of more complete detection

- isolated_star_cat -> isolated_star_presource_associations
- isolated_star_sources -> isolated_star_presources