### PR TITLE
DM-46627: Move bands_fit from MPF config to CoaddMultibandFitSubConfig

### DIFF
--- a/python/lsst/pipe/tasks/fit_coadd_multiband.py
+++ b/python/lsst/pipe/tasks/fit_coadd_multiband.py
@@ -183,6 +183,13 @@ class CoaddMultibandFitConnections(CoaddMultibandFitInputConnections):
 class CoaddMultibandFitSubConfig(pexConfig.Config):
     """Configuration for implementing fitter subtasks.
     """
+
+    bands_fit = pexConfig.ListField[str](
+        default=[],
+        doc="list of bandpass filters to fit",
+        listCheck=lambda x: (len(x) > 0) and (len(set(x)) == len(x)),
+    )
+
     @abstractmethod
     def bands_read_only(self) -> set:
         """Return the set of bands that the Task needs to read (e.g. for


### PR DESCRIPTION
This really should have been in the base class all along instead of being specific to MultiProFit - multiband fitters are going to have to specify which bands they fit one way or another and picking this option seems fine.