### PR TITLE
DM-46991: Add PreSource.yaml and update Source.yaml to work with calibrateImage.

### DIFF
--- a/schemas/PreSource.yaml
+++ b/schemas/PreSource.yaml
@@ -4,7 +4,8 @@
 # See the DPDD for more information about the output: https://lse-163.lsst.io
 funcs:
     sourceId:
-        functor: Index
+        functor: Column
+        args: id
     coord_ra:
         # reference position required by db. Not in DPDD
         functor: CoordColumn
@@ -13,12 +14,6 @@ funcs:
         # Reference position required by db. Not in DPDD
         functor: CoordColumn
         args: coord_dec
-    visit:
-        functor: Column
-        args: visit
-    detector:
-        functor: Column
-        args: detector
    # objectId: not avaliable
     # ssObjectId: not avaliable
     parentSourceId:


### PR DESCRIPTION
These need to differ only because they're being produced by different tasks with different ways of handling IDs.

I'm making minor adjustments instead of switching to the existing configuration for initial_stars_detector because I don't want to reconfigure downstream analysis tasks (which require many measurement columns that calibrateImage doesn't run by default) on this ticket.  I expect the final configuration to be somewhere in between.