### PR TITLE
DM-47730: Use new refcat loader method to improve refcat flux field checks.

### DIFF
--- a/python/lsst/pipe/tasks/loadReferenceCatalog.py
+++ b/python/lsst/pipe/tasks/loadReferenceCatalog.py
@@ -38,8 +38,6 @@ from lsst.pipe.tasks.colorterms import ColortermLibrary
 from lsst.afw.image import abMagErrFromFluxErr
 from lsst.meas.algorithms import ReferenceObjectLoader, LoadReferenceObjectsConfig
 
-import lsst.geom
-
 
 class LoadReferenceCatalogConfig(pexConfig.Config):
     """Config for LoadReferenceCatalogTask"""
@@ -340,9 +338,7 @@ class LoadReferenceCatalogTask(pipeBase.Task):
             if refFilterName is None:
                 continue
             try:
-                results = self.refObjLoader.loadSkyCircle(center,
-                                                          0.05*lsst.geom.degrees,
-                                                          refFilterName)
+                results = self.refObjLoader.loadSchema(refFilterName)
                 foundReferenceFilter = True
                 self._referenceFilter = refFilterName
                 break
@@ -377,7 +373,7 @@ class LoadReferenceCatalogTask(pipeBase.Task):
 
             if refFilterName is not None:
                 try:
-                    fluxField = getRefFluxField(results.refCat.schema, filterName=refFilterName)
+                    fluxField = getRefFluxField(results.schema, filterName=refFilterName)
                 except RuntimeError:
                     # This flux field isn't available.  Set to None
                     fluxField = None

--- a/tests/test_loadReferenceCatalog.py
+++ b/tests/test_loadReferenceCatalog.py
@@ -63,6 +63,14 @@ class TrivialLoader(ReferenceObjectLoader):
     def loadPixelBox(self, bbox, wcs, referenceFilter, **kwargs):
         return self.loadSkyCircle(None, None, referenceFilter)
 
+    def loadSchema(self, filterName):
+        refCat = self.make_synthetic_refcat(_synthCenter, _synthFlux)
+        fluxField = getRefFluxField(schema=refCat.schema, filterName=filterName)
+        return pipeBase.Struct(
+            schema=refCat.schema,
+            fluxField=fluxField
+        )
+
 
 class LoadReferenceCatalogTestCase(lsst.utils.tests.TestCase):
     @classmethod


### PR DESCRIPTION
The new implementation no longer assumes there is a refcat shard overlapping the center of a tract, which was important for ci_hsc.