### PR TITLE
DM-35396: Strip provenance headers before merging tables

### DIFF
--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -1345,6 +1345,9 @@ class MakeCcdVisitTableTask(pipeBase.PipelineTask):
                 continue
             visitInfo = visitSummary[0].getVisitInfo()
 
+            # Strip provenance to prevent merge confusion.
+            strip_provenance_from_fits_header(visitSummary.metadata)
+
             ccdEntry = {}
             summaryTable = visitSummary.asAstropy()
             selectColumns = ["id", "visit", "physical_filter", "band", "ra", "dec",


### PR DESCRIPTION
Without this the astropy merge code complains that duplicate headers exist and picks the first value. Butler will update the provenance itself.