### PR TITLE
DM-49097 : Create empty DataFrame rather than convert from Table

### DIFF
--- a/python/lsst/pipe/tasks/drpAssociationPipe.py
+++ b/python/lsst/pipe/tasks/drpAssociationPipe.py
@@ -275,7 +275,10 @@ class DrpAssociationPipeTask(pipeBase.PipelineTask):
                 unassociatedSsObjects = unassociatedSsObjects[ssObjInTractPatch]
                 nSsSrc = ssInTractPatch.sum()
                 nSsObj = ssObjInTractPatch.sum()
-                diaCat = ssoAssocResult.unAssocDiaSources.to_pandas()
+                if len(ssoAssocResult.unAssocDiaSources) > 0:
+                    diaCat = ssoAssocResult.unAssocDiaSources.to_pandas()
+                else:
+                    diaCat = pd.DataFrame(columns=ssoAssocResult.unAssocDiaSources.columns)
 
             diaInTractPatch = self._trimToPatch(diaCat,
                                                 innerPatchBox,


### PR DESCRIPTION
drpAssociationPipe would fail when no diaSources were found due to an astropy-to-Pandas conversion on an empty Table with a datetime64 column. The solution checks to see if the Table is empty before converting, in which case it replaces the Table with a new empty DataFrame with matching columns. 