### PR TITLE
DM-49161: Raise MatcherFailure on no matches in PhotoCalTask.

### DIFF
--- a/python/lsst/pipe/tasks/photoCal.py
+++ b/python/lsst/pipe/tasks/photoCal.py
@@ -31,7 +31,7 @@ import lsst.pex.config as pexConf
 import lsst.pipe.base as pipeBase
 from lsst.afw.image import abMagErrFromFluxErr, makePhotoCalibFromCalibZeroPoint
 import lsst.afw.table as afwTable
-from lsst.meas.astrom import DirectMatchTask, DirectMatchConfigWithoutLoader
+from lsst.meas.astrom import DirectMatchTask, DirectMatchConfigWithoutLoader, MatcherFailure
 import lsst.afw.display as afwDisplay
 from lsst.meas.algorithms import getRefFluxField, ReserveSourcesTask
 from lsst.utils.timer import timeMethod
@@ -259,7 +259,7 @@ class PhotoCalTask(pipeBase.Task):
         srcInstFluxErrArr = srcInstFluxErrArr * referenceFlux
 
         if not matches:
-            raise RuntimeError("No reference stars are available")
+            raise MatcherFailure("No reference stars are available")
         refSchema = matches[0].first.schema
 
         if self.config.applyColorTerms:


### PR DESCRIPTION
While this exception was intended to be raised by the matcher itself, it seems quite appropriate to use it downstream when it's clearly a problem in the matching.