### PR TITLE
DM-49263-v29: Backport deprecating and disabling propagating photometric calibration uncertainty

### DIFF
--- a/python/lsst/pipe/tasks/coaddBase.py
+++ b/python/lsst/pipe/tasks/coaddBase.py
@@ -72,7 +72,7 @@ class CoaddBaseConfig(pexConfig.Config):
         dtype=bool,
         doc="Add photometric calibration variance to warp variance plane.",
         default=False,
-        deprecated="Deprecated and ignored.  Will be removed after v30.",
+        deprecated="Deprecated and ignored.  Will be removed after v29.",
     )
     # TODO: Remove this field in DM-44792.
     matchingKernelSize = pexConfig.Field(

--- a/python/lsst/pipe/tasks/coaddBase.py
+++ b/python/lsst/pipe/tasks/coaddBase.py
@@ -67,10 +67,12 @@ class CoaddBaseConfig(pexConfig.Config):
         doc="Subtask that helps fill CoaddInputs catalogs added to the final Exposure",
         target=CoaddInputRecorderTask,
     )
+    # TODO[DM-49400]: remove this field (it already does nothing).
     includeCalibVar = pexConfig.Field(
         dtype=bool,
         doc="Add photometric calibration variance to warp variance plane.",
         default=False,
+        deprecated="Deprecated and ignored.  Will be removed after v30.",
     )
     # TODO: Remove this field in DM-44792.
     matchingKernelSize = pexConfig.Field(

--- a/python/lsst/pipe/tasks/makeWarp.py
+++ b/python/lsst/pipe/tasks/makeWarp.py
@@ -450,8 +450,6 @@ class MakeWarpTask(CoaddBaseTask):
         backgroundList = len(calExpList)*[None] if backgroundList is None else backgroundList
         skyCorrList = len(calExpList)*[None] if skyCorrList is None else skyCorrList
 
-        includeCalibVar = self.config.includeCalibVar
-
         indices = []
         for index, (calexp, background, skyCorr) in enumerate(zip(calExpList,
                                                                   backgroundList,
@@ -525,8 +523,7 @@ class MakeWarpTask(CoaddBaseTask):
                 calexp.maskedImage -= skyCorr.getImage()
 
             # Calibrate the image.
-            calexp.maskedImage = photoCalib.calibrateImage(calexp.maskedImage,
-                                                           includeScaleUncertainty=includeCalibVar)
+            calexp.maskedImage = photoCalib.calibrateImage(calexp.maskedImage)
             # This new PhotoCalib shouldn't need to be used, but setting it
             # here to reflect the fact that the image now has calibrated pixels
             # might help avoid future bugs.


### PR DESCRIPTION
This also includes one commit that is not (yet) on main that just updates the release in which the deprecated interfaces will be removed after from v30 to v29, reflecting the fact that the deprecation is happening earlier. This commit will be added to main after the backport is complete.
