### PR TITLE
DM-49263-v29: Shift removal to post-v29 to reflect deprecation in v29 (forward-port)

### DIFF
--- a/python/lsst/pipe/tasks/coaddBase.py
+++ b/python/lsst/pipe/tasks/coaddBase.py
@@ -72,7 +72,7 @@ class CoaddBaseConfig(pexConfig.Config):
         dtype=bool,
         doc="Add photometric calibration variance to warp variance plane.",
         default=False,
-        deprecated="Deprecated and ignored.  Will be removed after v30.",
+        deprecated="Deprecated and ignored.  Will be removed after v29.",
     )
     # TODO: Remove this field in DM-44792.
     matchingKernelSize = pexConfig.Field(


### PR DESCRIPTION
With the deprecations from DM-49263 now appearing in v29 due a backport, we also need to adjust the deprecation clock on main.