### PR TITLE
DM-49452: Disable and deprecate propagating PhotoCalib uncertainty in functors.

### DIFF
--- a/python/lsst/pipe/tasks/functors.py
+++ b/python/lsst/pipe/tasks/functors.py
@@ -1676,8 +1676,9 @@ class LocalPhotometry(Functor):
         Name of the assocated error columns for ``instFluxCol``.
     photoCalibCol : `str`
         Name of local calibration column.
-    photoCalibErrCol : `str`
-        Error associated with ``photoCalibCol``
+    photoCalibErrCol : `str`, optional
+        Error associated with ``photoCalibCol``.  Ignored and deprecated; will
+        be removed after v29.
 
     See Also
     --------
@@ -1690,12 +1691,15 @@ class LocalPhotometry(Functor):
                  instFluxCol,
                  instFluxErrCol,
                  photoCalibCol,
-                 photoCalibErrCol,
+                 photoCalibErrCol=None,
                  **kwargs):
         self.instFluxCol = instFluxCol
         self.instFluxErrCol = instFluxErrCol
         self.photoCalibCol = photoCalibCol
-        self.photoCalibErrCol = photoCalibErrCol
+        # TODO[DM-49400]: remove this check and the argument it corresponds to.
+        if photoCalibErrCol is not None:
+            warnings.warn("The photoCalibErrCol argument is deprecated and will be removed after v29.",
+                          category=FutureWarning)
         super().__init__(**kwargs)
 
     def instFluxToNanojansky(self, instFlux, localCalib):
@@ -1715,26 +1719,33 @@ class LocalPhotometry(Functor):
         """
         return instFlux * localCalib
 
-    def instFluxErrToNanojanskyErr(self, instFlux, instFluxErr, localCalib, localCalibErr):
+    def instFluxErrToNanojanskyErr(self, instFlux, instFluxErr, localCalib, localCalibErr=None):
         """Convert instrument flux to nanojanskys.
 
         Parameters
         ----------
         instFlux : `~numpy.ndarray` or `~pandas.Series`
-            Array of instrument flux measurements.
+            Array of instrument flux measurements.  Ignored (accepted for
+            backwards compatibility and consistency with magnitude-error
+            calculation methods).
         instFluxErr : `~numpy.ndarray` or `~pandas.Series`
             Errors on associated ``instFlux`` values.
         localCalib : `~numpy.ndarray` or `~pandas.Series`
             Array of local photometric calibration estimates.
-        localCalibErr : `~numpy.ndarray` or `~pandas.Series`
-           Errors on associated ``localCalib`` values.
+        localCalibErr : `~numpy.ndarray` or `~pandas.Series`, optional
+            Errors on associated ``localCalib`` values.  Ignored and deprecated;
+            will be removed after v29.
 
         Returns
         -------
         calibFluxErr : `~numpy.ndarray` or `~pandas.Series`
             Errors on calibrated flux measurements.
         """
-        return np.hypot(instFluxErr * localCalib, instFlux * localCalibErr)
+        # TODO[DM-49400]: remove this check and the argument it corresponds to.
+        if localCalibErr is not None:
+            warnings.warn("The localCalibErr argument is deprecated and will be removed after v29.",
+                          category=FutureWarning)
+        return instFluxErr * localCalib
 
     def instFluxToMagnitude(self, instFlux, localCalib):
         """Convert instrument flux to nanojanskys.
@@ -1753,7 +1764,7 @@ class LocalPhotometry(Functor):
         """
         return -2.5 * np.log10(self.instFluxToNanojansky(instFlux, localCalib)) + self.logNJanskyToAB
 
-    def instFluxErrToMagnitudeErr(self, instFlux, instFluxErr, localCalib, localCalibErr):
+    def instFluxErrToMagnitudeErr(self, instFlux, instFluxErr, localCalib, localCalibErr=None):
         """Convert instrument flux err to nanojanskys.
 
         Parameters
@@ -1764,15 +1775,20 @@ class LocalPhotometry(Functor):
             Errors on associated ``instFlux`` values.
         localCalib : `~numpy.ndarray` or `~pandas.Series`
             Array of local photometric calibration estimates.
-        localCalibErr : `~numpy.ndarray` or `~pandas.Series`
-           Errors on associated ``localCalib`` values.
+        localCalibErr : `~numpy.ndarray` or `~pandas.Series`, optional
+            Errors on associated ``localCalib`` values.  Ignored and deprecated;
+            will be removed after v29.
 
         Returns
         -------
         calibMagErr: `~numpy.ndarray` or `~pandas.Series`
             Error on calibrated AB magnitudes.
         """
-        err = self.instFluxErrToNanojanskyErr(instFlux, instFluxErr, localCalib, localCalibErr)
+        # TODO[DM-49400]: remove this check and the argument it corresponds to.
+        if localCalibErr is not None:
+            warnings.warn("The localCalibErr argument is deprecated and will be removed after v29.",
+                          category=FutureWarning)
+        err = self.instFluxErrToNanojanskyErr(instFlux, instFluxErr, localCalib)
         return 2.5 / np.log(10) * err / self.instFluxToNanojansky(instFlux, instFluxErr)
 
 
@@ -1803,8 +1819,7 @@ class LocalNanojanskyErr(LocalPhotometry):
 
     @property
     def columns(self):
-        return [self.instFluxCol, self.instFluxErrCol,
-                self.photoCalibCol, self.photoCalibErrCol]
+        return [self.instFluxCol, self.instFluxErrCol, self.photoCalibCol]
 
     @property
     def name(self):
@@ -1812,8 +1827,7 @@ class LocalNanojanskyErr(LocalPhotometry):
 
     def _func(self, df):
         return self.instFluxErrToNanojanskyErr(df[self.instFluxCol], df[self.instFluxErrCol],
-                                               df[self.photoCalibCol],
-                                               df[self.photoCalibErrCol]).astype(np.float32)
+                                               df[self.photoCalibCol]).astype(np.float32)
 
 
 class LocalDipoleMeanFlux(LocalPhotometry):
@@ -1833,14 +1847,14 @@ class LocalDipoleMeanFlux(LocalPhotometry):
                  instFluxPosErrCol,
                  instFluxNegErrCol,
                  photoCalibCol,
-                 photoCalibErrCol,
+                 # TODO[DM-49400]: remove this option; it's already deprecated (in super).
+                 photoCalibErrCol=None,
                  **kwargs):
         self.instFluxNegCol = instFluxNegCol
         self.instFluxPosCol = instFluxPosCol
         self.instFluxNegErrCol = instFluxNegErrCol
         self.instFluxPosErrCol = instFluxPosErrCol
         self.photoCalibCol = photoCalibCol
-        self.photoCalibErrCol = photoCalibErrCol
         super().__init__(instFluxNegCol,
                          instFluxNegErrCol,
                          photoCalibCol,
@@ -1880,19 +1894,14 @@ class LocalDipoleMeanFluxErr(LocalDipoleMeanFlux):
                 self.instFluxNegCol,
                 self.instFluxPosErrCol,
                 self.instFluxNegErrCol,
-                self.photoCalibCol,
-                self.photoCalibErrCol]
+                self.photoCalibCol]
 
     @property
     def name(self):
         return f'dipMeanFluxErr_{self.instFluxPosCol}_{self.instFluxNegCol}'
 
     def _func(self, df):
-        return 0.5*np.sqrt(
-            (np.fabs(df[self.instFluxNegCol]) + np.fabs(df[self.instFluxPosCol])
-             * df[self.photoCalibErrCol])**2
-            + (df[self.instFluxNegErrCol]**2 + df[self.instFluxPosErrCol]**2)
-            * df[self.photoCalibCol]**2)
+        return 0.5*np.hypot(df[self.instFluxNegErrCol], df[self.instFluxPosErrCol]) * df[self.photoCalibCol]
 
 
 class LocalDipoleDiffFlux(LocalDipoleMeanFlux):
@@ -1942,19 +1951,14 @@ class LocalDipoleDiffFluxErr(LocalDipoleMeanFlux):
                 self.instFluxNegCol,
                 self.instFluxPosErrCol,
                 self.instFluxNegErrCol,
-                self.photoCalibCol,
-                self.photoCalibErrCol]
+                self.photoCalibCol]
 
     @property
     def name(self):
         return f'dipDiffFluxErr_{self.instFluxPosCol}_{self.instFluxNegCol}'
 
     def _func(self, df):
-        return np.sqrt(
-            ((np.fabs(df[self.instFluxPosCol]) - np.fabs(df[self.instFluxNegCol]))
-             * df[self.photoCalibErrCol])**2
-            + (df[self.instFluxPosErrCol]**2 + df[self.instFluxNegErrCol]**2)
-            * df[self.photoCalibCol]**2)
+        return np.hypot(df[self.instFluxPosErrCol], df[self.instFluxNegErrCol]) * df[self.photoCalibCol]
 
 
 class Ebv(Functor):

--- a/schemas/Source.yaml
+++ b/schemas/Source.yaml
@@ -50,14 +50,12 @@ funcs:
             - slot_CalibFlux_instFlux
             - slot_CalibFlux_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     calibFluxErr:
         functor: LocalNanojanskyErr
         args:
             - slot_CalibFlux_instFlux
             - slot_CalibFlux_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
    # Not in DPDD. Used for QA
     ap03Flux:
         functor: LocalNanojansky
@@ -65,14 +63,12 @@ funcs:
             - base_CircularApertureFlux_3_0_instFlux
             - base_CircularApertureFlux_3_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap03FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_3_0_instFlux
             - base_CircularApertureFlux_3_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap03Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_3_0_flag
@@ -83,14 +79,12 @@ funcs:
             - base_CircularApertureFlux_6_0_instFlux
             - base_CircularApertureFlux_6_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap06FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_6_0_instFlux
             - base_CircularApertureFlux_6_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap06Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_6_0_flag
@@ -100,14 +94,12 @@ funcs:
             - base_CircularApertureFlux_9_0_instFlux
             - base_CircularApertureFlux_9_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap09FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_9_0_instFlux
             - base_CircularApertureFlux_9_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap09Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_9_0_flag
@@ -117,14 +109,12 @@ funcs:
             - base_CircularApertureFlux_12_0_instFlux
             - base_CircularApertureFlux_12_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap12FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_12_0_instFlux
             - base_CircularApertureFlux_12_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap12Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_12_0_flag
@@ -134,14 +124,12 @@ funcs:
             - base_CircularApertureFlux_17_0_instFlux
             - base_CircularApertureFlux_17_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap17FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_17_0_instFlux
             - base_CircularApertureFlux_17_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap17Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_17_0_flag
@@ -151,14 +139,12 @@ funcs:
             - base_CircularApertureFlux_25_0_instFlux
             - base_CircularApertureFlux_25_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap25FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_25_0_instFlux
             - base_CircularApertureFlux_25_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap25Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_25_0_flag
@@ -168,14 +154,12 @@ funcs:
             - base_CircularApertureFlux_35_0_instFlux
             - base_CircularApertureFlux_35_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap35FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_35_0_instFlux
             - base_CircularApertureFlux_35_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap35Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_35_0_flag
@@ -185,14 +169,12 @@ funcs:
             - base_CircularApertureFlux_50_0_instFlux
             - base_CircularApertureFlux_50_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap50FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_50_0_instFlux
             - base_CircularApertureFlux_50_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap50Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_50_0_flag
@@ -202,14 +184,12 @@ funcs:
             - base_CircularApertureFlux_70_0_instFlux
             - base_CircularApertureFlux_70_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap70FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_70_0_instFlux
             - base_CircularApertureFlux_70_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap70Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_70_0_flag
@@ -222,28 +202,24 @@ funcs:
             - base_LocalBackground_instFlux
             - base_LocalBackground_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     skyErr:
         functor: LocalNanojanskyErr
         args:
             - base_LocalBackground_instFlux
             - base_LocalBackground_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     psfFlux:
         functor: LocalNanojansky
         args:
             - slot_PsfFlux_instFlux
             - slot_PsfFlux_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     psfFluxErr:
         functor: LocalNanojanskyErr
         args:
             - slot_PsfFlux_instFlux
             - slot_PsfFlux_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
 
     # These PS columns do not make sense anymore as named
     # psX
@@ -303,14 +279,12 @@ funcs:
             - base_GaussianFlux_instFlux
             - base_GaussianFlux_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     gaussianFluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_GaussianFlux_instFlux
             - base_GaussianFlux_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     extendedness:
         functor: SinglePrecisionFloatColumn
         args: base_ClassificationExtendedness_value

--- a/tests/test_functors.py
+++ b/tests/test_functors.py
@@ -51,7 +51,7 @@ from lsst.pipe.tasks.functors import (CompositeFunctor, CustomFunctor, Column, R
 ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
-class FunctorTestCase(unittest.TestCase):
+class FunctorTestCase(lsst.utils.tests.TestCase):
 
     def getMultiIndexDataFrame(self, dataDict):
         """Create a simple test multi-index DataFrame."""
@@ -444,18 +444,16 @@ class FunctorTestCase(unittest.TestCase):
         flux = 1000
         fluxErr = 10
         calib = 10
-        calibErr = 1
+        calibErr = 0.0
         self.dataDict["base_PsfFlux_instFlux"] = np.full(self.nRecords, flux)
         self.dataDict["base_PsfFlux_instFluxErr"] = np.full(self.nRecords,
                                                             fluxErr)
         self.dataDict["base_LocalPhotoCalib"] = np.full(self.nRecords, calib)
-        self.dataDict["base_LocalPhotoCalibErr"] = np.full(self.nRecords,
-                                                           calibErr)
+
         df = self.getMultiIndexDataFrame(self.dataDict)
         func = LocalPhotometry("base_PsfFlux_instFlux",
                                "base_PsfFlux_instFluxErr",
-                               "base_LocalPhotoCalib",
-                               "base_LocalPhotoCalibErr")
+                               "base_LocalPhotoCalib")
 
         nanoJansky = func.instFluxToNanojansky(
             df[("meas", "g", "base_PsfFlux_instFlux")],
@@ -466,13 +464,11 @@ class FunctorTestCase(unittest.TestCase):
         nanoJanskyErr = func.instFluxErrToNanojanskyErr(
             df[("meas", "g", "base_PsfFlux_instFlux")],
             df[("meas", "g", "base_PsfFlux_instFluxErr")],
-            df[("meas", "g", "base_LocalPhotoCalib")],
-            df[("meas", "g", "base_LocalPhotoCalibErr")])
+            df[("meas", "g", "base_LocalPhotoCalib")])
         magErr = func.instFluxErrToMagnitudeErr(
             df[("meas", "g", "base_PsfFlux_instFlux")],
             df[("meas", "g", "base_PsfFlux_instFluxErr")],
-            df[("meas", "g", "base_LocalPhotoCalib")],
-            df[("meas", "g", "base_LocalPhotoCalibErr")])
+            df[("meas", "g", "base_LocalPhotoCalib")])
 
         self.assertTrue(np.allclose(nanoJansky.values,
                                     flux * calib,
@@ -503,8 +499,7 @@ class FunctorTestCase(unittest.TestCase):
     def _testLocalPhotometryFunctors(self, functor, df, testValues):
         func = functor("base_PsfFlux_instFlux",
                        "base_PsfFlux_instFluxErr",
-                       "base_LocalPhotoCalib",
-                       "base_LocalPhotoCalibErr")
+                       "base_LocalPhotoCalib")
         val = self._funcVal(func, df)
         self.assertTrue(np.allclose(testValues.values,
                                     val.values,
@@ -517,7 +512,7 @@ class FunctorTestCase(unittest.TestCase):
         fluxPos = 101
         fluxErr = 10
         calib = 10
-        calibErr = 1
+        calibErr = 0.0
 
         # compute expected values.
         absMean = 0.5*(fluxPos - fluxNeg)*calib
@@ -532,57 +527,51 @@ class FunctorTestCase(unittest.TestCase):
         self.dataDict["ip_diffim_DipoleFluxPos_instFlux"] = np.full(self.nRecords, fluxPos)
         self.dataDict["ip_diffim_DipoleFluxPos_instFluxErr"] = np.full(self.nRecords, fluxErr)
         self.dataDict["base_LocalPhotoCalib"] = np.full(self.nRecords, calib)
-        self.dataDict["base_LocalPhotoCalibErr"] = np.full(self.nRecords,
-                                                           calibErr)
 
         df = self.getMultiIndexDataFrame(self.dataDict)
         func = LocalDipoleMeanFlux("ip_diffim_DipoleFluxPos_instFlux",
                                    "ip_diffim_DipoleFluxNeg_instFlux",
                                    "ip_diffim_DipoleFluxPos_instFluxErr",
                                    "ip_diffim_DipoleFluxNeg_instFluxErr",
-                                   "base_LocalPhotoCalib",
-                                   "base_LocalPhotoCalibErr")
+                                   "base_LocalPhotoCalib")
         val = self._funcVal(func, df)
-        self.assertTrue(np.allclose(val.values,
-                                    absMean,
-                                    atol=1e-13,
-                                    rtol=0))
+        self.assertFloatsAlmostEqual(val.values,
+                                     absMean,
+                                     atol=1e-13,
+                                     rtol=0)
 
         func = LocalDipoleMeanFluxErr("ip_diffim_DipoleFluxPos_instFlux",
                                       "ip_diffim_DipoleFluxNeg_instFlux",
                                       "ip_diffim_DipoleFluxPos_instFluxErr",
                                       "ip_diffim_DipoleFluxNeg_instFluxErr",
-                                      "base_LocalPhotoCalib",
-                                      "base_LocalPhotoCalibErr")
+                                      "base_LocalPhotoCalib")
         val = self._funcVal(func, df)
-        self.assertTrue(np.allclose(val.values,
-                                    absMeanErr,
-                                    atol=1e-13,
-                                    rtol=0))
+        self.assertFloatsAlmostEqual(val.values,
+                                     absMeanErr,
+                                     atol=1e-13,
+                                     rtol=0)
 
         func = LocalDipoleDiffFlux("ip_diffim_DipoleFluxPos_instFlux",
                                    "ip_diffim_DipoleFluxNeg_instFlux",
                                    "ip_diffim_DipoleFluxPos_instFluxErr",
                                    "ip_diffim_DipoleFluxNeg_instFluxErr",
-                                   "base_LocalPhotoCalib",
-                                   "base_LocalPhotoCalibErr")
+                                   "base_LocalPhotoCalib")
         val = self._funcVal(func, df)
-        self.assertTrue(np.allclose(val.values,
-                                    absDiff,
-                                    atol=1e-13,
-                                    rtol=0))
+        self.assertFloatsAlmostEqual(val.values,
+                                     absDiff,
+                                     atol=1e-13,
+                                     rtol=0)
 
         func = LocalDipoleDiffFluxErr("ip_diffim_DipoleFluxPos_instFlux",
                                       "ip_diffim_DipoleFluxNeg_instFlux",
                                       "ip_diffim_DipoleFluxPos_instFluxErr",
                                       "ip_diffim_DipoleFluxNeg_instFluxErr",
-                                      "base_LocalPhotoCalib",
-                                      "base_LocalPhotoCalibErr")
+                                      "base_LocalPhotoCalib")
         val = self._funcVal(func, df)
-        self.assertTrue(np.allclose(val.values,
-                                    absDiffErr,
-                                    atol=1e-13,
-                                    rtol=0))
+        self.assertFloatsAlmostEqual(val.values,
+                                     absDiffErr,
+                                     atol=1e-13,
+                                     rtol=0)
 
     def testComputePositionAngle(self, offset=0.0001):
         """Test computation of position angle from (RA1, Dec1) to (RA2, Dec2)


### PR DESCRIPTION
This also fixes an associativity bug in the dipole mean flux uncertainty calculation that had been masked by the PhotoCalib uncertainty in the test being exactly one.