### PR TITLE
DM-49452-v29: Disable and deprecate propagating PhotoCalib uncertainty in functors.

### DIFF
--- a/schemas/Source.yaml
+++ b/schemas/Source.yaml
@@ -56,14 +56,12 @@ funcs:
             - slot_CalibFlux_instFlux
             - slot_CalibFlux_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     calibFluxErr:
         functor: LocalNanojanskyErr
         args:
             - slot_CalibFlux_instFlux
             - slot_CalibFlux_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
    # Not in DPDD. Used for QA
     ap03Flux:
         functor: LocalNanojansky
@@ -71,14 +69,12 @@ funcs:
             - base_CircularApertureFlux_3_0_instFlux
             - base_CircularApertureFlux_3_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap03FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_3_0_instFlux
             - base_CircularApertureFlux_3_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap03Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_3_0_flag
@@ -89,14 +85,12 @@ funcs:
             - base_CircularApertureFlux_6_0_instFlux
             - base_CircularApertureFlux_6_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap06FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_6_0_instFlux
             - base_CircularApertureFlux_6_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap06Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_6_0_flag
@@ -106,14 +100,12 @@ funcs:
             - base_CircularApertureFlux_9_0_instFlux
             - base_CircularApertureFlux_9_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap09FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_9_0_instFlux
             - base_CircularApertureFlux_9_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap09Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_9_0_flag
@@ -123,14 +115,12 @@ funcs:
             - base_CircularApertureFlux_12_0_instFlux
             - base_CircularApertureFlux_12_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap12FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_12_0_instFlux
             - base_CircularApertureFlux_12_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap12Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_12_0_flag
@@ -140,14 +130,12 @@ funcs:
             - base_CircularApertureFlux_17_0_instFlux
             - base_CircularApertureFlux_17_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap17FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_17_0_instFlux
             - base_CircularApertureFlux_17_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap17Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_17_0_flag
@@ -157,14 +145,12 @@ funcs:
             - base_CircularApertureFlux_25_0_instFlux
             - base_CircularApertureFlux_25_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap25FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_25_0_instFlux
             - base_CircularApertureFlux_25_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap25Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_25_0_flag
@@ -174,14 +160,12 @@ funcs:
             - base_CircularApertureFlux_35_0_instFlux
             - base_CircularApertureFlux_35_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap35FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_35_0_instFlux
             - base_CircularApertureFlux_35_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap35Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_35_0_flag
@@ -191,14 +175,12 @@ funcs:
             - base_CircularApertureFlux_50_0_instFlux
             - base_CircularApertureFlux_50_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap50FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_50_0_instFlux
             - base_CircularApertureFlux_50_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap50Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_50_0_flag
@@ -208,14 +190,12 @@ funcs:
             - base_CircularApertureFlux_70_0_instFlux
             - base_CircularApertureFlux_70_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap70FluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_CircularApertureFlux_70_0_instFlux
             - base_CircularApertureFlux_70_0_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     ap70Flux_flag:
         functor: Column
         args: base_CircularApertureFlux_70_0_flag
@@ -228,28 +208,24 @@ funcs:
             - base_LocalBackground_instFlux
             - base_LocalBackground_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     skyErr:
         functor: LocalNanojanskyErr
         args:
             - base_LocalBackground_instFlux
             - base_LocalBackground_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     psfFlux:
         functor: LocalNanojansky
         args:
             - slot_PsfFlux_instFlux
             - slot_PsfFlux_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     psfFluxErr:
         functor: LocalNanojanskyErr
         args:
             - slot_PsfFlux_instFlux
             - slot_PsfFlux_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
 
     # These PS columns do not make sense anymore as named
     # psX
@@ -309,14 +285,12 @@ funcs:
             - base_GaussianFlux_instFlux
             - base_GaussianFlux_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     gaussianFluxErr:
         functor: LocalNanojanskyErr
         args:
             - base_GaussianFlux_instFlux
             - base_GaussianFlux_instFluxErr
             - base_LocalPhotoCalib
-            - base_LocalPhotoCalibErr
     extendedness:
         functor: Column
         args: base_ClassificationExtendedness_value

--- a/tests/test_functors.py
+++ b/tests/test_functors.py
@@ -51,7 +51,7 @@ from lsst.pipe.tasks.functors import (CompositeFunctor, CustomFunctor, Column, R
 ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
-class FunctorTestCase(unittest.TestCase):
+class FunctorTestCase(lsst.utils.tests.TestCase):
 
     def getMultiIndexDataFrame(self, dataDict):
         """Create a simple test multi-index DataFrame."""
@@ -444,18 +444,16 @@ class FunctorTestCase(unittest.TestCase):
         flux = 1000
         fluxErr = 10
         calib = 10
-        calibErr = 1
+        calibErr = 0.0
         self.dataDict["base_PsfFlux_instFlux"] = np.full(self.nRecords, flux)
         self.dataDict["base_PsfFlux_instFluxErr"] = np.full(self.nRecords,
                                                             fluxErr)
         self.dataDict["base_LocalPhotoCalib"] = np.full(self.nRecords, calib)
-        self.dataDict["base_LocalPhotoCalibErr"] = np.full(self.nRecords,
-                                                           calibErr)
+
         df = self.getMultiIndexDataFrame(self.dataDict)
         func = LocalPhotometry("base_PsfFlux_instFlux",
                                "base_PsfFlux_instFluxErr",
-                               "base_LocalPhotoCalib",
-                               "base_LocalPhotoCalibErr")
+                               "base_LocalPhotoCalib")
 
         nanoJansky = func.instFluxToNanojansky(
             df[("meas", "g", "base_PsfFlux_instFlux")],
@@ -466,13 +464,11 @@ class FunctorTestCase(unittest.TestCase):
         nanoJanskyErr = func.instFluxErrToNanojanskyErr(
             df[("meas", "g", "base_PsfFlux_instFlux")],
             df[("meas", "g", "base_PsfFlux_instFluxErr")],
-            df[("meas", "g", "base_LocalPhotoCalib")],
-            df[("meas", "g", "base_LocalPhotoCalibErr")])
+            df[("meas", "g", "base_LocalPhotoCalib")])
         magErr = func.instFluxErrToMagnitudeErr(
             df[("meas", "g", "base_PsfFlux_instFlux")],
             df[("meas", "g", "base_PsfFlux_instFluxErr")],
-            df[("meas", "g", "base_LocalPhotoCalib")],
-            df[("meas", "g", "base_LocalPhotoCalibErr")])
+            df[("meas", "g", "base_LocalPhotoCalib")])
 
         self.assertTrue(np.allclose(nanoJansky.values,
                                     flux * calib,
@@ -503,8 +499,7 @@ class FunctorTestCase(unittest.TestCase):
     def _testLocalPhotometryFunctors(self, functor, df, testValues):
         func = functor("base_PsfFlux_instFlux",
                        "base_PsfFlux_instFluxErr",
-                       "base_LocalPhotoCalib",
-                       "base_LocalPhotoCalibErr")
+                       "base_LocalPhotoCalib")
         val = self._funcVal(func, df)
         self.assertTrue(np.allclose(testValues.values,
                                     val.values,
@@ -517,7 +512,7 @@ class FunctorTestCase(unittest.TestCase):
         fluxPos = 101
         fluxErr = 10
         calib = 10
-        calibErr = 1
+        calibErr = 0.0
 
         # compute expected values.
         absMean = 0.5*(fluxPos - fluxNeg)*calib
@@ -532,57 +527,51 @@ class FunctorTestCase(unittest.TestCase):
         self.dataDict["ip_diffim_DipoleFluxPos_instFlux"] = np.full(self.nRecords, fluxPos)
         self.dataDict["ip_diffim_DipoleFluxPos_instFluxErr"] = np.full(self.nRecords, fluxErr)
         self.dataDict["base_LocalPhotoCalib"] = np.full(self.nRecords, calib)
-        self.dataDict["base_LocalPhotoCalibErr"] = np.full(self.nRecords,
-                                                           calibErr)
 
         df = self.getMultiIndexDataFrame(self.dataDict)
         func = LocalDipoleMeanFlux("ip_diffim_DipoleFluxPos_instFlux",
                                    "ip_diffim_DipoleFluxNeg_instFlux",
                                    "ip_diffim_DipoleFluxPos_instFluxErr",
                                    "ip_diffim_DipoleFluxNeg_instFluxErr",
-                                   "base_LocalPhotoCalib",
-                                   "base_LocalPhotoCalibErr")
+                                   "base_LocalPhotoCalib")
         val = self._funcVal(func, df)
-        self.assertTrue(np.allclose(val.values,
-                                    absMean,
-                                    atol=1e-13,
-                                    rtol=0))
+        self.assertFloatsAlmostEqual(val.values,
+                                     absMean,
+                                     atol=1e-13,
+                                     rtol=0)
 
         func = LocalDipoleMeanFluxErr("ip_diffim_DipoleFluxPos_instFlux",
                                       "ip_diffim_DipoleFluxNeg_instFlux",
                                       "ip_diffim_DipoleFluxPos_instFluxErr",
                                       "ip_diffim_DipoleFluxNeg_instFluxErr",
-                                      "base_LocalPhotoCalib",
-                                      "base_LocalPhotoCalibErr")
+                                      "base_LocalPhotoCalib")
         val = self._funcVal(func, df)
-        self.assertTrue(np.allclose(val.values,
-                                    absMeanErr,
-                                    atol=1e-13,
-                                    rtol=0))
+        self.assertFloatsAlmostEqual(val.values,
+                                     absMeanErr,
+                                     atol=1e-13,
+                                     rtol=0)
 
         func = LocalDipoleDiffFlux("ip_diffim_DipoleFluxPos_instFlux",
                                    "ip_diffim_DipoleFluxNeg_instFlux",
                                    "ip_diffim_DipoleFluxPos_instFluxErr",
                                    "ip_diffim_DipoleFluxNeg_instFluxErr",
-                                   "base_LocalPhotoCalib",
-                                   "base_LocalPhotoCalibErr")
+                                   "base_LocalPhotoCalib")
         val = self._funcVal(func, df)
-        self.assertTrue(np.allclose(val.values,
-                                    absDiff,
-                                    atol=1e-13,
-                                    rtol=0))
+        self.assertFloatsAlmostEqual(val.values,
+                                     absDiff,
+                                     atol=1e-13,
+                                     rtol=0)
 
         func = LocalDipoleDiffFluxErr("ip_diffim_DipoleFluxPos_instFlux",
                                       "ip_diffim_DipoleFluxNeg_instFlux",
                                       "ip_diffim_DipoleFluxPos_instFluxErr",
                                       "ip_diffim_DipoleFluxNeg_instFluxErr",
-                                      "base_LocalPhotoCalib",
-                                      "base_LocalPhotoCalibErr")
+                                      "base_LocalPhotoCalib")
         val = self._funcVal(func, df)
-        self.assertTrue(np.allclose(val.values,
-                                    absDiffErr,
-                                    atol=1e-13,
-                                    rtol=0))
+        self.assertFloatsAlmostEqual(val.values,
+                                     absDiffErr,
+                                     atol=1e-13,
+                                     rtol=0)
 
     def testComputePositionAngle(self, offset=0.0001):
         """Test computation of position angle from (RA1, Dec1) to (RA2, Dec2)


### PR DESCRIPTION
This also fixes an associativity bug in the dipole mean flux uncertainty calculation that had been masked by the PhotoCalib uncertainty in the test being exactly one.