### PR TITLE
DM-49727: Add ComputeObjectEpochsTask

### DIFF
--- a/python/lsst/pipe/tasks/functors.py
+++ b/python/lsst/pipe/tasks/functors.py
@@ -755,8 +755,11 @@ class MultibandColumn(Column):
     def band_to_check(self):
         return self._band_to_check
 
+
+class MultibandSinglePrecisionFloatColumn(MultibandColumn):
+    """A float32 MultibandColumn"""
     def _func(self, df):
-        return df[self.col].astype(np.float32)
+        return super()._func(df).astype(np.float32)
 
 
 class SinglePrecisionFloatColumn(Column):

--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -1122,7 +1122,18 @@ class TransformObjectCatalogTask(TransformCatalogBaseTask):
             handle_multiband = handles_multi[dataset]
             df_dataset = handle_multiband.get()
             if isinstance(df_dataset, astropy.table.Table):
-                df_dataset = df_dataset.to_pandas().set_index(name_index, drop=False)
+                # Allow astropy table inputs to already have the output index
+                if name_index not in df_dataset.colnames:
+                    if self.config.primaryKey in df_dataset.colnames:
+                        name_index_ap = self.config.primaryKey
+                    else:
+                        raise RuntimeError(
+                            f"Neither of {name_index=} nor {self.config.primaryKey=} appear in"
+                            f" {df_dataset.colnames=} for {dataset=}"
+                        )
+                else:
+                    name_index_ap = name_index
+                df_dataset = df_dataset.to_pandas().set_index(name_index_ap, drop=False)
             elif isinstance(df_dataset, afwTable.SourceCatalog):
                 df_dataset = df_dataset.asAstropy().to_pandas().set_index(name_index, drop=False)
             # TODO: should funcDict have noDup funcs removed?

--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -912,6 +912,13 @@ class TransformObjectCatalogConnections(pipeBase.PipelineTaskConnections,
         name="{coaddName}Coadd_Sersic_multiprofit",
         deferLoad=True,
     )
+    inputCatalogEpoch = connectionTypes.Input(
+        doc="Catalog of mean epochs for each object per band.",
+        dimensions=("tract", "patch", "skymap"),
+        storageClass="ArrowAstropy",
+        name="object_epoch",
+        deferLoad=True,
+    )
     outputCatalog = connectionTypes.Output(
         doc="Per-Patch Object Table of columns transformed from the deepCoadd_obj table per the standard "
             "data model.",
@@ -999,7 +1006,7 @@ class TransformObjectCatalogTask(TransformCatalogBaseTask):
     _DefaultName = "transformObjectCatalog"
     ConfigClass = TransformObjectCatalogConfig
 
-    datasets_multiband = ("ref", "Sersic_multiprofit")
+    datasets_multiband = ("epoch", "ref", "Sersic_multiprofit")
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         inputs = butlerQC.get(inputRefs)
@@ -1008,6 +1015,7 @@ class TransformObjectCatalogTask(TransformCatalogBaseTask):
                              "Must be a valid path to yaml in order to run Task as a PipelineTask.")
         result = self.run(handle=inputs["inputCatalog"], funcs=self.funcs,
                           dataId=dict(outputRefs.outputCatalog.dataId.mapping),
+                          handle_epoch=inputs["inputCatalogEpoch"],
                           handle_ref=inputs["inputCatalogRef"],
                           handle_Sersic_multiprofit=inputs["inputCatalogSersicMultiprofit"],
                           )

--- a/schemas/Object.yaml
+++ b/schemas/Object.yaml
@@ -876,6 +876,42 @@ funcs:
         functor: SinglePrecisionFloatColumn
         args: slot_Shape_xy
         dataset: ref
+    g_epoch:
+        functor: MultibandColumn
+        args:
+            - g_epoch
+            - g
+        dataset: epoch
+    i_epoch:
+        functor: MultibandColumn
+        args:
+            - i_epoch
+            - i
+        dataset: epoch
+    r_epoch:
+        functor: MultibandColumn
+        args:
+            - r_epoch
+            - r
+        dataset: epoch
+    u_epoch:
+        functor: MultibandColumn
+        args:
+            - u_epoch
+            - u
+        dataset: epoch
+    y_epoch:
+        functor: MultibandColumn
+        args:
+            - y_epoch
+            - y
+        dataset: epoch
+    z_epoch:
+        functor: MultibandColumn
+        args:
+            - z_epoch
+            - z
+        dataset: epoch
     # DM-22247: Add Star/Galaxy sep columns
     #     - Morphological Star Galaxy Classifier (Names? float 0-1)]
     #     - Morphological + Color (SED-based) Star Galaxy Classifier (Names? float 0-1)]

--- a/schemas/Object.yaml
+++ b/schemas/Object.yaml
@@ -737,37 +737,37 @@ funcs:
         args: rho
         dataset: Sersic_multiprofit
     g_sersicFlux:
-        functor: MultibandColumn
+        functor: MultibandSinglePrecisionFloatColumn
         args:
             - g_Flux
             - g
         dataset: Sersic_multiprofit
     i_sersicFlux:
-        functor: MultibandColumn
+        functor: MultibandSinglePrecisionFloatColumn
         args:
             - i_Flux
             - i
         dataset: Sersic_multiprofit
     r_sersicFlux:
-        functor: MultibandColumn
+        functor: MultibandSinglePrecisionFloatColumn
         args:
             - r_Flux
             - r
         dataset: Sersic_multiprofit
     u_sersicFlux:
-        functor: MultibandColumn
+        functor: MultibandSinglePrecisionFloatColumn
         args:
             - u_Flux
             - u
         dataset: Sersic_multiprofit
     y_sersicFlux:
-        functor: MultibandColumn
+        functor: MultibandSinglePrecisionFloatColumn
         args:
             - y_Flux
             - y
         dataset: Sersic_multiprofit
     z_sersicFlux:
-        functor: MultibandColumn
+        functor: MultibandSinglePrecisionFloatColumn
         args:
             - z_Flux
             - z
@@ -805,37 +805,37 @@ funcs:
         args: rhoErr
         dataset: Sersic_multiprofit
     g_sersicFluxErr:
-        functor: MultibandColumn
+        functor: MultibandSinglePrecisionFloatColumn
         args:
             - g_FluxErr
             - g
         dataset: Sersic_multiprofit
     i_sersicFluxErr:
-        functor: MultibandColumn
+        functor: MultibandSinglePrecisionFloatColumn
         args:
             - i_FluxErr
             - i
         dataset: Sersic_multiprofit
     r_sersicFluxErr:
-        functor: MultibandColumn
+        functor: MultibandSinglePrecisionFloatColumn
         args:
             - r_FluxErr
             - r
         dataset: Sersic_multiprofit
     u_sersicFluxErr:
-        functor: MultibandColumn
+        functor: MultibandSinglePrecisionFloatColumn
         args:
             - u_FluxErr
             - u
         dataset: Sersic_multiprofit
     y_sersicFluxErr:
-        functor: MultibandColumn
+        functor: MultibandSinglePrecisionFloatColumn
         args:
             - y_FluxErr
             - y
         dataset: Sersic_multiprofit
     z_sersicFluxErr:
-        functor: MultibandColumn
+        functor: MultibandSinglePrecisionFloatColumn
         args:
             - z_FluxErr
             - z

--- a/tests/test_transformObject.py
+++ b/tests/test_transformObject.py
@@ -47,9 +47,13 @@ class TransformObjectCatalogTestCase(unittest.TestCase):
         self.dataId = {"tract": 9615, "patch": "4,4"}
         self.handle = InMemoryDatasetHandle(df, storageClass="DataFrame", dataId=self.dataId)
         n_rows = len(df)
+        tab_epoch = astropy.table.Table({df.index.name: df.index, "r_epoch": [0.]*n_rows})
         tab_ref = astropy.table.Table({df.index.name: df.index, "refBand": ["r"]*n_rows})
         tab_sersic = astropy.table.Table({df.index.name: df.index, "sersic_n_iter": [0] * n_rows})
         self.kwargs_task = {
+            "handle_epoch": InMemoryDatasetHandle(
+                tab_epoch, storageClass="ArrowAstropy", dataId=self.dataId,
+            ),
             "handle_ref": InMemoryDatasetHandle(
                 tab_ref, storageClass="ArrowAstropy", dataId=self.dataId,
             ),
@@ -58,6 +62,7 @@ class TransformObjectCatalogTestCase(unittest.TestCase):
             ),
         }
         self.funcs_multi = {
+            "epoch": Column("r_epoch", dataset="epoch"),
             "refBand": Column("refBand", dataset="ref"),
             "sersic_n_iter": Column("sersic_n_iter", dataset="Sersic_multiprofit"),
         }


### PR DESCRIPTION
This is a minimally altered version of ObjectEpochTableTask from analysis_tools (which I intend to deprecate shortly) but using `deepCoadd_obj` as an input instead of `objectTable`, so that it can more easily be merged into `objectTable`.