### PR TITLE
DM-40348: Stop propogating Detector through ConsolidateVisitSummaryTask (again).

### DIFF
--- a/python/lsst/pipe/tasks/postprocess.py
+++ b/python/lsst/pipe/tasks/postprocess.py
@@ -1312,7 +1312,6 @@ class ConsolidateVisitSummaryTask(pipeBase.PipelineTask):
     - The wcs.
     - The photoCalib.
     - The physical_filter and band (if available).
-    - The detector.
     - The PSF model.
     - The aperture correction map.
     - The transmission curve.
@@ -1384,7 +1383,6 @@ class ConsolidateVisitSummaryTask(pipeBase.PipelineTask):
             rec.setValidPolygon(validPolygon)
 
             if self.config.full:
-                rec.setDetector(dataRef.get(component="detector"))
                 rec.setPsf(dataRef.get(component="psf"))
                 rec.setApCorrMap(dataRef.get(component="apCorrMap"))
                 rec.setTransmissionCurve(dataRef.get(component="transmissionCurve"))


### PR DESCRIPTION
The Detector is very heavyweight when read from an Exposure, because each Detector ends up with its own copy of some camera-wide state (which is shared when a Camera is constructed directly).  And it turns out we don't use the Detector downstream, and don't attach one in UpdateVisitSummaryTask, either.