### PR TITLE
DM-50695: Raise MatcherError if no reference sources have finite flux

### DIFF
--- a/python/lsst/pipe/tasks/photoCal.py
+++ b/python/lsst/pipe/tasks/photoCal.py
@@ -314,6 +314,10 @@ class PhotoCalTask(pipeBase.Task):
         srcMagErrArr = abMagErrFromFluxErr(srcInstFluxErrArr*1e-9, srcInstFluxArr*1e-9)
 
         good = np.isfinite(srcMagArr) & np.isfinite(refMagArr)
+        if not np.any(good):
+            raise MatcherFailure("No matched reference stars with valid fluxes",
+                                 goodSrc=int(np.sum(np.isfinite(srcMagArr))),
+                                 goodRef=int(np.sum(np.isfinite(refMagArr))))
 
         return pipeBase.Struct(
             srcMag=srcMagArr[good],


### PR DESCRIPTION
The resulting error looks like:
```
lsst.meas.astrom.exceptions.MatcherFailure: No matched reference stars with valid fluxes: {'goodSrc': 369, 'goodRef': 0}
```