### PR TITLE
DM-51429: Modify skyCorr bgModel2 minFrac to 0.3

### DIFF
--- a/python/lsst/pipe/tasks/skyCorrection.py
+++ b/python/lsst/pipe/tasks/skyCorrection.py
@@ -232,7 +232,7 @@ class SkyCorrectionConfig(PipelineTaskConfig, pipelineConnections=SkyCorrectionC
     def setDefaults(self):
         Config.setDefaults(self)
         self.bgModel2.doSmooth = True
-        self.bgModel2.minFrac = 0.5
+        self.bgModel2.minFrac = 0.3
         self.bgModel2.xSize = 256
         self.bgModel2.ySize = 256
         self.bgModel2.smoothScale = 1.0


### PR DESCRIPTION
The existing legacy HSC config value of bgModel2.minFrac=0.5 served to exclude fields whereby a large fraction of data was lost due to, e.g., bright stars. For Rubin, we hit this threshold more often due to crowded fields (see postage stamp links on DM-51429 as evidence). To that end, here we reduce the bgModel2.minFrac config to 0.3. The background task default (used for bgModel1) is 0.1. Therefore, 0.3 is still somewhat conservative, helping to guard against low-number statistics in very crowded fields. However, testing shows that reducing this value to 0.3 appears to work without any adverse results.