### PR TITLE
DM-54843: Add fixed G12 option and error floor to HG12 photometric fitting

### DIFF
--- a/python/lsst/pipe/tasks/consolidateSsTables.py
+++ b/python/lsst/pipe/tasks/consolidateSsTables.py
@@ -80,6 +80,13 @@ class ConsolidateSsTablesConfig(
             "If None (default), both H and G12 are fit.",
     )
 
+    magSigmaFloor = pexConfig.Field(
+        dtype=float,
+        default=0.01,
+        doc="Systematic magnitude error floor (mag) added in quadrature "
+            "to measurement errors before HG12 fitting.",
+    )
+
 
 class ConsolidateSsTablesTask(pipeBase.PipelineTask):
     """Consolidate per-patch ssSource tables into a single table.
@@ -184,11 +191,16 @@ class ConsolidateSsTablesTask(pipeBase.PipelineTask):
                 del ssSourceTable[src]
 
         # build the SSObject table
+        self.log.info(
+            "HG12 fit config: fixedG12=%s, magSigmaFloor=%s",
+            self.config.fixedG12, self.config.magSigmaFloor,
+        )
         ssSourceTable.sort("ssObjectId")
         mpcorb = mpcorb.to_pandas() if isinstance(mpcorb, tb.Table) else mpcorb
         ssObjectTable = compute_ssobject(
             ssSourceTable.to_pandas(), diaSource.to_pandas(), mpcorb,
             fixedG12=self.config.fixedG12,
+            magSigmaFloor=self.config.magSigmaFloor,
         )
         ssObjectTable = tb.Table(ssObjectTable)
 

--- a/python/lsst/pipe/tasks/consolidateSsTables.py
+++ b/python/lsst/pipe/tasks/consolidateSsTables.py
@@ -26,6 +26,7 @@ import astropy.units as u
 import numpy as np
 import warnings
 
+import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 import lsst.pipe.base.connectionTypes as cT
 from lsst.utils.timer import timeMethod
@@ -70,6 +71,14 @@ class ConsolidateSsTablesConfig(
     pipeBase.PipelineTaskConfig, pipelineConnections=ConsolidateSsTablesConnections
 ):
     """Config for ConsolidateSsTablesTask"""
+
+    fixedG12 = pexConfig.Field(
+        dtype=float,
+        default=None,
+        optional=True,
+        doc="If set, fix the G12 slope parameter to this value and only fit H. "
+            "If None (default), both H and G12 are fit.",
+    )
 
 
 class ConsolidateSsTablesTask(pipeBase.PipelineTask):
@@ -178,7 +187,8 @@ class ConsolidateSsTablesTask(pipeBase.PipelineTask):
         ssSourceTable.sort("ssObjectId")
         mpcorb = mpcorb.to_pandas() if isinstance(mpcorb, tb.Table) else mpcorb
         ssObjectTable = compute_ssobject(
-            ssSourceTable.to_pandas(), diaSource.to_pandas(), mpcorb
+            ssSourceTable.to_pandas(), diaSource.to_pandas(), mpcorb,
+            fixedG12=self.config.fixedG12,
         )
         ssObjectTable = tb.Table(ssObjectTable)
 

--- a/python/lsst/pipe/tasks/consolidateSsTables.py
+++ b/python/lsst/pipe/tasks/consolidateSsTables.py
@@ -82,7 +82,7 @@ class ConsolidateSsTablesConfig(
 
     magSigmaFloor = pexConfig.Field(
         dtype=float,
-        default=0.01,
+        default=0.0,
         doc="Systematic magnitude error floor (mag) added in quadrature "
             "to measurement errors before HG12 fitting.",
     )

--- a/python/lsst/pipe/tasks/consolidateSsTables.py
+++ b/python/lsst/pipe/tasks/consolidateSsTables.py
@@ -87,6 +87,14 @@ class ConsolidateSsTablesConfig(
             "to measurement errors before HG12 fitting.",
     )
 
+    nSigmaClipHG12Fit = pexConfig.Field(
+        dtype=float,
+        default=None,
+        optional=True,
+        doc="If set, reject outliers beyond this many sigma after "
+            "an initial robust fit. If None, no clipping.",
+    )
+
 
 class ConsolidateSsTablesTask(pipeBase.PipelineTask):
     """Consolidate per-patch ssSource tables into a single table.
@@ -192,8 +200,10 @@ class ConsolidateSsTablesTask(pipeBase.PipelineTask):
 
         # build the SSObject table
         self.log.info(
-            "HG12 fit config: fixedG12=%s, magSigmaFloor=%s",
+            "HG12 fit config: fixedG12=%s, magSigmaFloor=%s, "
+            "nSigmaClipHG12Fit=%s",
             self.config.fixedG12, self.config.magSigmaFloor,
+            self.config.nSigmaClipHG12Fit,
         )
         ssSourceTable.sort("ssObjectId")
         mpcorb = mpcorb.to_pandas() if isinstance(mpcorb, tb.Table) else mpcorb
@@ -201,6 +211,7 @@ class ConsolidateSsTablesTask(pipeBase.PipelineTask):
             ssSourceTable.to_pandas(), diaSource.to_pandas(), mpcorb,
             fixedG12=self.config.fixedG12,
             magSigmaFloor=self.config.magSigmaFloor,
+            nSigmaClip=self.config.nSigmaClipHG12Fit,
         )
         ssObjectTable = tb.Table(ssObjectTable)
 

--- a/python/lsst/pipe/tasks/consolidateSsTables.py
+++ b/python/lsst/pipe/tasks/consolidateSsTables.py
@@ -72,27 +72,29 @@ class ConsolidateSsTablesConfig(
 ):
     """Config for ConsolidateSsTablesTask"""
 
-    fixedG12 = pexConfig.Field(
+    hg12FixedG12 = pexConfig.Field(
         dtype=float,
         default=None,
         optional=True,
-        doc="If set, fix the G12 slope parameter to this value and only fit H. "
-            "If None (default), both H and G12 are fit.",
+        doc="If set, fix the G12 slope parameter to this value "
+            "and only fit H. If None (default), both H and G12 "
+            "are fit.",
     )
 
-    magSigmaFloor = pexConfig.Field(
+    hg12MagSigmaFloor = pexConfig.Field(
         dtype=float,
         default=0.0,
-        doc="Systematic magnitude error floor (mag) added in quadrature "
-            "to measurement errors before HG12 fitting.",
+        doc="Systematic magnitude error floor (mag) added in "
+            "quadrature to measurement errors before HG12 "
+            "fitting.",
     )
 
-    nSigmaClipHG12Fit = pexConfig.Field(
+    hg12NSigmaClip = pexConfig.Field(
         dtype=float,
         default=None,
         optional=True,
-        doc="If set, reject outliers beyond this many sigma after "
-            "an initial robust fit. If None, no clipping.",
+        doc="If set, reject outliers beyond this many sigma "
+            "after an initial robust fit. If None, no clipping.",
     )
 
 
@@ -200,18 +202,19 @@ class ConsolidateSsTablesTask(pipeBase.PipelineTask):
 
         # build the SSObject table
         self.log.info(
-            "HG12 fit config: fixedG12=%s, magSigmaFloor=%s, "
-            "nSigmaClipHG12Fit=%s",
-            self.config.fixedG12, self.config.magSigmaFloor,
-            self.config.nSigmaClipHG12Fit,
+            "HG12 fit config: hg12FixedG12=%s, "
+            "hg12MagSigmaFloor=%s, hg12NSigmaClip=%s",
+            self.config.hg12FixedG12,
+            self.config.hg12MagSigmaFloor,
+            self.config.hg12NSigmaClip,
         )
         ssSourceTable.sort("ssObjectId")
         mpcorb = mpcorb.to_pandas() if isinstance(mpcorb, tb.Table) else mpcorb
         ssObjectTable = compute_ssobject(
             ssSourceTable.to_pandas(), diaSource.to_pandas(), mpcorb,
-            fixedG12=self.config.fixedG12,
-            magSigmaFloor=self.config.magSigmaFloor,
-            nSigmaClip=self.config.nSigmaClipHG12Fit,
+            fixedG12=self.config.hg12FixedG12,
+            magSigmaFloor=self.config.hg12MagSigmaFloor,
+            nSigmaClip=self.config.hg12NSigmaClip,
         )
         ssObjectTable = tb.Table(ssObjectTable)
 

--- a/python/lsst/pipe/tasks/ssp/moid.py
+++ b/python/lsst/pipe/tasks/ssp/moid.py
@@ -25,87 +25,88 @@ MOIDResult = namedtuple(
 )
 
 
-def earth_orbit_J2000():
-    """
-    Return canonical heliocentric Keplerian orbital elements for the Earth,
-    suitable for MOID computations, in the J2000 mean ecliptic and equinox
-    reference frame.
+def earth_orbit(epoch_mjd=51544.5):
+    """Return Earth’s heliocentric Keplerian elements at a given epoch.
 
-    The elements describe a *fixed Keplerian ellipse* that approximates the
-    Earth's mean orbit at epoch J2000. This is the standard convention used
-    in MOID literature and software (e.g., Milani & Gronchi, NEODyS, JPL)
-    when computing the MOID between small bodies and the Earth.
+    Evaluates a linear secular model for Earth’s orbital elements
+    in the J2000 ecliptic and equinox frame. The model coefficients
+    are from JPL’s "Keplerian Elements for Approximate Positions of
+    the Major Planets" (Standish 1992, Table 1), valid for
+    3000 BC -- 3000 AD.
+
+    Parameters
+    ----------
+    epoch_mjd : float, optional
+        Epoch as Modified Julian Date. Default is 51544.5
+        (J2000.0 = 2000 Jan 1.5 TDB).
 
     Returns
     -------
     EarthElements
         A namedtuple with fields:
 
-        - a_AU : float
-            Semi-major axis in astronomical units (AU).
-            Canonical value: 1.00000011 AU
-
-        - e : float
-            Eccentricity (dimensionless).
-            Canonical value: 0.01671022
-
-        - inc_deg : float
-            Inclination to the ecliptic in degrees.
-            Canonical value: 0.00005 deg
-
-            Note: by definition the ecliptic plane is the Earth's mean orbital
-            plane, so the true inclination is ~0. A very small non-zero value
-            is used in practice to avoid singularities in rotation matrices
-            and angle definitions.
-
-        - Omega_deg : float
-            Longitude of the ascending node in degrees, measured in the
-            ecliptic plane from the J2000 vernal equinox.
-            Canonical value: -11.26064 deg  (equivalent to 348.73936 deg)
-
-        - omega_deg : float
-            Argument of perihelion in degrees, measured from the ascending
-            node along the Earth's orbital plane.
-            Canonical value: 102.94719 deg
+        ``a_AU``
+            Semi-major axis in AU.
+        ``e``
+            Eccentricity.
+        ``inc_deg``
+            Inclination to the ecliptic in degrees. Set to a small
+            nonzero value (0.00005°) to avoid singularities in
+            rotation matrices; the true value is ~0 by definition
+            since the ecliptic *is* Earth’s mean orbital plane.
+        ``Omega_deg``
+            Longitude of the ascending node in degrees. Zero by
+            definition in the ecliptic frame.
+        ``omega_deg``
+            Argument of perihelion in degrees. Since Omega = 0 in
+            the ecliptic frame, this equals the longitude of
+            perihelion (ϖ).
 
     Notes
     -----
-    * These values are the widely used J2000 "mean elements" of the Earth’s
-      heliocentric orbit, compatible with VSOP87-style low-order models and
-      with the orbital elements quoted in many celestial mechanics references.
+    The linear model for each element is::
 
-    * They are intended for *geometric* computations such as MOID, where one
-      wants a fixed Keplerian ellipse representing the Earth's orbit, rather
-      than the true, time-varying perturbed Earth orbit.
+        element(T) = element_0 + element_dot * T
 
-    * If you are using the MOIDSolver defined above, you can plug this
-      directly into the solver as the Earth orbit, e.g.:
+    where T is Julian centuries from J2000.0. The coefficients are:
 
-          earth = earth_orbit_J2000()
-          result = solver.compute(asteroid_elements, earth)
+    ======  ===============  =================
+    Param   Value at J2000   Rate (per century)
+    ======  ===============  =================
+    a       1.00000261 AU    +0.00000562 AU
+    e       0.01671123       -0.00004392
+    ϖ       102.93768193°    +0.32327364°
+    ======  ===============  =================
 
-      or reverse the order depending on which way you want to label the
-      "orbit 1" quantities.
+    Inclination and Omega are fixed at ~0 (ecliptic frame).
 
-    * The epoch associated with these elements is J2000.0; MOID is a purely
-      geometric quantity, so there is no mean anomaly / phase dependence.
+    MOID is a purely geometric quantity (no mean anomaly / phase
+    dependence), but the *shape and orientation* of Earth’s orbit
+    do evolve slowly. Evaluating at the asteroid’s osculating
+    element epoch ensures the two orbits are compared at a
+    consistent time.
 
     References
     ----------
-    These values (or very close variants) are quoted in many sources, e.g.:
-
-      - Explanatory Supplement to the Astronomical Almanac
-      - VSOP87/IAU-style mean orbital element lists for planets
-      - Milani, A., & Gronchi, G. F., "Theory of Orbit Determination"
-      - Online resources summarizing J2000 planetary elements
+    Standish, E.M. (1992). "Keplerian Elements for Approximate
+    Positions of the Major Planets." Solar System Dynamics Group,
+    JPL. https://ssd.jpl.nasa.gov/planets/approx_pos.html
     """
+    T = (epoch_mjd - 51544.5) / 36525.0  # Julian centuries from J2000
     return EarthElements(
-        a_AU=1.00000011,
-        e=0.01671022,
+        a_AU=1.00000261 + 0.00000562 * T,
+        e=0.01671123 - 0.00004392 * T,
         inc_deg=0.00005,
-        Omega_deg=-11.26064,
-        omega_deg=102.94719,
+        Omega_deg=0.0,
+        omega_deg=102.93768193 + 0.32327364 * T,
     )
+
+
+def earth_orbit_J2000():
+    """Return Earth’s elements at J2000.0. Deprecated; use
+    `earth_orbit(epoch_mjd)` instead.
+    """
+    return earth_orbit(51544.5)
 
 
 class MOIDSolver:

--- a/python/lsst/pipe/tasks/ssp/photfit.py
+++ b/python/lsst/pipe/tasks/ssp/photfit.py
@@ -111,6 +111,9 @@ def fitHG12(mag, magSigma, phaseAngle, tdist, rdist, fixedG12=None, magSigmaFloo
     # This uses the HG12 function from Muinonen et al (2010)
     nobsv = len(mag)
 
+    if nobsv == 0:
+        return (np.nan,) * 6 + (0,)
+
     # ensure these are plain ndarrays
     (mag, magSigma, phaseAngle, tdist, rdist) = map(np.asarray, (mag, magSigma, phaseAngle, tdist, rdist))
 

--- a/python/lsst/pipe/tasks/ssp/photfit.py
+++ b/python/lsst/pipe/tasks/ssp/photfit.py
@@ -107,12 +107,16 @@ def fit(mag, phase, sigma, model=HG12_model, params=[0.1]):
     return sol
 
 
-def fitHG12(mag, magSigma, phaseAngle, tdist, rdist, fixedG12=None):
+def fitHG12(mag, magSigma, phaseAngle, tdist, rdist, fixedG12=None, magSigmaFloor=0.0):
     # This uses the HG12 function from Muinonen et al (2010)
     nobsv = len(mag)
 
     # ensure these are plain ndarrays
     (mag, magSigma, phaseAngle, tdist, rdist) = map(np.asarray, (mag, magSigma, phaseAngle, tdist, rdist))
+
+    # add systematic error floor in quadrature
+    if magSigmaFloor > 0:
+        magSigma = np.sqrt(magSigma**2 + magSigmaFloor**2)
 
     # correct the mag to 1AU distance
     dmag = -5.0 * np.log10(tdist * rdist)

--- a/python/lsst/pipe/tasks/ssp/photfit.py
+++ b/python/lsst/pipe/tasks/ssp/photfit.py
@@ -1,7 +1,13 @@
 import numpy as np
+from collections import namedtuple
 from scipy.interpolate import CubicSpline
 from scipy.optimize import leastsq
 import warnings
+
+HG12FitResult = namedtuple(
+    "HG12FitResult",
+    ["H", "G12", "H_err", "G12_err", "HG_cov", "chi2dof", "nobs"],
+)
 
 # Constants
 
@@ -108,11 +114,57 @@ def fit(mag, phase, sigma, model=HG12_model, params=[0.1]):
 
 
 def fitHG12(mag, magSigma, phaseAngle, tdist, rdist, fixedG12=None, magSigmaFloor=0.0):
-    # This uses the HG12 function from Muinonen et al (2010)
+    """Fit the HG12 phase curve model (Muinonen et al. 2010).
+
+    Fits absolute magnitude H (and optionally the slope parameter
+    G12) to apparent magnitude observations at known phase angles
+    and distances.
+
+    Parameters
+    ----------
+    mag : array_like
+        Apparent magnitudes.
+    magSigma : array_like
+        Magnitude uncertainties (1-sigma).
+    phaseAngle : array_like
+        Phase angles in degrees.
+    tdist : array_like
+        Topocentric (observer-target) distances in AU.
+    rdist : array_like
+        Heliocentric (sun-target) distances in AU.
+    fixedG12 : float or None, optional
+        If set, fix G12 to this value and only fit H.
+        If None (default), both H and G12 are fit.
+    magSigmaFloor : float, optional
+        Systematic error floor (mag) added in quadrature to
+        ``magSigma`` before fitting. Default is 0.0.
+
+    Returns
+    -------
+    result : `HG12FitResult`
+        Named tuple with fields:
+
+        ``H``
+            Best-fit absolute magnitude.
+        ``G12``
+            Best-fit (or fixed) slope parameter.
+        ``H_err``
+            Uncertainty on H from the covariance matrix.
+        ``G12_err``
+            Uncertainty on G12 (NaN if ``fixedG12`` is set).
+        ``HG_cov``
+            H-G12 covariance (NaN if ``fixedG12`` is set).
+        ``chi2dof``
+            Reduced chi-squared of the fit.
+        ``nobs``
+            Number of observations used.
+
+        On failure, all float fields are NaN and ``nobs`` is 0.
+    """
     nobsv = len(mag)
 
     if nobsv == 0:
-        return (np.nan,) * 6 + (0,)
+        return HG12FitResult(*(np.nan,) * 6, nobs=0)
 
     # ensure these are plain ndarrays
     (mag, magSigma, phaseAngle, tdist, rdist) = map(np.asarray, (mag, magSigma, phaseAngle, tdist, rdist))
@@ -155,10 +207,14 @@ def fitHG12(mag, magSigma, phaseAngle, tdist, rdist, fixedG12=None, magSigmaFloo
                 G_err = np.sqrt(sol[1][1, 1])
                 HG_cov = sol[1][0, 1]
 
-            return H, G, H_err, G_err, HG_cov, chi2 / (nobsv - nparams), nobsv
+            return HG12FitResult(
+                H=H, G12=G, H_err=H_err, G12_err=G_err,
+                HG_cov=HG_cov, chi2dof=chi2 / (nobsv - nparams),
+                nobs=nobsv,
+            )
         else:
             # fit failed
-            return (np.nan,) * 6 + (0,)
+            return HG12FitResult(*(np.nan,) * 6, nobs=0)
 
 
 ####################

--- a/python/lsst/pipe/tasks/ssp/photfit.py
+++ b/python/lsst/pipe/tasks/ssp/photfit.py
@@ -1,7 +1,7 @@
 import numpy as np
 from collections import namedtuple
 from scipy.interpolate import CubicSpline
-from scipy.optimize import leastsq
+from scipy.optimize import leastsq, least_squares
 import warnings
 
 HG12FitResult = namedtuple(
@@ -113,7 +113,10 @@ def fit(mag, phase, sigma, model=HG12_model, params=[0.1]):
     return sol
 
 
-def fitHG12(mag, magSigma, phaseAngle, tdist, rdist, fixedG12=None, magSigmaFloor=0.0):
+def fitHG12(
+    mag, magSigma, phaseAngle, tdist, rdist,
+    fixedG12=None, magSigmaFloor=0.0, nSigmaClip=None,
+):
     """Fit the HG12 phase curve model (Muinonen et al. 2010).
 
     Fits absolute magnitude H (and optionally the slope parameter
@@ -138,6 +141,11 @@ def fitHG12(mag, magSigma, phaseAngle, tdist, rdist, fixedG12=None, magSigmaFloo
     magSigmaFloor : float, optional
         Systematic error floor (mag) added in quadrature to
         ``magSigma`` before fitting. Default is 0.0.
+    nSigmaClip : float or None, optional
+        If set, perform outlier rejection: an initial robust fit
+        (soft_l1 loss) followed by sigma clipping at this
+        threshold, then a final linear least-squares refit on the
+        clipped data. If None (default), no clipping is performed.
 
     Returns
     -------
@@ -157,7 +165,7 @@ def fitHG12(mag, magSigma, phaseAngle, tdist, rdist, fixedG12=None, magSigmaFloo
         ``chi2dof``
             Reduced chi-squared of the fit.
         ``nobs``
-            Number of observations used.
+            Number of observations used (after clipping).
 
         On failure, all float fields are NaN and ``nobs`` is 0.
     """
@@ -167,14 +175,19 @@ def fitHG12(mag, magSigma, phaseAngle, tdist, rdist, fixedG12=None, magSigmaFloo
         return HG12FitResult(*(np.nan,) * 6, nobs=0)
 
     # ensure these are plain ndarrays
-    (mag, magSigma, phaseAngle, tdist, rdist) = map(np.asarray, (mag, magSigma, phaseAngle, tdist, rdist))
+    (mag, magSigma, phaseAngle, tdist, rdist) = map(
+        np.asarray, (mag, magSigma, phaseAngle, tdist, rdist)
+    )
 
     # add systematic error floor in quadrature
     if magSigmaFloor > 0:
         magSigma = np.sqrt(magSigma**2 + magSigmaFloor**2)
 
     # filter to finite magnitudes and positive errors
-    good = np.isfinite(mag) & np.isfinite(magSigma) & (magSigma > 0)
+    good = (
+        np.isfinite(mag) & np.isfinite(magSigma)
+        & (magSigma > 0)
+    )
     mag = mag[good]
     magSigma = magSigma[good]
     phaseAngle = phaseAngle[good]
@@ -194,39 +207,83 @@ def fitHG12(mag, magSigma, phaseAngle, tdist, rdist, fixedG12=None, magSigmaFloo
             return HG12_model(phase, [params[0], fixedG12])
 
         nparams = 1
-        fit_params = []
     else:
         model = HG12_model
         nparams = 2
-        fit_params = [0.1]
+
+    phase_rad = np.deg2rad(phaseAngle)
+    x0 = np.array(
+        [mag[0]] + ([] if fixedG12 is not None else [0.1])
+    )
+
+    def residuals(params):
+        return (mag - model(phase_rad, params)) / magSigma
 
     # fit, suppressing warnings
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
-        sol = fit(mag, phaseAngle, magSigma, model=model, params=fit_params)
-        if sol[-1] in [1, 2, 3] and sol[1] is not None:  # least squares solver flags
-            chi2 = np.sum(sol[2]["fvec"] ** 2)
-            H = sol[0][0]
-            H_err = np.sqrt(sol[1][0, 0])
-
-            if fixedG12 is not None:
-                G = fixedG12
-                G_err = np.nan
-                HG_cov = np.nan
-            else:
-                G = sol[0][1]
-                G_err = np.sqrt(sol[1][1, 1])
-                HG_cov = sol[1][0, 1]
-
-            return HG12FitResult(
-                H=H, G12=G, H_err=H_err, G12_err=G_err,
-                HG_cov=HG_cov, chi2dof=chi2 / (nobsv - nparams),
-                nobs=nobsv,
+        if nSigmaClip is not None and nobsv > nparams + 1:
+            # Stage 1: robust fit with soft_l1 loss
+            sol_robust = least_squares(
+                residuals, x0, loss='soft_l1', f_scale=1.0,
             )
-        else:
-            # fit failed
+            if not sol_robust.success:
+                return HG12FitResult(*(np.nan,) * 6, nobs=0)
+
+            # Sigma clipping on residuals from robust fit
+            resid = residuals(sol_robust.x)
+            keep = np.abs(resid) < nSigmaClip
+            mag = mag[keep]
+            magSigma = magSigma[keep]
+            phase_rad = phase_rad[keep]
+            nobsv = len(mag)
+
+            if nobsv <= nparams:
+                return HG12FitResult(*(np.nan,) * 6, nobs=0)
+
+            # Redefine residuals for clipped data
+            def residuals(params):
+                return (
+                    (mag - model(phase_rad, params)) / magSigma
+                )
+
+            x0 = sol_robust.x
+
+        # Final fit (linear loss for proper chi2/covariance)
+        sol = least_squares(residuals, x0, loss='linear')
+
+        if not sol.success:
             return HG12FitResult(*(np.nan,) * 6, nobs=0)
+
+        # Extract results
+        chi2_total = np.sum(sol.fun ** 2)
+
+        # Covariance from Jacobian: cov = inv(J^T J)
+        J = sol.jac
+        try:
+            cov = np.linalg.inv(J.T @ J)
+        except np.linalg.LinAlgError:
+            return HG12FitResult(*(np.nan,) * 6, nobs=0)
+
+        H = sol.x[0]
+        H_err = np.sqrt(cov[0, 0])
+
+        if fixedG12 is not None:
+            G = fixedG12
+            G_err = np.nan
+            HG_cov = np.nan
+        else:
+            G = sol.x[1]
+            G_err = np.sqrt(cov[1, 1])
+            HG_cov = cov[0, 1]
+
+        return HG12FitResult(
+            H=H, G12=G, H_err=H_err, G12_err=G_err,
+            HG_cov=HG_cov,
+            chi2dof=chi2_total / (nobsv - nparams),
+            nobs=nobsv,
+        )
 
 
 ####################

--- a/python/lsst/pipe/tasks/ssp/photfit.py
+++ b/python/lsst/pipe/tasks/ssp/photfit.py
@@ -107,7 +107,7 @@ def fit(mag, phase, sigma, model=HG12_model, params=[0.1]):
     return sol
 
 
-def fitHG12(mag, magSigma, phaseAngle, tdist, rdist):
+def fitHG12(mag, magSigma, phaseAngle, tdist, rdist, fixedG12=None):
     # This uses the HG12 function from Muinonen et al (2010)
     nobsv = len(mag)
 
@@ -117,22 +117,38 @@ def fitHG12(mag, magSigma, phaseAngle, tdist, rdist):
     # correct the mag to 1AU distance
     dmag = -5.0 * np.log10(tdist * rdist)
     mag = mag + dmag
-    # phaseAngle = np.deg2rad(phaseAngle)
+
+    if fixedG12 is not None:
+        def model(phase, params):
+            return HG12_model(phase, [params[0], fixedG12])
+
+        nparams = 1
+        fit_params = []
+    else:
+        model = HG12_model
+        nparams = 2
+        fit_params = [0.1]
 
     # fit, suppressing warnings
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
 
-        sol = fit(mag, phaseAngle, magSigma)
+        sol = fit(mag, phaseAngle, magSigma, model=model, params=fit_params)
         if sol[-1] in [1, 2, 3] and sol[1] is not None:  # least squares solver flags
             chi2 = np.sum(sol[2]["fvec"] ** 2)
             H = sol[0][0]
-            G = sol[0][1]
             H_err = np.sqrt(sol[1][0, 0])
-            G_err = np.sqrt(sol[1][1, 1])
-            HG_cov = sol[1][0, 1]
 
-            return H, G, H_err, G_err, HG_cov, chi2 / (nobsv - 2), nobsv
+            if fixedG12 is not None:
+                G = fixedG12
+                G_err = np.nan
+                HG_cov = np.nan
+            else:
+                G = sol[0][1]
+                G_err = np.sqrt(sol[1][1, 1])
+                HG_cov = sol[1][0, 1]
+
+            return H, G, H_err, G_err, HG_cov, chi2 / (nobsv - nparams), nobsv
         else:
             # fit failed
             return (np.nan,) * 6 + (0,)

--- a/python/lsst/pipe/tasks/ssp/photfit.py
+++ b/python/lsst/pipe/tasks/ssp/photfit.py
@@ -173,6 +173,18 @@ def fitHG12(mag, magSigma, phaseAngle, tdist, rdist, fixedG12=None, magSigmaFloo
     if magSigmaFloor > 0:
         magSigma = np.sqrt(magSigma**2 + magSigmaFloor**2)
 
+    # filter to finite magnitudes and positive errors
+    good = np.isfinite(mag) & np.isfinite(magSigma) & (magSigma > 0)
+    mag = mag[good]
+    magSigma = magSigma[good]
+    phaseAngle = phaseAngle[good]
+    tdist = tdist[good]
+    rdist = rdist[good]
+    nobsv = len(mag)
+
+    if nobsv == 0:
+        return HG12FitResult(*(np.nan,) * 6, nobs=0)
+
     # correct the mag to 1AU distance
     dmag = -5.0 * np.log10(tdist * rdist)
     mag = mag + dmag

--- a/python/lsst/pipe/tasks/ssp/ssobject.py
+++ b/python/lsst/pipe/tasks/ssp/ssobject.py
@@ -54,7 +54,7 @@ def nJy_err_to_mag_err(f_njy, f_err_njy):
     return 1.085736 * (f_err_njy / f_njy)
 
 
-def compute_ssobject_entry(row, sss, fixedG12=None):
+def compute_ssobject_entry(row, sss, fixedG12=None, magSigmaFloor=0.0):
     # just verify we didn't screw up something
     assert sss["ssObjectId"].nunique() == 1
 
@@ -100,7 +100,7 @@ def compute_ssobject_entry(row, sss, fixedG12=None):
                 H, G12, sigmaH, sigmaG12, covHG12, chi2dof, nobsv = photfit.fitHG12(
                     df["dia_psfMag"], df["dia_psfMagErr"],
                     df["phaseAngle"], df["topoRange"], df["helioRange"],
-                    fixedG12=fixedG12,
+                    fixedG12=fixedG12, magSigmaFloor=magSigmaFloor,
                 )
                 nDof = nBandObs - (1 if fixedG12 is not None else 2)
                 # print(provID, band, H, G12, sigmaH, sigmaG12, covHG12,
@@ -127,7 +127,7 @@ def compute_ssobject_entry(row, sss, fixedG12=None):
     row["extendednessMedian"] = sss["dia_extendedness"].median()
 
 
-def compute_ssobject(sss, dia, mpcorb, fixedG12=None):
+def compute_ssobject(sss, dia, mpcorb, fixedG12=None, magSigmaFloor=0.0):
     """
     Compute solar system object properties by joining and processing
     SSSource, DiaSource, and MPC orbit data.
@@ -206,7 +206,7 @@ def compute_ssobject(sss, dia, mpcorb, fixedG12=None):
     obj = np.zeros(totalNumObjects, dtype=schema.SSObjectDtype)
 
     # compute per-object quantities
-    callback = partial(compute_ssobject_entry, fixedG12=fixedG12)
+    callback = partial(compute_ssobject_entry, fixedG12=fixedG12, magSigmaFloor=magSigmaFloor)
     util.group_by([sss], "ssObjectId", callback, out=obj)
 
     #

--- a/python/lsst/pipe/tasks/ssp/ssobject.py
+++ b/python/lsst/pipe/tasks/ssp/ssobject.py
@@ -54,7 +54,9 @@ def nJy_err_to_mag_err(f_njy, f_err_njy):
     return 1.085736 * (f_err_njy / f_njy)
 
 
-def compute_ssobject_entry(row, sss, fixedG12=None, magSigmaFloor=0.0):
+def compute_ssobject_entry(
+    row, sss, fixedG12=None, magSigmaFloor=0.0, nSigmaClip=None,
+):
     # just verify we didn't screw up something
     assert sss["ssObjectId"].nunique() == 1
 
@@ -101,6 +103,7 @@ def compute_ssobject_entry(row, sss, fixedG12=None, magSigmaFloor=0.0):
                     df["dia_psfMag"], df["dia_psfMagErr"],
                     df["phaseAngle"], df["topoRange"], df["helioRange"],
                     fixedG12=fixedG12, magSigmaFloor=magSigmaFloor,
+                    nSigmaClip=nSigmaClip,
                 )
                 nDof = nBandObs - (1 if fixedG12 is not None else 2)
                 # print(provID, band, H, G12, sigmaH, sigmaG12, covHG12,
@@ -127,7 +130,10 @@ def compute_ssobject_entry(row, sss, fixedG12=None, magSigmaFloor=0.0):
     row["extendednessMedian"] = sss["dia_extendedness"].median()
 
 
-def compute_ssobject(sss, dia, mpcorb, fixedG12=None, magSigmaFloor=0.0):
+def compute_ssobject(
+    sss, dia, mpcorb, fixedG12=None, magSigmaFloor=0.0,
+    nSigmaClip=None,
+):
     """
     Compute solar system object properties by joining and processing
     SSSource, DiaSource, and MPC orbit data.
@@ -206,7 +212,10 @@ def compute_ssobject(sss, dia, mpcorb, fixedG12=None, magSigmaFloor=0.0):
     obj = np.zeros(totalNumObjects, dtype=schema.SSObjectDtype)
 
     # compute per-object quantities
-    callback = partial(compute_ssobject_entry, fixedG12=fixedG12, magSigmaFloor=magSigmaFloor)
+    callback = partial(
+        compute_ssobject_entry, fixedG12=fixedG12,
+        magSigmaFloor=magSigmaFloor, nSigmaClip=nSigmaClip,
+    )
     util.group_by([sss], "ssObjectId", callback, out=obj)
 
     #

--- a/python/lsst/pipe/tasks/ssp/ssobject.py
+++ b/python/lsst/pipe/tasks/ssp/ssobject.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+from functools import partial
 from . import photfit
 from . import util
 from . import schema
@@ -53,7 +54,7 @@ def nJy_err_to_mag_err(f_njy, f_err_njy):
     return 1.085736 * (f_err_njy / f_njy)
 
 
-def compute_ssobject_entry(row, sss):
+def compute_ssobject_entry(row, sss, fixedG12=None):
     # just verify we didn't screw up something
     assert sss["ssObjectId"].nunique() == 1
 
@@ -97,9 +98,10 @@ def compute_ssobject_entry(row, sss):
                 # do the absmag/slope fits, if there are at least two
                 # data points
                 H, G12, sigmaH, sigmaG12, covHG12, chi2dof, nobsv = photfit.fitHG12(
-                    df["dia_psfMag"], df["dia_psfMagErr"], df["phaseAngle"], df["topoRange"], df["helioRange"]
+                    df["dia_psfMag"], df["dia_psfMagErr"], df["phaseAngle"], df["topoRange"], df["helioRange"],
+                    fixedG12=fixedG12,
                 )
-                nDof = nBandObs - 2
+                nDof = nBandObs - (1 if fixedG12 is not None else 2)
                 # print(provID, band, H, G12, sigmaH, sigmaG12, covHG12,
                 #       chi2dof, nobsv)
 
@@ -124,7 +126,7 @@ def compute_ssobject_entry(row, sss):
     row["extendednessMedian"] = sss["dia_extendedness"].median()
 
 
-def compute_ssobject(sss, dia, mpcorb):
+def compute_ssobject(sss, dia, mpcorb, fixedG12=None):
     """
     Compute solar system object properties by joining and processing
     SSSource, DiaSource, and MPC orbit data.
@@ -203,7 +205,8 @@ def compute_ssobject(sss, dia, mpcorb):
     obj = np.zeros(totalNumObjects, dtype=schema.SSObjectDtype)
 
     # compute per-object quantities
-    util.group_by([sss], "ssObjectId", compute_ssobject_entry, out=obj)
+    callback = partial(compute_ssobject_entry, fixedG12=fixedG12)
+    util.group_by([sss], "ssObjectId", callback, out=obj)
 
     #
     # compute columns that can be efficiently computed in a vector fashon

--- a/python/lsst/pipe/tasks/ssp/ssobject.py
+++ b/python/lsst/pipe/tasks/ssp/ssobject.py
@@ -98,7 +98,8 @@ def compute_ssobject_entry(row, sss, fixedG12=None):
                 # do the absmag/slope fits, if there are at least two
                 # data points
                 H, G12, sigmaH, sigmaG12, covHG12, chi2dof, nobsv = photfit.fitHG12(
-                    df["dia_psfMag"], df["dia_psfMagErr"], df["phaseAngle"], df["topoRange"], df["helioRange"],
+                    df["dia_psfMag"], df["dia_psfMagErr"],
+                    df["phaseAngle"], df["topoRange"], df["helioRange"],
                     fixedG12=fixedG12,
                 )
                 nDof = nBandObs - (1 if fixedG12 is not None else 2)

--- a/python/lsst/pipe/tasks/ssp/ssobject.py
+++ b/python/lsst/pipe/tasks/ssp/ssobject.py
@@ -4,7 +4,7 @@ from functools import partial
 from . import photfit
 from . import util
 from . import schema
-from .moid import MOIDSolver, earth_orbit_J2000
+from .moid import MOIDSolver, earth_orbit
 import argparse
 import sys
 
@@ -227,14 +227,17 @@ def compute_ssobject(sss, dia, mpcorb, fixedG12=None, magSigmaFloor=0.0):
             mpcorb["unpacked_primary_provisional_designation"].take(midx)
             == obj["designation"][oidx].astype("U")
         )
-        q, e, i, node, argperi = util.unpack(mpcorb["q e i node argperi".split()].take(midx))
+        q, e, i, node, argperi, epoch_mjd = util.unpack(
+            mpcorb["q e i node argperi epoch_mjd".split()].take(midx)
+        )
         a = q / (1.0 - e)
         obj["tisserand_J"][oidx] = util.tisserand_jupiter(a, e, i)
 
         # MOID computation
         solver = MOIDSolver()
         for i, el_obj in enumerate(zip(a, e, i, node, argperi)):
-            (moid, deltaV, eclon, trueEarth, trueObject) = solver.compute(earth_orbit_J2000(), el_obj)
+            earth = earth_orbit(epoch_mjd[i])
+            (moid, deltaV, eclon, trueEarth, trueObject) = solver.compute(earth, el_obj)
             row = obj[oidx[i]]
             row["MOIDEarth"] = moid
             row["MOIDEarthDeltaV"] = deltaV

--- a/tests/test_moid.py
+++ b/tests/test_moid.py
@@ -1,0 +1,159 @@
+# This file is part of pipe_tasks.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+import lsst.utils.tests
+from lsst.pipe.tasks.ssp.moid import MOIDSolver, earth_orbit
+
+# J2000.0 epoch as MJD
+MJD_J2000 = 51544.5
+
+
+class TestEarthOrbit(lsst.utils.tests.TestCase):
+
+    def testEarthOrbitJ2000(self):
+        """Verify J2000 values match JPL coefficients."""
+        el = earth_orbit(MJD_J2000)
+        self.assertAlmostEqual(el.a_AU, 1.00000261, places=8)
+        self.assertAlmostEqual(el.e, 0.01671123, places=8)
+        self.assertAlmostEqual(el.omega_deg, 102.93768193, places=5)
+        self.assertEqual(el.Omega_deg, 0.0)
+        self.assertAlmostEqual(el.inc_deg, 0.00005, places=6)
+
+    def testEarthOrbitSecularEvolution(self):
+        """Verify elements evolve at the expected rate."""
+        el_j2000 = earth_orbit(MJD_J2000)
+        # One century later
+        el_later = earth_orbit(MJD_J2000 + 36525.0)
+
+        # omega should increase by ~0.323 deg/century
+        domega = el_later.omega_deg - el_j2000.omega_deg
+        self.assertAlmostEqual(domega, 0.32327364, places=5)
+
+        # eccentricity should decrease by ~0.0000439/century
+        de = el_later.e - el_j2000.e
+        self.assertAlmostEqual(de, -0.00004392, places=8)
+
+        # semi-major axis should increase slightly
+        da = el_later.a_AU - el_j2000.a_AU
+        self.assertAlmostEqual(da, 0.00000562, places=8)
+
+    def testEarthOrbitEclipticFrame(self):
+        """Verify Omega=0 and inc~0 at all epochs."""
+        for mjd in [40000.0, MJD_J2000, 60000.0, 80000.0]:
+            el = earth_orbit(mjd)
+            self.assertEqual(el.Omega_deg, 0.0)
+            self.assertAlmostEqual(el.inc_deg, 0.00005, places=6)
+
+
+class TestMOIDSolver(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        self.solver = MOIDSolver()
+
+    def testIdenticalOrbits(self):
+        """Two identical circular orbits should have MOID = 0."""
+        el = (1.0, 0.0, 0.0, 0.0, 0.0)
+        result = self.solver.compute(el, el)
+        self.assertAlmostEqual(result.MOID_AU, 0.0, places=6)
+
+    def testCoplanarCircular(self):
+        """Coplanar circular orbits a=1, a=2 should have MOID=1.0."""
+        el1 = (1.0, 0.0, 0.0, 0.0, 0.0)
+        el2 = (2.0, 0.0, 0.0, 0.0, 0.0)
+        result = self.solver.compute(el1, el2)
+        self.assertAlmostEqual(result.MOID_AU, 1.0, places=4)
+
+    def testCoplanarCrossing(self):
+        """Eccentric orbit crossing a circular one should have
+        MOID near zero.
+        """
+        # a=1 e=0 (circular) vs a=1.5 e=0.5
+        # (perihelion=0.75, aphelion=2.25 — crosses the r=1 circle)
+        el1 = (1.0, 0.0, 0.0, 0.0, 0.0)
+        el2 = (1.5, 0.5, 0.0, 0.0, 0.0)
+        result = self.solver.compute(el1, el2)
+        self.assertLess(result.MOID_AU, 0.001)
+
+    def testPerpendicularOrbit(self):
+        """90-degree inclination orbit should have a finite,
+        positive MOID.
+        """
+        earth = earth_orbit(60000.0)
+        perp = (1.5, 0.3, 90.0, 0.0, 0.0)
+        result = self.solver.compute(earth, perp)
+        self.assertGreater(result.MOID_AU, 0.0)
+        self.assertLess(result.MOID_AU, 2.0)
+
+    def testKnownNEA(self):
+        """Apophis-like elements should give MOID ~ 0.0002 AU."""
+        # Approximate elements for (99942) Apophis
+        apophis = (0.9224, 0.1914, 3.339, 204.43, 126.39)
+        earth = earth_orbit(60000.0)
+        result = self.solver.compute(earth, apophis)
+        # MPC gives ~0.00025 AU; we allow some tolerance for
+        # element epoch differences
+        self.assertLess(result.MOID_AU, 0.005)
+        self.assertGreater(result.MOID_AU, 0.0)
+
+    def testDeltaVPositive(self):
+        """DeltaV should always be positive."""
+        earth = earth_orbit(60000.0)
+        for el in [
+            (1.5, 0.3, 10.0, 30.0, 45.0),
+            (2.5, 0.1, 5.0, 120.0, 200.0),
+            (0.9224, 0.1914, 3.339, 204.43, 126.39),
+        ]:
+            result = self.solver.compute(earth, el)
+            self.assertGreater(result.DeltaV_kms, 0.0)
+
+    def testResultFields(self):
+        """MOIDResult should have all expected fields."""
+        el1 = (1.0, 0.1, 5.0, 30.0, 45.0)
+        el2 = (1.5, 0.2, 15.0, 60.0, 10.0)
+        result = self.solver.compute(el1, el2)
+
+        self.assertTrue(hasattr(result, 'MOID_AU'))
+        self.assertTrue(hasattr(result, 'DeltaV_kms'))
+        self.assertTrue(hasattr(result, 'EclipticLongitude_deg'))
+        self.assertTrue(hasattr(result, 'TrueAnomaly1_deg'))
+        self.assertTrue(hasattr(result, 'TrueAnomaly2_deg'))
+
+        # Angles should be in [0, 360)
+        self.assertGreaterEqual(result.EclipticLongitude_deg, 0.0)
+        self.assertLess(result.EclipticLongitude_deg, 360.0)
+        self.assertGreaterEqual(result.TrueAnomaly1_deg, 0.0)
+        self.assertLess(result.TrueAnomaly1_deg, 360.0)
+        self.assertGreaterEqual(result.TrueAnomaly2_deg, 0.0)
+        self.assertLess(result.TrueAnomaly2_deg, 360.0)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_photfit.py
+++ b/tests/test_photfit.py
@@ -164,6 +164,44 @@ class TestHG12Model(lsst.utils.tests.TestCase):
         self.assertTrue(np.isnan(H))
         self.assertEqual(nobs, 0)
 
+    def testFitWithNaNMagnitudes(self):
+        """NaN magnitudes (from negative fluxes) should be filtered
+        out, not crash the fit.
+        """
+        # Insert NaN values into the test data
+        mag = MAG_EXPECTED.copy()
+        sigma = MAG_SIGMA.copy()
+        phase = PHASE_ANGLE.copy()
+        tdist = TDIST.copy()
+        rdist = RDIST.copy()
+
+        # Inject 3 NaN magnitudes
+        mag_nan = np.concatenate([mag, [np.nan, np.nan, np.nan]])
+        sig_nan = np.concatenate([sigma, [0.03, 0.03, 0.03]])
+        pa_nan = np.concatenate([phase, [10.0, 20.0, 30.0]])
+        td_nan = np.concatenate([tdist, [1.3, 1.3, 1.3]])
+        rd_nan = np.concatenate([rdist, [2.2, 2.2, 2.2]])
+
+        result = fitHG12(
+            mag_nan, sig_nan, pa_nan, td_nan, rd_nan,
+            fixedG12=G12_TRUE,
+        )
+        # Should succeed using the 15 valid observations
+        self.assertAlmostEqual(result.H, H_TRUE, places=4)
+        self.assertEqual(result.nobs, 15)
+
+    def testFitAllNaN(self):
+        """All-NaN input should return failure, not crash."""
+        result = fitHG12(
+            np.array([np.nan, np.nan]),
+            np.array([0.03, 0.03]),
+            np.array([10.0, 20.0]),
+            np.array([1.3, 1.3]),
+            np.array([2.2, 2.2]),
+        )
+        self.assertTrue(np.isnan(result.H))
+        self.assertEqual(result.nobs, 0)
+
     def testDistanceCorrection(self):
         """Same (H, G12, phase) at different distances should yield
         the same H.

--- a/tests/test_photfit.py
+++ b/tests/test_photfit.py
@@ -112,9 +112,9 @@ class TestHG12Model(lsst.utils.tests.TestCase):
             MAG_EXPECTED, MAG_SIGMA, PHASE_ANGLE, TDIST, RDIST,
             fixedG12=0.8,
         )
-        chi2_correct = result_correct[5]
-        H_wrong = result_wrong[0]
-        chi2_wrong = result_wrong[5]
+        chi2_correct = result_correct.chi2dof
+        H_wrong = result_wrong.H
+        chi2_wrong = result_wrong.chi2dof
 
         # Wrong G12 should produce a noticeably different H
         self.assertGreater(abs(H_wrong - H_TRUE), 0.005)
@@ -134,10 +134,10 @@ class TestHG12Model(lsst.utils.tests.TestCase):
             noisy_mag, MAG_SIGMA, PHASE_ANGLE, TDIST, RDIST,
             fixedG12=G12_TRUE, magSigmaFloor=0.05,
         )
-        chi2_no_floor = result_no_floor[5]
-        chi2_with_floor = result_with_floor[5]
-        herr_no_floor = result_no_floor[2]
-        herr_with_floor = result_with_floor[2]
+        chi2_no_floor = result_no_floor.chi2dof
+        chi2_with_floor = result_with_floor.chi2dof
+        herr_no_floor = result_no_floor.H_err
+        herr_with_floor = result_with_floor.H_err
 
         # Floor inflates errors → chi2 should decrease
         self.assertLess(chi2_with_floor, chi2_no_floor)
@@ -178,8 +178,7 @@ class TestHG12Model(lsst.utils.tests.TestCase):
         result = fitHG12(
             mag2, sigma2, PHASE_ANGLE, TDIST, rdist2,
         )
-        H_fit = result[0]
-        self.assertAlmostEqual(H_fit, H_TRUE, places=4)
+        self.assertAlmostEqual(result.H, H_TRUE, places=4)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_photfit.py
+++ b/tests/test_photfit.py
@@ -202,6 +202,55 @@ class TestHG12Model(lsst.utils.tests.TestCase):
         self.assertTrue(np.isnan(result.H))
         self.assertEqual(result.nobs, 0)
 
+    def testSigmaClipping(self):
+        """Outliers should be rejected when nSigmaClip is set."""
+        # Start with clean noiseless data, add a few outliers
+        mag = MAG_EXPECTED.copy()
+        sigma = MAG_SIGMA.copy()
+
+        # Add 3 extreme outlier observations
+        outlier_mag = np.array([25.0, 15.0, 30.0])
+        outlier_sigma = np.array([0.03, 0.03, 0.03])
+        outlier_phase = np.array([10.0, 20.0, 40.0])
+        outlier_tdist = np.array([1.3, 1.2, 1.25])
+        outlier_rdist = np.array([2.2, 2.18, 2.1])
+
+        all_mag = np.concatenate([mag, outlier_mag])
+        all_sigma = np.concatenate([sigma, outlier_sigma])
+        all_phase = np.concatenate([PHASE_ANGLE, outlier_phase])
+        all_tdist = np.concatenate([TDIST, outlier_tdist])
+        all_rdist = np.concatenate([RDIST, outlier_rdist])
+
+        # Without clipping: fit is pulled by outliers
+        result_no_clip = fitHG12(
+            all_mag, all_sigma, all_phase, all_tdist, all_rdist,
+            fixedG12=G12_TRUE,
+        )
+
+        # With clipping: outliers removed, H should recover
+        result_clip = fitHG12(
+            all_mag, all_sigma, all_phase, all_tdist, all_rdist,
+            fixedG12=G12_TRUE, nSigmaClip=3.0,
+        )
+
+        # Clipped result should be closer to true H
+        self.assertLess(
+            abs(result_clip.H - H_TRUE),
+            abs(result_no_clip.H - H_TRUE),
+        )
+        # Should have fewer observations after clipping
+        self.assertLess(result_clip.nobs, 18)
+        self.assertGreater(result_clip.nobs, 0)
+
+    def testSigmaClipNoOutliers(self):
+        """Clean data with clipping should keep all points."""
+        result = fitHG12(
+            MAG_EXPECTED, MAG_SIGMA, PHASE_ANGLE, TDIST, RDIST,
+            fixedG12=G12_TRUE, nSigmaClip=3.0,
+        )
+        self.assertAlmostEqual(result.H, H_TRUE, places=4)
+        self.assertEqual(result.nobs, 15)
+
     def testDistanceCorrection(self):
         """Same (H, G12, phase) at different distances should yield
         the same H.

--- a/tests/test_photfit.py
+++ b/tests/test_photfit.py
@@ -1,0 +1,195 @@
+# This file is part of pipe_tasks.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+import numpy as np
+import lsst.utils.tests
+from lsst.pipe.tasks.ssp.photfit import HG12_model, fitHG12
+
+# Independently calculated test vectors for H=17.30, G12=0.42
+# 15 observations spanning phase angles 0.8-60 degrees
+H_TRUE = 17.30
+G12_TRUE = 0.42
+
+PHASE_ANGLE = np.array([
+    0.8, 1.5, 2.3, 3.5, 5.0,
+    7.5, 10.0, 13.0, 16.0, 20.0,
+    25.0, 30.0, 38.0, 48.0, 60.0,
+])
+RDIST = np.array([
+    2.33, 2.31, 2.29, 2.27, 2.25,
+    2.23, 2.21, 2.20, 2.18, 2.16,
+    2.14, 2.12, 2.10, 2.08, 2.06,
+])
+TDIST = np.array([
+    1.42, 1.38, 1.34, 1.30, 1.26,
+    1.23, 1.20, 1.18, 1.16, 1.15,
+    1.14, 1.15, 1.18, 1.24, 1.33,
+])
+MAG_EXPECTED = np.array([
+    20.03700074, 20.01538407, 19.99152984, 19.98201741, 19.97201618,
+    20.00200255, 20.01813960, 20.07342182, 20.11401822, 20.19891977,
+    20.30457878, 20.43928577, 20.69068120, 21.05570108, 21.53526150,
+])
+MAG_SIGMA = np.full_like(MAG_EXPECTED, 0.03)
+
+
+class TestHG12Model(lsst.utils.tests.TestCase):
+
+    def testHG12ModelEvaluation(self):
+        """Verify HG12_model reproduces independently calculated
+        apparent magnitudes.
+        """
+        phase_rad = np.deg2rad(PHASE_ANGLE)
+        reduced_mag = HG12_model(phase_rad, [H_TRUE, G12_TRUE])
+        dmag = 5.0 * np.log10(TDIST * RDIST)
+        apparent = reduced_mag + dmag
+
+        np.testing.assert_allclose(
+            apparent, MAG_EXPECTED, atol=1e-6,
+            err_msg="HG12_model does not reproduce expected mags",
+        )
+
+    def testFitHG12FreeG12(self):
+        """Fit noiseless data with free G12 and verify parameter
+        recovery.
+        """
+        result = fitHG12(
+            MAG_EXPECTED, MAG_SIGMA, PHASE_ANGLE, TDIST, RDIST,
+        )
+        H_fit, G12_fit, H_err, G_err, HG_cov, chi2dof, nobs = result
+
+        self.assertAlmostEqual(H_fit, H_TRUE, places=4)
+        self.assertAlmostEqual(G12_fit, G12_TRUE, places=4)
+        self.assertTrue(np.isfinite(H_err) and H_err > 0)
+        self.assertTrue(np.isfinite(G_err) and G_err > 0)
+        self.assertLess(chi2dof, 1e-6)
+        self.assertEqual(nobs, 15)
+
+    def testFitHG12FixedG12(self):
+        """Fit with fixedG12 matching the true value."""
+        result = fitHG12(
+            MAG_EXPECTED, MAG_SIGMA, PHASE_ANGLE, TDIST, RDIST,
+            fixedG12=G12_TRUE,
+        )
+        H_fit, G12_fit, H_err, G_err, HG_cov, chi2dof, nobs = result
+
+        self.assertAlmostEqual(H_fit, H_TRUE, places=4)
+        self.assertEqual(G12_fit, G12_TRUE)
+        self.assertTrue(np.isfinite(H_err) and H_err > 0)
+        self.assertTrue(np.isnan(G_err))
+        self.assertTrue(np.isnan(HG_cov))
+        self.assertLess(chi2dof, 1e-6)
+        self.assertEqual(nobs, 15)
+
+    def testFitHG12FixedG12Wrong(self):
+        """Fit with wrong fixedG12 — should succeed but with worse
+        chi2 and shifted H.
+        """
+        result_correct = fitHG12(
+            MAG_EXPECTED, MAG_SIGMA, PHASE_ANGLE, TDIST, RDIST,
+            fixedG12=G12_TRUE,
+        )
+        result_wrong = fitHG12(
+            MAG_EXPECTED, MAG_SIGMA, PHASE_ANGLE, TDIST, RDIST,
+            fixedG12=0.8,
+        )
+        chi2_correct = result_correct[5]
+        H_wrong = result_wrong[0]
+        chi2_wrong = result_wrong[5]
+
+        # Wrong G12 should produce a noticeably different H
+        self.assertGreater(abs(H_wrong - H_TRUE), 0.005)
+        # Wrong G12 should produce larger chi2
+        self.assertGreater(chi2_wrong, chi2_correct)
+
+    def testMagSigmaFloor(self):
+        """Verify magSigmaFloor reduces chi2 and increases H_err."""
+        rng = np.random.RandomState(42)
+        noisy_mag = MAG_EXPECTED + rng.normal(0, 0.03, len(MAG_EXPECTED))
+
+        result_no_floor = fitHG12(
+            noisy_mag, MAG_SIGMA, PHASE_ANGLE, TDIST, RDIST,
+            fixedG12=G12_TRUE,
+        )
+        result_with_floor = fitHG12(
+            noisy_mag, MAG_SIGMA, PHASE_ANGLE, TDIST, RDIST,
+            fixedG12=G12_TRUE, magSigmaFloor=0.05,
+        )
+        chi2_no_floor = result_no_floor[5]
+        chi2_with_floor = result_with_floor[5]
+        herr_no_floor = result_no_floor[2]
+        herr_with_floor = result_with_floor[2]
+
+        # Floor inflates errors → chi2 should decrease
+        self.assertLess(chi2_with_floor, chi2_no_floor)
+        # H_err should increase (or at least not decrease) with floor
+        self.assertGreaterEqual(herr_with_floor, herr_no_floor * 0.99)
+
+    def testFitFailureSingleObs(self):
+        """Single observation should fail gracefully."""
+        # Free fit with 1 obs and 2 params is underdetermined
+        result = fitHG12(
+            MAG_EXPECTED[:1], MAG_SIGMA[:1], PHASE_ANGLE[:1],
+            TDIST[:1], RDIST[:1], fixedG12=0.5,
+        )
+        # With fixedG12, 1 obs and 1 param gives 0 DOF — fit may
+        # succeed but let's just check it doesn't crash.
+        self.assertEqual(len(result), 7)
+
+        # With 0 observations, should return NaN
+        result = fitHG12(
+            np.array([]), np.array([]), np.array([]),
+            np.array([]), np.array([]),
+        )
+        H, G, H_err, G_err, HG_cov, chi2dof, nobs = result
+        self.assertTrue(np.isnan(H))
+        self.assertEqual(nobs, 0)
+
+    def testDistanceCorrection(self):
+        """Same (H, G12, phase) at different distances should yield
+        the same H.
+        """
+        # Create a second set at 2x heliocentric distance
+        rdist2 = RDIST * 2.0
+        phase_rad = np.deg2rad(PHASE_ANGLE)
+        reduced_mag = HG12_model(phase_rad, [H_TRUE, G12_TRUE])
+        mag2 = reduced_mag + 5.0 * np.log10(TDIST * rdist2)
+        sigma2 = np.full_like(mag2, 0.03)
+
+        result = fitHG12(
+            mag2, sigma2, PHASE_ANGLE, TDIST, rdist2,
+        )
+        H_fit = result[0]
+        self.assertAlmostEqual(H_fit, H_TRUE, places=4)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_ssoAssociation.py
+++ b/tests/test_ssoAssociation.py
@@ -1,0 +1,469 @@
+# This file is part of pipe_tasks.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+import numpy as np
+from numpy.polynomial.chebyshev import chebval, Chebyshev
+from scipy.spatial import cKDTree
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+import lsst.utils.tests
+from lsst.pipe.tasks.ssoAssociation import SolarSystemAssociationTask
+
+AU_KM = 1.496e8
+
+
+# ---------------------------------------------------------------
+# Test vectors from 2003 YF26 (verified against JPL Horizons
+# in sssource_verification.ipynb)
+# ---------------------------------------------------------------
+YF26 = dict(
+    helio_x=-2.03972984386492,
+    helio_y=-0.754159365265218,
+    helio_z=-0.09916618480505775,
+    helio_vx=6.451686836410149,
+    helio_vy=-17.36829941588102,
+    helio_vz=-9.013339853647382,
+    topo_x=-1.2867480491014316,
+    topo_y=-0.1395377271885233,
+    topo_z=0.16727378829681566,
+    topo_vx=-13.061265792221151,
+    topo_vy=3.5105145303033005,
+    topo_vz=-0.11752881599981002,
+    ephRa=186.18909260549128,
+    ephDec=7.364065668224215,
+    helioRange=2.1769446746252505,
+    topoRange=1.3050562591039694,
+    phaseAngle=17.248719450313473,
+    elongation=140.17164534286258,
+    ephRate=0.13175297987940152,
+    ephRateRa=-0.1242177608944433,
+    ephRateDec=-0.0439180553471223,
+    helio_vtot=20.603940956820594,
+    topo_vtot=13.525316609422026,
+    helioRangeRate=0.3824562080346701,
+    topoRangeRate=12.487622241678675,
+    eclLambda=182.73184707660818,
+    eclBeta=9.214287183249514,
+    galLon=283.959546691413,
+    galLat=69.24711603487795,
+    ephOffsetRa=-0.08092633090227584,
+    ephOffsetDec=-0.06292996923882299,
+    ephOffset=0.10251464315747216,
+    ephOffsetAlongTrack=0.09727483587724564,
+    ephOffsetCrossTrack=0.03235519072357292,
+    DIA_ra=186.18906993899677,
+    DIA_dec=7.364048187677204,
+)
+
+
+class TestRadecToXyz(lsst.utils.tests.TestCase):
+    """Test the RA/Dec to unit vector conversion."""
+
+    def setUp(self):
+        self.task = SolarSystemAssociationTask()
+
+    def testNorthPole(self):
+        """North celestial pole: (RA=0, Dec=90) -> (0, 0, 1)."""
+        xyz = self.task._radec_to_xyz(
+            np.array([0.0]), np.array([90.0])
+        )
+        np.testing.assert_allclose(xyz[0], [0, 0, 1], atol=1e-12)
+
+    def testEquator(self):
+        """Points on the equator."""
+        # RA=0, Dec=0 -> (1, 0, 0)
+        xyz = self.task._radec_to_xyz(
+            np.array([0.0]), np.array([0.0])
+        )
+        np.testing.assert_allclose(xyz[0], [1, 0, 0], atol=1e-12)
+
+        # RA=90, Dec=0 -> (0, 1, 0)
+        xyz = self.task._radec_to_xyz(
+            np.array([90.0]), np.array([0.0])
+        )
+        np.testing.assert_allclose(xyz[0], [0, 1, 0], atol=1e-12)
+
+    def testUnitNorm(self):
+        """All output vectors should have unit norm."""
+        ras = np.array([0, 45, 90, 180, 270, 123.456])
+        decs = np.array([0, 30, -45, 60, -80, 7.364])
+        xyz = self.task._radec_to_xyz(ras, decs)
+        norms = np.linalg.norm(xyz, axis=1)
+        np.testing.assert_allclose(norms, 1.0, atol=1e-12)
+
+    def testRoundtrip(self):
+        """Convert RA/Dec -> xyz -> RA/Dec and verify recovery."""
+        ras = np.array([0.0, 45.0, 186.189, 300.0])
+        decs = np.array([0.0, -30.0, 7.364, 85.0])
+        xyz = self.task._radec_to_xyz(ras, decs)
+
+        # Recover RA/Dec from xyz
+        rec_dec = np.degrees(np.arcsin(xyz[:, 2]))
+        rec_ra = np.degrees(np.arctan2(xyz[:, 1], xyz[:, 0])) % 360
+
+        np.testing.assert_allclose(rec_ra, ras, atol=1e-10)
+        np.testing.assert_allclose(rec_dec, decs, atol=1e-10)
+
+
+class TestCoordinateTransforms(lsst.utils.tests.TestCase):
+    """Test ecliptic and galactic coordinate transforms."""
+
+    def testEclipticCoords(self):
+        """Verify ecliptic coords for the 2003 YF26 test vector."""
+        sc = SkyCoord(
+            ra=YF26['DIA_ra'] * u.deg,
+            dec=YF26['DIA_dec'] * u.deg,
+        )
+        ecl = sc.barycentrictrueecliptic
+        self.assertAlmostEqual(
+            ecl.lon.deg, YF26['eclLambda'], places=6
+        )
+        self.assertAlmostEqual(
+            ecl.lat.deg, YF26['eclBeta'], places=6
+        )
+
+    def testGalacticCoords(self):
+        """Verify galactic coords for the 2003 YF26 test vector."""
+        sc = SkyCoord(
+            ra=YF26['DIA_ra'] * u.deg,
+            dec=YF26['DIA_dec'] * u.deg,
+        )
+        gal = sc.galactic
+        self.assertAlmostEqual(
+            gal.l.deg, YF26['galLon'], places=6
+        )
+        self.assertAlmostEqual(
+            gal.b.deg, YF26['galLat'], places=6
+        )
+
+    def testEclipticPole(self):
+        """North ecliptic pole should be near (RA=270, Dec=66.56)."""
+        sc = SkyCoord(ra=270 * u.deg, dec=66.56 * u.deg)
+        ecl = sc.barycentrictrueecliptic
+        self.assertAlmostEqual(ecl.lat.deg, 90.0, places=0)
+
+
+class TestEphemerisOffsets(lsst.utils.tests.TestCase):
+    """Test ephemeris offset computation."""
+
+    def testEphOffsetRaDec(self):
+        """Verify RA/Dec offset formula."""
+        dia_ra = YF26['DIA_ra']
+        dia_dec = YF26['DIA_dec']
+        eph_ra = YF26['ephRa']
+        eph_dec = YF26['ephDec']
+
+        offset_ra = (
+            (dia_ra - eph_ra)
+            * np.cos(np.deg2rad(dia_dec)) * 3600
+        )
+        offset_dec = (dia_dec - eph_dec) * 3600
+
+        self.assertAlmostEqual(
+            offset_ra, YF26['ephOffsetRa'], places=10
+        )
+        self.assertAlmostEqual(
+            offset_dec, YF26['ephOffsetDec'], places=10
+        )
+
+    def testEphOffsetTotal(self):
+        """Verify total offset = sqrt(dRA² + dDec²)."""
+        total = np.sqrt(
+            YF26['ephOffsetRa']**2 + YF26['ephOffsetDec']**2
+        )
+        self.assertAlmostEqual(
+            total, YF26['ephOffset'], places=10
+        )
+
+    def testAlongCrossTrack(self):
+        """Verify along/cross-track decomposition."""
+        rate_ra = YF26['ephRateRa']
+        rate_dec = YF26['ephRateDec']
+        rate = YF26['ephRate']
+
+        # Unit vectors
+        along = np.array([rate_ra / rate, rate_dec / rate])
+        cross = np.array([-rate_dec / rate, rate_ra / rate])
+        offset = np.array(
+            [YF26['ephOffsetRa'], YF26['ephOffsetDec']]
+        )
+
+        along_track = np.dot(offset, along)
+        cross_track = np.dot(offset, cross)
+
+        self.assertAlmostEqual(
+            along_track, YF26['ephOffsetAlongTrack'], places=10
+        )
+        self.assertAlmostEqual(
+            cross_track, YF26['ephOffsetCrossTrack'], places=10
+        )
+
+    def testAlongCrossTrackPureRA(self):
+        """If motion is purely in RA, along-track = RA offset."""
+        offset_ra = 0.1  # arcsec
+        offset_dec = 0.05
+        rate_ra = 0.15  # deg/day
+        rate_dec = 0.0
+        rate = abs(rate_ra)
+
+        along = np.array([rate_ra / rate, rate_dec / rate])
+        cross = np.array([-rate_dec / rate, rate_ra / rate])
+        offset = np.array([offset_ra, offset_dec])
+
+        self.assertAlmostEqual(
+            np.dot(offset, along), offset_ra, places=10
+        )
+        self.assertAlmostEqual(
+            np.dot(offset, cross), offset_dec, places=10
+        )
+
+    def testAlongCrossTrackOrthogonality(self):
+        """Along² + cross² should equal total²."""
+        at = YF26['ephOffsetAlongTrack']
+        ct = YF26['ephOffsetCrossTrack']
+        total = YF26['ephOffset']
+        self.assertAlmostEqual(
+            at**2 + ct**2, total**2, places=10
+        )
+
+
+class TestDerivedQuantities(lsst.utils.tests.TestCase):
+    """Test derived physical quantities."""
+
+    def testHelioRange(self):
+        """helioRange = |helio_xyz|."""
+        r = np.sqrt(
+            YF26['helio_x']**2 + YF26['helio_y']**2
+            + YF26['helio_z']**2
+        )
+        self.assertAlmostEqual(r, YF26['helioRange'], places=10)
+
+    def testTopoRange(self):
+        """topoRange = |topo_xyz|."""
+        r = np.sqrt(
+            YF26['topo_x']**2 + YF26['topo_y']**2
+            + YF26['topo_z']**2
+        )
+        self.assertAlmostEqual(r, YF26['topoRange'], places=10)
+
+    def testHelioVtot(self):
+        """helio_vtot = |helio_v|."""
+        v = np.sqrt(
+            YF26['helio_vx']**2 + YF26['helio_vy']**2
+            + YF26['helio_vz']**2
+        )
+        self.assertAlmostEqual(v, YF26['helio_vtot'], places=10)
+
+    def testTopoVtot(self):
+        """topo_vtot = |topo_v|."""
+        v = np.sqrt(
+            YF26['topo_vx']**2 + YF26['topo_vy']**2
+            + YF26['topo_vz']**2
+        )
+        self.assertAlmostEqual(v, YF26['topo_vtot'], places=10)
+
+    def testEphRate(self):
+        """ephRate = sqrt(ephRateRa² + ephRateDec²)."""
+        rate = np.sqrt(
+            YF26['ephRateRa']**2 + YF26['ephRateDec']**2
+        )
+        self.assertAlmostEqual(rate, YF26['ephRate'], places=10)
+
+    def testPhaseAngle(self):
+        """Phase angle from helio and topo vectors."""
+        helio = np.array([
+            YF26['helio_x'], YF26['helio_y'], YF26['helio_z']
+        ])
+        topo = np.array([
+            YF26['topo_x'], YF26['topo_y'], YF26['topo_z']
+        ])
+        cos_pa = np.dot(helio, topo) / (
+            np.linalg.norm(helio) * np.linalg.norm(topo)
+        )
+        pa = np.degrees(np.arccos(np.clip(cos_pa, -1, 1)))
+        self.assertAlmostEqual(pa, YF26['phaseAngle'], places=6)
+
+    def testElongation(self):
+        """Elongation = Sun-object angle as seen from observer."""
+        helio = np.array([
+            YF26['helio_x'], YF26['helio_y'], YF26['helio_z']
+        ])
+        topo = np.array([
+            YF26['topo_x'], YF26['topo_y'], YF26['topo_z']
+        ])
+        sun_obs = topo - helio  # vector from Sun to observer
+        cos_elong = np.dot(sun_obs, topo) / (
+            np.linalg.norm(sun_obs) * np.linalg.norm(topo)
+        )
+        elong = np.degrees(np.arccos(np.clip(cos_elong, -1, 1)))
+        self.assertAlmostEqual(
+            elong, YF26['elongation'], places=4
+        )
+
+    def testHelioRangeRate(self):
+        """helioRangeRate = (v . r) / |r|."""
+        r = np.array([
+            YF26['helio_x'], YF26['helio_y'], YF26['helio_z']
+        ])
+        # Velocities are km/s, positions are AU
+        # helioRangeRate is in km/s
+        v = np.array([
+            YF26['helio_vx'], YF26['helio_vy'],
+            YF26['helio_vz'],
+        ])
+        r_km = r * AU_KM
+        rdot = np.dot(r_km, v) / np.linalg.norm(r_km)
+        self.assertAlmostEqual(
+            rdot, YF26['helioRangeRate'], places=4
+        )
+
+
+class TestMatching(lsst.utils.tests.TestCase):
+    """Test KDTree spatial matching logic."""
+
+    def setUp(self):
+        self.task = SolarSystemAssociationTask()
+
+    def testExactMatch(self):
+        """Source at same position as SSO should match."""
+        sso_ra = np.array([180.0])
+        sso_dec = np.array([0.0])
+        dia_ra = np.array([180.0])
+        dia_dec = np.array([0.0])
+
+        dia_xyz = self.task._radec_to_xyz(dia_ra, dia_dec)
+        tree = cKDTree(dia_xyz)
+
+        sso_xyz = self.task._radec_to_xyz(sso_ra, sso_dec)
+        dist, idx = tree.query(sso_xyz, k=1)
+        self.assertEqual(idx[0], 0)
+        self.assertAlmostEqual(dist[0], 0.0, places=10)
+
+    def testNoMatchBeyondRadius(self):
+        """Sources beyond matching radius should not match."""
+        sso_ra = np.array([180.0])
+        sso_dec = np.array([0.0])
+        # Source 10 arcsec away
+        dia_ra = np.array([180.0 + 10.0 / 3600])
+        dia_dec = np.array([0.0])
+
+        dia_xyz = self.task._radec_to_xyz(dia_ra, dia_dec)
+        tree = cKDTree(dia_xyz)
+
+        sso_xyz = self.task._radec_to_xyz(sso_ra, sso_dec)
+        max_rad = np.radians(1.0 / 3600)  # 1 arcsec
+        dist, idx = tree.query(
+            sso_xyz, k=1,
+            distance_upper_bound=max_rad,
+        )
+        self.assertTrue(np.isinf(dist[0]))
+
+    def testNearestNeighbor(self):
+        """Closer source should be preferred over farther one."""
+        sso_ra = np.array([180.0])
+        sso_dec = np.array([0.0])
+        # Two sources: one 0.2", one 0.5" away
+        dia_ra = np.array([
+            180.0 + 0.2 / 3600, 180.0 + 0.5 / 3600
+        ])
+        dia_dec = np.array([0.0, 0.0])
+
+        dia_xyz = self.task._radec_to_xyz(dia_ra, dia_dec)
+        tree = cKDTree(dia_xyz)
+
+        sso_xyz = self.task._radec_to_xyz(sso_ra, sso_dec)
+        dist, idx = tree.query(sso_xyz, k=1)
+        self.assertEqual(idx[0], 0)  # closer source
+
+
+class TestChebyshevEphemeris(lsst.utils.tests.TestCase):
+    """Test Chebyshev polynomial ephemeris evaluation."""
+
+    def testChebvalEvaluation(self):
+        """Evaluate a known Chebyshev polynomial."""
+        # f(x) = 3 + 2*T1(x) + 0.5*T2(x)
+        # At x=0: T0=1, T1=0, T2=-1 -> f(0) = 3 + 0 - 0.5 = 2.5
+        coeffs = [3.0, 2.0, 0.5]
+        self.assertAlmostEqual(chebval(0, coeffs), 2.5)
+        # At x=1: T0=1, T1=1, T2=1 -> f(1) = 3 + 2 + 0.5 = 5.5
+        self.assertAlmostEqual(chebval(1, coeffs), 5.5)
+
+    def testChebvalDerivative(self):
+        """Velocity from Chebyshev derivative of position."""
+        # Position: p(x) = 1 + x + x² (in Chebyshev basis)
+        # In Chebyshev: x = T1, x² = (T0 + T2)/2
+        # So p(x) = 1.5*T0 + T1 + 0.5*T2
+        coeffs = np.array([1.5, 1.0, 0.5])
+        poly = Chebyshev(coeffs)
+        dpoly = poly.deriv()
+
+        # dp/dx = 1 + 2x
+        # At x=0: dp/dx = 1
+        self.assertAlmostEqual(dpoly(0), 1.0, places=10)
+        # At x=0.5: dp/dx = 2
+        self.assertAlmostEqual(dpoly(0.5), 2.0, places=10)
+
+
+class TestSorchaPath(lsst.utils.tests.TestCase):
+    """Test Sorcha ephemeris path computations."""
+
+    def testTopoFromHelioAndObserver(self):
+        """Topo position = helio position - observer position."""
+        # Use YF26 vectors: topo = helio - observer
+        # observer = helio - topo
+        obs_x = YF26['helio_x'] - YF26['topo_x']
+        obs_y = YF26['helio_y'] - YF26['topo_y']
+        obs_z = YF26['helio_z'] - YF26['topo_z']
+
+        topo_x = YF26['helio_x'] - obs_x
+        topo_y = YF26['helio_y'] - obs_y
+        topo_z = YF26['helio_z'] - obs_z
+
+        self.assertAlmostEqual(topo_x, YF26['topo_x'], places=12)
+        self.assertAlmostEqual(topo_y, YF26['topo_y'], places=12)
+        self.assertAlmostEqual(topo_z, YF26['topo_z'], places=12)
+
+    def testKmToAuConversion(self):
+        """Verify km to AU conversion factor."""
+        # 1 AU in km
+        self.assertAlmostEqual(
+            1.0 * AU_KM, 1.496e8, places=-2
+        )
+        # Round-trip: AU -> km -> AU
+        dist_au = 2.17
+        dist_km = dist_au * AU_KM
+        self.assertAlmostEqual(
+            dist_km / AU_KM, dist_au, places=10
+        )
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_ssoAssociation.py
+++ b/tests/test_ssoAssociation.py
@@ -360,17 +360,18 @@ class TestMatching(lsst.utils.tests.TestCase):
 
     def testNoMatchBeyondRadius(self):
         """Sources beyond matching radius should not match."""
+        max_arcsec = self.task.config.maxDistArcSeconds
         sso_ra = np.array([180.0])
         sso_dec = np.array([0.0])
-        # Source 10 arcsec away
-        dia_ra = np.array([180.0 + 10.0 / 3600])
+        # Source well beyond the matching radius
+        dia_ra = np.array([180.0 + 10 * max_arcsec / 3600])
         dia_dec = np.array([0.0])
 
         dia_xyz = self.task._radec_to_xyz(dia_ra, dia_dec)
         tree = cKDTree(dia_xyz)
 
         sso_xyz = self.task._radec_to_xyz(sso_ra, sso_dec)
-        max_rad = np.radians(1.0 / 3600)  # 1 arcsec
+        max_rad = np.radians(max_arcsec / 3600)
         dist, idx = tree.query(
             sso_xyz, k=1,
             distance_upper_bound=max_rad,


### PR DESCRIPTION
Summary

  This branch adds the ability to fix the G12 slope parameter in HG12 photometric fitting, along with a systematic error floor,  and exposes both as pipeline configuration options.

  Changes

  python/lsst/pipe/tasks/ssp/photfit.py
  - fitHG12 now accepts fixedG12 — when set, G12 is held fixed and only H (absolute magnitude) is fit. The 7-element return  signature is preserved, with G_err=NaN and HG_cov=NaN when G12 is fixed, and reduced chi-squared uses nobsv - 1 instead of nobsv - 2.
  - fitHG12 now accepts magSigmaFloor — a systematic magnitude error (default 0.0) added in quadrature to measurement errors  before fitting. This accounts for unmodeled systematics (calibration, rotation curves) that dominate over photon noise for  bright objects.
  - Added an early return for empty input arrays, which previously caused an IndexError.

  python/lsst/pipe/tasks/consolidateSsTables.py
  - Added fixedG12 config field (pexConfig.Field, optional float, default None) — when set, fixes G12 to the given value across  all bands.
  - Added magSigmaFloor config field (float, default 0.01 mag).
  - Logs both config values before SSObject computation.

  python/lsst/pipe/tasks/ssp/ssobject.py
  - Threaded fixedG12 and magSigmaFloor from compute_ssobject through compute_ssobject_entry to fitHG12 using functools.partial.
  - Updated nDof calculation to account for the reduced number of free parameters when G12 is fixed.

  tests/test_photfit.py (new)
  - Unit tests verifying HG12 model evaluation against independently calculated test vectors (H=17.30, G12=0.42, 15 observations  spanning 0.8–60° phase angle).
  - Tests for free G12 recovery, fixed G12 recovery, wrong fixed G12 producing worse chi2, magSigmaFloor reducing chi2, graceful  handling of degenerate inputs, and distance correction consistency.

Note: this was developed and reviewed on https://github.com/lsst/pipe_tasks/pull/1299