### PR TITLE
DM-54976: Drop obs_info from ExtendedPsfCandidate.

### DIFF
--- a/python/lsst/pipe/tasks/extended_psf/extended_psf_candidates.py
+++ b/python/lsst/pipe/tasks/extended_psf/extended_psf_candidates.py
@@ -34,7 +34,6 @@ from collections.abc import Sequence
 from types import EllipsisType
 from typing import Any
 
-from astro_metadata_translator import ObservationInfo
 from pydantic import BaseModel, Field
 
 from lsst.images import (
@@ -146,8 +145,6 @@ class ExtendedPsfCandidate(MaskedImage):
         Schema for the mask, required if a mask is provided.
     projection : `~lsst.images.Projection`, optional
         Projection to map pixels to the sky.
-    obs_info : `~astro_metadata_translator.ObservationInfo`, optional
-        Standardized description of visit metadata.
     metadata : `dict` [`str`, `MetadataValue`], optional
         Additional metadata to associate with this cutout.
     psf_kernel_image : `~lsst.images.Image`, optional
@@ -171,7 +168,6 @@ class ExtendedPsfCandidate(MaskedImage):
         variance: Image | None = None,
         mask_schema: MaskSchema | None = None,
         projection: Projection | None = None,
-        obs_info: ObservationInfo | None = None,
         metadata: dict[str, MetadataValue] | None = None,
         psf_kernel_image: Image | None = None,
         star_info: ExtendedPsfCandidateInfo | None = None,
@@ -182,7 +178,6 @@ class ExtendedPsfCandidate(MaskedImage):
             variance=variance,
             mask_schema=mask_schema,
             projection=projection,
-            obs_info=obs_info,
             metadata=metadata,
         )
 
@@ -195,7 +190,7 @@ class ExtendedPsfCandidate(MaskedImage):
         super().__getitem__(bbox)
         return self._transfer_metadata(
             ExtendedPsfCandidate(
-                # Projection and obs_info propagate from the image.
+                # Projection propagates from the image.
                 self.image[bbox],
                 mask=self.mask[bbox],
                 variance=self.variance[bbox],


### PR DESCRIPTION
We're removing it from the MaskedImage base class, and it's not really needed here on its own.