### PR TITLE
DM-55422: Adapt to lsst.images roundtrip and __getitem__ API changes

### DIFF
--- a/python/lsst/pipe/tasks/extended_psf/extended_psf_candidates.py
+++ b/python/lsst/pipe/tasks/extended_psf/extended_psf_candidates.py
@@ -146,9 +146,7 @@ class ExtendedPsfCandidate(MaskedImage):
         self._star_info = star_info or ExtendedPsfCandidateInfo()
 
     def __getitem__(self, bbox: Box | EllipsisType) -> ExtendedPsfCandidate:
-        if bbox is ...:
-            return self
-        super().__getitem__(bbox)
+        bbox, _ = self._handle_getitem_args(bbox)
         return self._transfer_metadata(
             ExtendedPsfCandidate(
                 # Projection propagates from the image.

--- a/python/lsst/pipe/tasks/extended_psf/extended_psf_image.py
+++ b/python/lsst/pipe/tasks/extended_psf/extended_psf_image.py
@@ -173,9 +173,7 @@ class ExtendedPsfImage(GeneralizedImage):
         return self._fit
 
     def __getitem__(self, bbox: Box | EllipsisType) -> ExtendedPsfImage:
-        super().__getitem__(bbox)
-        if bbox is ...:
-            return self
+        bbox, _ = self._handle_getitem_args(bbox)
         return self._transfer_metadata(
             ExtendedPsfImage(
                 self.image[bbox],

--- a/tests/test_extended_psf.py
+++ b/tests/test_extended_psf.py
@@ -123,7 +123,7 @@ class ExtendedPsfCandidatesTestCase(lsst.utils.tests.TestCase):
         """Test that ExtendedPsfCandidates can be serialized/deserialized."""
 
         with lsst.images.tests.RoundtripFits(
-            self, self.extended_psf_candidates, storage_class="ExtendedPsfCandidates"
+            self.extended_psf_candidates, storage_class="ExtendedPsfCandidates"
         ) as roundtrip:
             pass
         extended_psf_candidates = roundtrip.result
@@ -258,7 +258,6 @@ class ExtendedPsfImageTestCase(lsst.utils.tests.TestCase):
     def test_fits_roundtrip(self):
         """Test that ExtendedPsfImage can be serialized/deserialized."""
         with lsst.images.tests.RoundtripFits(
-            self,
             self.extended_psf_image,
             storage_class="ExtendedPsfImage",
         ) as roundtrip:


### PR DESCRIPTION
RoundtripFits no longer takes a TestCase argument, and GeneralizedImage subclasses now delegate argument checking to _handle_getitem_args instead of super().__getitem__.

Depends on lsst/images#63